### PR TITLE
Rulefit speedup

### DIFF
--- a/experiments/models/stablelinear.py
+++ b/experiments/models/stablelinear.py
@@ -24,8 +24,7 @@ class StableLinear(RuleFit):
                  lin_standardise=True,
                  exp_rand_tree_size=True,
                  include_linear=True,
-                 alphas=None,
-                 cv=3,
+                 alpha=None,
                  random_state=None):
         super().__init__(tree_size,
                          sample_fract,
@@ -36,7 +35,7 @@ class StableLinear(RuleFit):
                          lin_standardise,
                          exp_rand_tree_size,
                          include_linear,
-                         alphas,
+                         alpha,
                          cv,
                          random_state)
         self.max_complexity = max_complexity
@@ -75,8 +74,7 @@ class StableLinear(RuleFit):
             X_concat = np.concatenate((X_concat, X_rules), axis=1)
 
         return score_linear(X_concat, y, rules, 
-                            alphas=self.alphas, 
-                            cv=self.cv,
+                            alpha=self.alpha, 
                             penalty=self.penalty,
                             prediction_task=self.prediction_task,
                             max_rules=self.max_rules, random_state=self.random_state)

--- a/experiments/models/stableskope.py
+++ b/experiments/models/stableskope.py
@@ -19,7 +19,7 @@ class StableSkopeClassifier(SkopeRulesClassifier):
                  recall_min=0.4,
                  n_estimators=10,
                  max_samples=.8,
-                 max_samples_features=1.,
+                 max_samples_features=.8,
                  bootstrap=False,
                  bootstrap_features=False,
                  max_depth=3,

--- a/imodels/rule_set/fplasso.py
+++ b/imodels/rule_set/fplasso.py
@@ -25,8 +25,7 @@ class FPLasso(RuleFit):
                  lin_standardise=True,
                  exp_rand_tree_size=True,
                  include_linear=True,
-                 alphas=None,
-                 cv=3,
+                 alpha=None,
                  random_state=None):
         super().__init__(tree_size,
                          sample_fract,
@@ -37,8 +36,7 @@ class FPLasso(RuleFit):
                          lin_standardise,
                          exp_rand_tree_size,
                          include_linear,
-                         alphas,
-                         cv,
+                         alpha,
                          random_state)
         self.disc_strategy = disc_strategy
         self.disc_kwargs = disc_kwargs

--- a/imodels/rule_set/rule_fit.py
+++ b/imodels/rule_set/rule_fit.py
@@ -71,8 +71,7 @@ class RuleFit(BaseEstimator, TransformerMixin, RuleSet):
                  lin_standardise=True,
                  exp_rand_tree_size=True,
                  include_linear=True,
-                 alphas=None,
-                 cv=3,
+                 alpha=None,
                  random_state=None):
         self.tree_size = tree_size
         self.sample_fract = sample_fract
@@ -83,8 +82,7 @@ class RuleFit(BaseEstimator, TransformerMixin, RuleSet):
         self.lin_standardise = lin_standardise
         self.exp_rand_tree_size = exp_rand_tree_size
         self.include_linear = include_linear
-        self.alphas = alphas
-        self.cv = cv
+        self.alpha = alpha
         self.random_state = random_state
 
         self.winsorizer = Winsorizer(trim_quantile=self.lin_trim_quantile)
@@ -274,10 +272,9 @@ class RuleFit(BaseEstimator, TransformerMixin, RuleSet):
             X_concat = np.concatenate((X_concat, X_rules), axis=1)
 
         return score_linear(X_concat, y, rules,
-                            alphas=self.alphas,
-                            cv=self.cv,
                             prediction_task=self.prediction_task,
                             max_rules=self.max_rules,
+                            alpha=self.alpha,
                             random_state=self.random_state)
 
 

