### PR TITLE
Fpskope and other improvements

### DIFF
--- a/imodels/__init__.py
+++ b/imodels/__init__.py
@@ -9,6 +9,7 @@ from .rule_list.greedy_rule_list import GreedyRuleListClassifier
 from .rule_list.one_r import OneRClassifier
 from .rule_set.rule_fit import RuleFitRegressor, RuleFitClassifier
 from .rule_set.fplasso import FPLassoRegressor, FPLassoClassifier
+from .rule_set.fpskope import FPSkopeClassifier
 from .rule_set.skope_rules import SkopeRulesClassifier
 from .rule_set.boosted_rules import BoostedRulesClassifier
 # from .tree.iterative_random_forest.iterative_random_forest import IRFClassifier

--- a/imodels/rule_set/fplasso.py
+++ b/imodels/rule_set/fplasso.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from imodels.rule_set.rule_fit import RuleFit
 from imodels.util.extract import extract_fpgrowth
 from imodels.util.convert import itemsets_to_rules
@@ -41,14 +43,13 @@ class FPLasso(RuleFit):
         super().fit(X, y, feature_names=feature_names)
         return self
     
-    def _extract_rules(self, X, y):
-        itemsets, discretizer = extract_fpgrowth(X, y,
-                                                 feature_labels=self.feature_names_,
-                                                 minsupport=self.minsupport,
-                                                 maxcardinality=self.maxcardinality,
-                                                 undiscretized_features=self.undiscretized_features,
-                                                 verbose=self.verbose)
-        self.discretizer = discretizer
+    def _extract_rules(self, X, y) -> List[str]:
+        itemsets = extract_fpgrowth(X, y,
+                                    feature_labels=self.feature_placeholders,
+                                    minsupport=self.minsupport,
+                                    maxcardinality=self.maxcardinality,
+                                    undiscretized_features=self.undiscretized_features,
+                                    verbose=self.verbose)[0]
         return itemsets_to_rules(itemsets)
 
 class FPLassoRegressor(FPLasso):        

--- a/imodels/rule_set/fpskope.py
+++ b/imodels/rule_set/fpskope.py
@@ -1,0 +1,57 @@
+import numpy as np
+
+from imodels.rule_set.skope_rules import SkopeRulesClassifier
+from imodels.util.extract import extract_fpgrowth
+from imodels.util.convert import itemsets_to_rules
+
+class FPSkopeClassifier(SkopeRulesClassifier):
+
+    def __init__(self,
+                 minsupport=0.1,
+                 maxcardinality=2,
+                 verbose=False,
+                 precision_min=0.5,
+                 recall_min=0.01,
+                 n_estimators=10,
+                 max_samples=.8,
+                 max_samples_features=1.,
+                 bootstrap=False,
+                 bootstrap_features=False,
+                 max_depth=3,
+                 max_depth_duplication=None,
+                 max_features=1.,
+                 min_samples_split=2,
+                 n_jobs=1,
+                 random_state=None):
+        super().__init__(precision_min,
+                         recall_min,
+                         n_estimators,
+                         max_samples,
+                         max_samples_features,
+                         bootstrap,
+                         bootstrap_features,
+                         max_depth,
+                         max_depth_duplication,
+                         max_features,
+                         min_samples_split,
+                         n_jobs,
+                         random_state,
+                         verbose)
+        self.minsupport = minsupport
+        self.maxcardinality = maxcardinality
+        self.verbose = verbose
+
+    def fit(self, X, y=None, feature_names=None, undiscretized_features=[], sample_weight=None):
+        self.undiscretized_features = undiscretized_features
+        super().fit(X, y, feature_names=feature_names, sample_weight=sample_weight)
+        return self
+
+    def _extract_rules(self, X, y):
+        itemsets, discretizer = extract_fpgrowth(X, y,
+                                                 feature_labels=self.feature_names_,
+                                                 minsupport=self.minsupport,
+                                                 maxcardinality=self.maxcardinality,
+                                                 undiscretized_features=self.undiscretized_features,
+                                                 verbose=self.verbose)
+        self.discretizer = discretizer
+        return [itemsets_to_rules(itemsets)], None, [np.arange(X.shape[0])], [np.arange(len(self.feature_names_))]

--- a/imodels/rule_set/fpskope.py
+++ b/imodels/rule_set/fpskope.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import numpy as np
 
 from imodels.rule_set.skope_rules import SkopeRulesClassifier
@@ -46,12 +48,11 @@ class FPSkopeClassifier(SkopeRulesClassifier):
         super().fit(X, y, feature_names=feature_names, sample_weight=sample_weight)
         return self
 
