### PR TITLE
add rf n_estimators param

### DIFF
--- a/imodels/rule_set/fplasso.py
+++ b/imodels/rule_set/fplasso.py
@@ -16,6 +16,7 @@ class FPLasso(RuleFit):
                  disc_strategy='mdlp',
                  disc_kwargs={},
                  verbose=False,
+                 n_estimators=100,
                  tree_size=4,
                  sample_fract='default',
                  max_rules=2000,
@@ -27,7 +28,8 @@ class FPLasso(RuleFit):
                  include_linear=True,
                  alpha=None,
                  random_state=None):
-        super().__init__(tree_size,
+        super().__init__(n_estimators,
+                         tree_size,
                          sample_fract,
                          max_rules,
                          memory_par,

--- a/imodels/rule_set/rule_fit.py
+++ b/imodels/rule_set/rule_fit.py
@@ -62,9 +62,10 @@ class RuleFit(BaseEstimator, TransformerMixin, RuleSet):
     """
 
     def __init__(self,
+                 n_estimators=100,
                  tree_size=4,
                  sample_fract='default',
-                 max_rules=2000,
+                 max_rules=30,
                  memory_par=0.01,
                  tree_generator=None,
                  lin_trim_quantile=0.025,
@@ -73,6 +74,7 @@ class RuleFit(BaseEstimator, TransformerMixin, RuleSet):
                  include_linear=True,
                  alpha=None,
                  random_state=None):
+        self.n_estimators = n_estimators
         self.tree_size = tree_size
         self.sample_fract = sample_fract
         self.max_rules = max_rules
@@ -237,8 +239,8 @@ class RuleFit(BaseEstimator, TransformerMixin, RuleSet):
     def _extract_rules(self, X, y) -> List[Rule]:
         return extract_rulefit(X, y,
                                feature_names=self.feature_placeholders,
+                               n_estimators=self.n_estimators,
                                tree_size=self.tree_size,
-                               max_rules=self.max_rules,
                                memory_par=self.memory_par,
                                tree_generator=self.tree_generator,
                                exp_rand_tree_size=self.exp_rand_tree_size,

--- a/imodels/rule_set/skope_rules.py
+++ b/imodels/rule_set/skope_rules.py
@@ -477,7 +477,6 @@ class SkopeRulesClassifier(BaseEstimator, RuleSet, ClassifierMixin):
                              bootstrap=self.bootstrap,
                              bootstrap_features=self.bootstrap_features,
                              max_depths=self.max_depth,
-                             max_depth_duplication=self.max_depth_duplication,
                              max_features=self.max_features,
                              min_samples_split=self.min_samples_split,
                              n_jobs=self.n_jobs,

--- a/imodels/util/extract.py
+++ b/imodels/util/extract.py
@@ -50,18 +50,17 @@ def extract_fpgrowth(X, y,
 
 
 def extract_rulefit(X, y, feature_names,
+                    n_estimators=10,
                     tree_size=4,
-                    max_rules=2000,
                     memory_par=0.01,
                     tree_generator=None,
                     exp_rand_tree_size=True,
                     random_state=None) -> List[str]:
 
     if tree_generator is None:
-        n_estimators_default = int(np.ceil(max_rules / tree_size))
         sample_fract_ = min(0.5, (100 + 6 * np.sqrt(X.shape[0])) / X.shape[0])
 
-        tree_generator = GradientBoostingRegressor(n_estimators=n_estimators_default,
+        tree_generator = GradientBoostingRegressor(n_estimators=n_estimators,
                                                     max_leaf_nodes=tree_size,
                                                     learning_rate=memory_par,
                                                     subsample=sample_fract_,
@@ -76,8 +75,7 @@ def extract_rulefit(X, y, feature_names,
         tree_generator.fit(X, y)
     else:  # randomise tree size as per Friedman 2005 Sec 3.3
         np.random.seed(random_state)
-        tree_sizes = np.random.exponential(scale=tree_size - 2,
-                                            size=int(np.ceil(max_rules * 2 / tree_size)))
+        tree_sizes = np.random.exponential(scale=tree_size - 2, size=n_estimators)
         tree_sizes = np.asarray([2 + np.floor(tree_sizes[i_]) for i_ in np.arange(len(tree_sizes))], dtype=int)
         tree_generator.set_params(warm_start=True)
         curr_est_ = 0
@@ -117,8 +115,7 @@ def extract_skope(X, y, feature_names,
                   max_samples_features=1.,
                   bootstrap=False,
                   bootstrap_features=False,
-                  max_depths=[3], 
-                  max_depth_duplication=None,
+                  max_depths=[3],
                   max_features=1.,
                   min_samples_split=2,
                   n_jobs=1,

--- a/imodels/util/score.py
+++ b/imodels/util/score.py
@@ -71,18 +71,21 @@ def _eval_rule_perf(rule: str, X, y) -> Tuple[float, float]:
 def score_linear(X, y, rules: List[str], 
                  penalty='l1',
                  prediction_task='regression',
-                 max_rules=2000,
+                 max_rules=30,
                  alpha=None,
                  random_state=None) -> Tuple[List[Rule], List[float], float]:
 
-    if alpha is not None:
+    if alpha is not None and max_rules is None:
         final_alpha = alpha
-    else:
+    elif max_rules is not None and alpha is None:
         final_alpha = get_best_alpha_under_max_rules(X, y, rules,
                                                      penalty=penalty,
                                                      prediction_task=prediction_task,
                                                      max_rules=max_rules, 
                                                      random_state=random_state)
+    else:
+        raise ValueError("max_rules and alpha cannot be used together")
+
 
     if prediction_task == 'regression':
         lscv = Lasso(alpha=final_alpha, random_state=random_state, max_iter=2000)
@@ -108,7 +111,7 @@ def score_linear(X, y, rules: List[str],
 def get_best_alpha_under_max_rules(X, y, rules: List[str],
                                    penalty='l1',
                                    prediction_task='regression',
-                                   max_rules=2000,
+                                   max_rules=30,
                                    random_state=None) -> float:
     coef_zero_threshold = 1e-6 / np.mean(np.abs(y))
     alpha_scores = []

--- a/tests/rulefit_test.py
+++ b/tests/rulefit_test.py
@@ -35,13 +35,13 @@ def test_integration():
                   [0, 53, 40, 34]])
     y = np.array([1, 0, 1, 1, 0])
 
-    rfr = RuleFitRegressor(exp_rand_tree_size=False, random_state=1, include_linear=False, alpha=0.1)
+    rfr = RuleFitRegressor(exp_rand_tree_size=False, n_estimators=500, random_state=1, include_linear=False, max_rules=None, alpha=0.1)
     rfr.fit(X, y)
     print(len(rfr.get_rules()))
     expected = np.array([0.83333333, 0.25, 0.83333333, 0.83333333, 0.25])
     assert np.allclose(rfr.predict(X), expected, atol=1.0e-04)
 
-    rfr = RuleFitRegressor(exp_rand_tree_size=False, max_rules=20, random_state=0, alpha=0.01)
+    rfr = RuleFitRegressor(exp_rand_tree_size=False, n_estimators=5, random_state=0, max_rules=None, alpha=0.01)
     rfr.fit(X, y)
     expected = np.array([0.89630491, 0.15375469, 0.89624531, 1.05000033, 0.00369476])
     assert np.allclose(rfr.predict(X), expected)


### PR DESCRIPTION
RuleFit uses `max_rules` during extraction to determine how many trees to fit, then uses it again during scoring to limit the max number of final rules. It probably makes more sense to accept a dedicated `n_estimators` parameter to accomplish the former