--- a/imodels/rule_set/rule_fit.py
+++ b/imodels/rule_set/rule_fit.py
@@ -171,14 +171,10 @@ class RuleFit(BaseEstimator, TransformerMixin, RuleSet):
             Transformed data set
         """
         df = pd.DataFrame(X, columns=self.feature_placeholders)
-        X_transformed = np.zeros([X.shape[0], 0])
-
-        for r in rules:
-            curr_rule_feature = np.zeros(X.shape[0])
-            curr_rule_feature[list(df.query(r).index)] = 1
-            curr_rule_feature = np.expand_dims(curr_rule_feature, axis=1)
-            X_transformed = np.concatenate((X_transformed, curr_rule_feature), axis=1)
-
+        X_transformed = np.zeros((X.shape[0], len(rules)))
+        for i, r in enumerate(rules):
+            features_r_uses = [term.split(' ')[0] for term in r.split(' and ')] 
+            X_transformed[df[features_r_uses].query(r).index.values, i] = 1
         return X_transformed
 
     def get_rules(self, exclude_zero_coef=False, subregion=None):

--- a/imodels/rule_set/rule_set.py
+++ b/imodels/rule_set/rule_set.py
@@ -29,8 +29,9 @@ class RuleSet:
         selected_rules = self.rules_without_feature_names_
 
         scores = np.zeros(X.shape[0])
-        for (r, w) in selected_rules:
-            scores[list(df.query(r).index)] += w[0]
+        for r in selected_rules: 
+            features_r_uses = list(map(lambda x: x[0], r.agg_dict.keys()))
+            scores[df[features_r_uses].query(str(r)).index.values] += r.args[0]
 
         return scores
 

--- a/imodels/util/score.py
+++ b/imodels/util/score.py
@@ -6,7 +6,8 @@ import numpy as np
 from sklearn.utils import indices_to_mask
 from sklearn.linear_model import Lasso, LogisticRegression
 from sklearn.linear_model._coordinate_descent import _alpha_grid
-from sklearn.model_selection import KFold
+from sklearn.model_selection import KFold, cross_val_score
+from sklearn.metrics import accuracy_score
 
 from imodels.util.rule import Rule
 
@@ -68,66 +69,80 @@ def _eval_rule_perf(rule: str, X, y) -> Tuple[float, float]:
 
 
 def score_linear(X, y, rules: List[str], 
-                 alphas=None, 
-                 cv=3,
                  penalty='l1',
                  prediction_task='regression',
-                 max_rules=2000, 
+                 max_rules=2000,
+                 alpha=None,
                  random_state=None) -> Tuple[List[Rule], List[float], float]:
-    if alphas is None:
-        if prediction_task == 'regression':
-            alphas = _alpha_grid(X, y)
-        elif prediction_task == 'classification':
-            alphas = [1 / alpha for alpha in np.logspace(-4, 4, num=10, base=10)]
 
-    coef_zero_threshold = 1e-6 / np.mean(np.abs(y))
-    mse_cv_scores = []
-    nonzero_rule_coefs_count = []
-    kf = KFold(cv)
-    
-    # alphas are sorted from most reg. to least reg.
-    for alpha in alphas: 
-        
-        if prediction_task == 'regression':
-            m = Lasso(alpha=alpha, random_state=random_state)
-        else:
-            m = LogisticRegression(penalty=penalty, C=1/alpha, solver='liblinear')
-        mse_cv = 0
-        for train_index, test_index in kf.split(X):
-            X_train, X_test = X[train_index], X[test_index]
-            y_train, y_test = y[train_index], y[test_index]
-            m.fit(X_train, y_train)
-            mse_cv += np.mean((m.predict(X_test) - y_test) ** 2)
-        
-        m.fit(X, y)
-        
-        rule_count = np.sum(np.abs(m.coef_.flatten()) > coef_zero_threshold)
-        if rule_count > max_rules:
-            break
-        nonzero_rule_coefs_count.append(rule_count)
-        mse_cv_scores.append(mse_cv / cv)
-    
-    # rare case in which diff alphas lead to identical scores
-    if np.all(mse_cv_scores == mse_cv_scores[0]):
-        best_alpha = alphas[len(mse_cv_scores) - 1]
+    if alpha is not None:
+        final_alpha = alpha
     else:
-        best_alpha = alphas[np.argmin(mse_cv_scores)]
+        final_alpha = get_best_alpha_under_max_rules(X, y, rules,
+                                                     penalty=penalty,
+                                                     prediction_task=prediction_task,
+                                                     max_rules=max_rules, 
+                                                     random_state=random_state)
 
     if prediction_task == 'regression':
-        lscv = Lasso(alpha=best_alpha, random_state=random_state, max_iter=2000)
+        lscv = Lasso(alpha=final_alpha, random_state=random_state, max_iter=2000)
     else:
-        lscv = LogisticRegression(penalty=penalty, C=1/best_alpha, solver='liblinear',
+        lscv = LogisticRegression(penalty=penalty, C=1/final_alpha, solver='liblinear',
                                   random_state=random_state, max_iter=200)
     lscv.fit(X, y)
 
     coef_ = lscv.coef_.flatten()
-    coefs = list(coef_[:len(coef_)-len(rules)])
+    coefs = list(coef_[:coef_.shape[0]-len(rules)])
     support = np.sum(X[:, -len(rules):], axis=0) / X.shape[0]
 
     nonzero_rules = []
+    coef_zero_threshold = 1e-6 / np.mean(np.abs(y))
     for r, w, s in zip(rules, coef_[-len(rules):], support):
         if abs(w) > coef_zero_threshold:
             nonzero_rules.append(Rule(r, args=[w], support=s))
             coefs.append(w)
     
     return nonzero_rules, coefs, lscv.intercept_
+
+
+def get_best_alpha_under_max_rules(X, y, rules: List[str],
+                                   penalty='l1',
+                                   prediction_task='regression',
+                                   max_rules=2000,
+                                   random_state=None) -> float:
+    coef_zero_threshold = 1e-6 / np.mean(np.abs(y))
+    alpha_scores = []
+    nonzero_rule_coefs_count = []
+
+    if prediction_task == 'regression':
+        alphas = _alpha_grid(X, y)
+    elif prediction_task == 'classification':
+        alphas = [1 / alpha for alpha in np.logspace(-4, 4, num=10, base=10)]
+
+    # alphas are sorted from most reg. to least reg.
+    for alpha in alphas:
+
+        if prediction_task == 'regression':
+            m = Lasso(alpha=alpha, random_state=random_state)
+            fold_scores = cross_val_score(m, X, y, cv=4, scoring='neg_mean_squared_error')
+            alpha_scores.append(np.mean(fold_scores))
+        else:
+            m = LogisticRegression(penalty=penalty, C=1/alpha, solver='liblinear', random_state=random_state)
+            fold_scores = cross_val_score(m, X, y, cv=4, scoring='accuracy')
+            alpha_scores.append(np.mean(fold_scores))
+        
+        m.fit(X, y)
+        
+        rule_coefs = m.coef_.flatten()[:X.shape[1]-len(rules)]
+        rule_count = np.sum(np.abs(rule_coefs) > coef_zero_threshold)
+        if rule_count > max_rules:
+            break
+        nonzero_rule_coefs_count.append(rule_count)
+
+    # rare case in which diff alphas lead to identical scores
+    if np.all(alpha_scores == alpha_scores[0]):
+        best_alpha = alphas[len(alpha_scores) - 1]
+    else:
+        best_alpha = alphas[np.argmax(alpha_scores)]
+    
+    return best_alpha

--- a/tests/rulefit_test.py
+++ b/tests/rulefit_test.py
@@ -35,13 +35,13 @@ def test_integration():
                   [0, 53, 40, 34]])
     y = np.array([1, 0, 1, 1, 0])
 
-    rfr = RuleFitRegressor(exp_rand_tree_size=False, random_state=1, include_linear=False)
+    rfr = RuleFitRegressor(exp_rand_tree_size=False, random_state=1, include_linear=False, alpha=0.1)
     rfr.fit(X, y)
     print(len(rfr.get_rules()))
-    expected = np.array([0.95068613, 0.0739708 , 0.95068613, 0.95068613, 0.0739708])
+    expected = np.array([0.83333333, 0.25, 0.83333333, 0.83333333, 0.25])
     assert np.allclose(rfr.predict(X), expected, atol=1.0e-04)
 
-    rfr = RuleFitRegressor(exp_rand_tree_size=False, max_rules=20, random_state=0)
+    rfr = RuleFitRegressor(exp_rand_tree_size=False, max_rules=20, random_state=0, alpha=0.01)
     rfr.fit(X, y)
-    expected = np.array([0.998019929, 0.00296281305, 0.997986350, 1.00094900, 0.0000819108129])
+    expected = np.array([0.89630491, 0.15375469, 0.89624531, 1.05000033, 0.00369476])
     assert np.allclose(rfr.predict(X), expected)


### PR DESCRIPTION
- make `df.query(rule)` calls faster by removing unneeded columns
- optionally allow user to pass `alpha` in `RuleFit`, `FPLasso`, `StableLinear` constructors to skip alpha validation loop 