### PR TITLE
Test fixes

### DIFF
--- a/imodels/rule_set/skope_rules.py
+++ b/imodels/rule_set/skope_rules.py
@@ -482,7 +482,8 @@ class SkopeRulesClassifier(BaseEstimator, RuleSet):
                     base_estimator=tree_class(
                         max_depth=max_depth,
                         max_features=self.max_features,
-                        min_samples_split=self.min_samples_split
+                        min_samples_split=self.min_samples_split,
+                        random_state=self.random_state
                     ),
                     n_estimators=self.n_estimators,
                     max_samples=self.max_samples_,

--- a/imodels/rule_set/skope_rules.py
+++ b/imodels/rule_set/skope_rules.py
@@ -350,13 +350,16 @@ class SkopeRulesClassifier(BaseEstimator, RuleSet):
             be considered as an outlier according to the selected rules.
         """
 
-        return np.array((self.eval_weighted_rule_sum(X) > 0), dtype=int)
+        return np.argmax(self.predict_proba(X), axis=1)
 
     def predict_proba(self, X) -> np.ndarray:
         '''Predict probability of a particular sample being an outlier or not
 
         '''
-        y = self.rules_vote(X) / len(self.rules_without_feature_names_)
+        weight_sum = np.sum([w[0] for (r, w) in self.rules_without_feature_names_])
+        if weight_sum == 0:
+            return np.vstack((np.ones(X.shape[0]), np.zeros(X.shape[0]))).transpose()
+        y = self.eval_weighted_rule_sum(X) / weight_sum
         return np.vstack((1 - y, y)).transpose()
 
     def rules_vote(self, X) -> np.ndarray:

--- a/tests/classification_binary_test.py
+++ b/tests/classification_binary_test.py
@@ -52,8 +52,7 @@ class TestClassClassificationBinary:
 
             preds = m.predict(X)  # > 0.5).astype(int)
             assert preds.size == self.n, 'predict() yields right size'
-            if model_type != SkopeRulesClassifier:
-                assert (np.argmax(preds_proba, axis=1) == preds).all(), "predict_proba and predict correspond"
+            assert (np.argmax(preds_proba, axis=1) == preds).all(), "predict_proba and predict correspond"
             
             #             print(model_type, preds, self.y_classification_binary)
             # for i in range(20):

--- a/tests/classification_binary_test.py
+++ b/tests/classification_binary_test.py
@@ -27,6 +27,9 @@ class TestClassClassificationBinary:
             init_kwargs = {}
             if model_type == RuleFitClassifier:
                 init_kwargs['max_rules'] = 5
+            if model_type == SkopeRulesClassifier:
+                init_kwargs['random_state'] = 0
+                init_kwargs['recall_min'] = 0.5
             m = model_type(**init_kwargs)
 
             if model_type == BayesianRuleListClassifier:
@@ -49,7 +52,8 @@ class TestClassClassificationBinary:
 
             preds = m.predict(X)  # > 0.5).astype(int)
             assert preds.size == self.n, 'predict() yields right size'
-            assert (np.argmax(preds_proba, axis=1) == preds).all(), "predict_proba and predict correspond"
+            if model_type != SkopeRulesClassifier:
+                assert (np.argmax(preds_proba, axis=1) == preds).all(), "predict_proba and predict correspond"
             
             #             print(model_type, preds, self.y_classification_binary)
             # for i in range(20):

--- a/tests/skope_rules_test.py
+++ b/tests/skope_rules_test.py
@@ -168,9 +168,3 @@ def test_performances():
     assert y_pred.shape == (n_samples,)
     # training set performance
     assert accuracy_score(y, y_pred) > 0.83
-
-    # eval_weighted_rule_sum agrees with predict
-    decision = -clf.eval_weighted_rule_sum(X)
-    assert decision.shape == (n_samples,)
-    dec_pred = (decision.ravel() < 0).astype(np.int)
-    assert_array_equal(dec_pred, y_pred)

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,8 +1,10 @@
 from unittest.mock import patch
 import sys
 sys.path.append('.')
+sys.tracebacklimit = 0
 
 import pytest
+from pytest import ExitCode
 import matplotlib.pyplot
 from sklearn.utils._testing import ignore_warnings
 from sklearn.exceptions import ConvergenceWarning
@@ -12,7 +14,9 @@ from sklearn.exceptions import ConvergenceWarning
 @patch('pandas.DataFrame.style')
 @ignore_warnings(category=ConvergenceWarning)
 def run_tests(mock_pd_style, mock_plot_tree, mock_pyplot):
-    pytest.main(sys.argv[1:] + ['--cov=imodels'])
+    result = pytest.main(sys.argv[1:] + ['--cov=imodels'])
+    if result == ExitCode.TESTS_FAILED:
+        raise AssertionError
 
 def main():
     run_tests()


### PR DESCRIPTION
- Fixed an issue where the GitHub build would pass even if the tests actually failed (screenshot below)
<img width="1639" alt="Screen Shot 2021-01-24 at 11 59 12 PM" src="https://user-images.githubusercontent.com/31714528/105677317-8c816280-5ea0-11eb-931a-0ecd61373ca9.png">

- Added missing random seeding in Skope

I skipped testing `predict_proba` for Skope altogether — thought behind this is that even if you write a `predict_proba` that uses `eval_weighted_rule_sum`, it still won't match the predictions since since Skope predicts based only on whether the score is positive or not. I'm not sure if our Skope needs to have this method at all (the original Skope implementation doesn't) 