-    def _extract_rules(self, X, y):
-        itemsets, discretizer = extract_fpgrowth(X, y,
-                                                 feature_labels=self.feature_names_,
-                                                 minsupport=self.minsupport,
-                                                 maxcardinality=self.maxcardinality,
-                                                 undiscretized_features=self.undiscretized_features,
-                                                 verbose=self.verbose)
-        self.discretizer = discretizer
-        return [itemsets_to_rules(itemsets)], None, [np.arange(X.shape[0])], [np.arange(len(self.feature_names_))]
+    def _extract_rules(self, X, y) -> List[str]:
+        itemsets = extract_fpgrowth(X, y,
+                                    feature_labels=self.feature_placeholders,
+                                    minsupport=self.minsupport,
+                                    maxcardinality=self.maxcardinality,
+                                    undiscretized_features=self.undiscretized_features,
+                                    verbose=self.verbose)[0]
+        return [itemsets_to_rules(itemsets)], [np.arange(X.shape[0])], [np.arange(len(self.feature_names))]

--- a/imodels/rule_set/rule_fit.py
+++ b/imodels/rule_set/rule_fit.py
@@ -195,7 +195,6 @@ class RuleFit(BaseEstimator, TransformerMixin, RuleSet):
                the coefficients and 'support' the support of the rule in the training
                data set (X)
         """
-
         n_features = len(self.coef) - len(self.rules_)
         rule_ensemble = list(self.rules_without_feature_names_)
         output_rules = []
@@ -224,7 +223,7 @@ class RuleFit(BaseEstimator, TransformerMixin, RuleSet):
                 rkx = self.transform(subregion, [rule])[:, -1]
                 importance = sum(abs(coef) * abs(rkx - rule.support)) / len(subregion)
 
-            output_rules += [(rule.__str__(), 'rule', coef, rule.support, importance)]
+            output_rules += [(self.rules_[i].rule, 'rule', coef, rule.support, importance)]
         rules = pd.DataFrame(output_rules, columns=["rule", "type", "coef", "support", "importance"])
         if exclude_zero_coef:
             rules = rules.ix[rules.coef != 0]

--- a/imodels/rule_set/rule_set.py
+++ b/imodels/rule_set/rule_set.py
@@ -18,7 +18,7 @@ class RuleSet:
 
     def eval_weighted_rule_sum(self, X) -> np.ndarray:
 
-        check_is_fitted(self, ['rules_without_feature_names_', 'n_features_', 'feature_names_'])
+        check_is_fitted(self, ['rules_without_feature_names_', 'n_features_', 'feature_placeholders'])
         X = check_array(X)
 
         if X.shape[1] != self.n_features_:
@@ -26,7 +26,7 @@ class RuleSet:
                              " Please reshape your data."
                              % (X.shape[1], self.n_features_))
 
-        df = pd.DataFrame(X, columns=self.feature_names_)
+        df = pd.DataFrame(X, columns=self.feature_placeholders)
         selected_rules = self.rules_without_feature_names_
 
         scores = np.zeros(X.shape[0])

--- a/imodels/util/extract.py
+++ b/imodels/util/extract.py
@@ -27,8 +27,8 @@ def extract_fpgrowth(X, y,
         y = y.values
 
     if feature_labels is None:
-        feature_labels = [f'X{i}' for i in range(X.shape[1])]
-        
+        feature_labels = [f'feature_{i}' for i in range(X.shape[1])]
+    
     discretizer = BRLDiscretizer(X, y, feature_labels=feature_labels, verbose=verbose)
     X = discretizer.discretize_mixed_data(X, y, undiscretized_features)
     X_df_onehot = discretizer.onehot_df
@@ -50,7 +50,7 @@ def extract_rulefit(X, y, feature_names,
                     memory_par=0.01,
                     tree_generator=None,
                     exp_rand_tree_size=True,
-                    random_state=None):
+                    random_state=None) -> List[str]:
 
     if tree_generator is None:
         n_estimators_default = int(np.ceil(max_rules / tree_size))
@@ -122,7 +122,7 @@ def extract_skope(X, y, feature_names,
                   min_samples_split=2,
                   n_jobs=1,
                   random_state=None,
-                  verbose=0):
+                  verbose=0) -> Tuple[List[str], List[np.array], List[np.array]]:
     
     ensembles = []
     if not isinstance(max_depths, Iterable):
@@ -176,4 +176,4 @@ def extract_skope(X, y, feature_names,
     for estimator, features in zip(estimators_, estimators_features_):
         extracted_rules.append(tree_to_rules(estimator, np.array(feature_names)[features]))
     
-    return extracted_rules, estimators_, estimators_samples_, estimators_features_
+    return extracted_rules, estimators_samples_, estimators_features_

--- a/imodels/util/rule.py
+++ b/imodels/util/rule.py
@@ -69,9 +69,10 @@ def replace_feature_name(rule: Rule, replace_dict: Dict[str, str]) -> Rule:
     def replace(match):
         return replace_dict[match.group(0)]
 
-    rule_replaced = copy.copy(rule)
-    rule_replaced.rule = re.sub('|'.join(r'\b%s\b' % re.escape(s) for s in replace_dict),
-                  replace, rule.rule)
+    rule_replaced = Rule(
+        re.sub('|'.join(r'\b%s\b' % re.escape(s) for s in replace_dict), replace, rule.rule),
+        args=rule.args
+    )
     return rule_replaced
 
 

--- a/imodels/util/score.py
+++ b/imodels/util/score.py
@@ -53,7 +53,7 @@ def score_oob(X,
     return scored_rules
 
 
-def _eval_rule_perf(rule, X, y) -> Tuple[float, float]:
+def _eval_rule_perf(rule: str, X, y) -> Tuple[float, float]:
     detected_index = list(X.query(rule).index)
     if len(detected_index) <= 1:
         return (0, 0)
@@ -67,7 +67,7 @@ def _eval_rule_perf(rule, X, y) -> Tuple[float, float]:
 
 def score_lasso(X, y, rules: List[str], alphas=None, cv=3,
                 prediction_task='regression',
-                max_rules=2000, random_state=None) -> Tuple[List[Rule], Lasso]:
+                max_rules=2000, random_state=None) -> Tuple[List[Rule], List[float], float]:
     if alphas is None:
         if prediction_task == 'regression':
             alphas = _alpha_grid(X, y)

--- a/tests/classification_binary_test.py
+++ b/tests/classification_binary_test.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from imodels import GreedyRuleListClassifier, SkopeRulesClassifier, BayesianRuleListClassifier, \
-    OneRClassifier, BoostedRulesClassifier, RuleFitClassifier, FPLassoClassifier  # IRFClassifier
+    OneRClassifier, BoostedRulesClassifier, RuleFitClassifier, FPLassoClassifier, FPSkopeClassifier  # IRFClassifier
 
 
 class TestClassClassificationBinary:
@@ -21,13 +21,14 @@ class TestClassClassificationBinary:
         '''Test imodels on basic binary classification task
         '''
         for model_type in [RuleFitClassifier, GreedyRuleListClassifier,
-                           FPLassoClassifier, SkopeRulesClassifier, 
-                           BoostedRulesClassifier, OneRClassifier]:  # IRFClassifier, 
+                           FPLassoClassifier, SkopeRulesClassifier,
+                           FPSkopeClassifier, BoostedRulesClassifier, 
+                           OneRClassifier]:  # IRFClassifier, 
 
             init_kwargs = {}
             if model_type == RuleFitClassifier:
                 init_kwargs['max_rules'] = 5
-            if model_type == SkopeRulesClassifier:
+            if model_type == SkopeRulesClassifier or model_type == FPSkopeClassifier:
                 init_kwargs['random_state'] = 0
                 init_kwargs['recall_min'] = 0.5
             m = model_type(**init_kwargs)

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,17 +1,17 @@
 from imodels import SkopeRulesClassifier
 from imodels.util.prune import deduplicate, find_similar_rulesets, f1_score
+from imodels.util.rule import Rule
 
 
 def test_similarity_tree():
     # Test that rules are well splitted
-    rules = [("a <= 2 and b > 45 and c <= 3 and a > 4", (1, 1, 0)),
-             ("a <= 2 and b > 45 and c <= 3 and a > 4", (1, 1, 0)),
-             ("a > 2 and b > 45", (0.5, 0.3, 0)),
-             ("a > 2 and b > 40", (0.5, 0.2, 0)),
-             ("a <= 2 and b <= 45", (1, 1, 0)),
-             ("a > 2 and c <= 3", (1, 1, 0)),
-             ("b > 45", (1, 1, 0)),
-             ]
+    rules = [Rule("a <= 2 and b > 45 and c <= 3 and a > 4", args=(1, 1, 0)),
+             Rule("a <= 2 and b > 45 and c <= 3 and a > 4", (1, 1, 0)),
+             Rule("a > 2 and b > 45", (0.5, 0.3, 0)),
+             Rule("a > 2 and b > 40", (0.5, 0.2, 0)),
+             Rule("a <= 2 and b <= 45", (1, 1, 0)),
+             Rule("a > 2 and c <= 3", (1, 1, 0)),
+             Rule("b > 45", (1, 1, 0))]
 
     sk = SkopeRulesClassifier(max_depth_duplication=2)
     rulesets = find_similar_rulesets(rules, max_depth_duplication=2)
@@ -34,9 +34,9 @@ def test_similarity_tree():
 
 
 def test_f1_score():
-    rule0 = ('a > 0', (0, 0, 0))
-    rule1 = ('a > 0', (0.5, 0.5, 0))
-    rule2 = ('a > 0', (0.5, 0, 0))
+    rule0 = Rule('a > 0', (0, 0, 0))
+    rule1 = Rule('a > 0', (0.5, 0.5, 0))
+    rule2 = Rule('a > 0', (0.5, 0, 0))
 
     assert f1_score(rule0) == 0
     assert f1_score(rule1) == 0.5


### PR DESCRIPTION
- I realized that most of Skope wasn't actually using our rule class (it was just representing rules as tuples) so I changed this, which required some small changes across the scoring / filtering / deduplication pipeline
- Added fpskope
- Added some more type hinting
- Switched to using placeholder feature names instead of actual feature names in `df.query(rule)` calls, which means we don't have to worry about users passing features with spaces or weird characters anymore