### PR TITLE
Fix pytest and expand percentiles

### DIFF
--- a/imodels/rule_set/slipper.py
+++ b/imodels/rule_set/slipper.py
@@ -102,7 +102,7 @@ class SlipperClassifier(BaseEstimator, ClassifierMixin):
         while not stop_condition:
             candidate_rule = curr_rule.copy()
             for feat in features:
-                pivots = np.percentile(X[:, feat], range(0, 100, 2),
+                pivots = np.percentile(X[:, feat], range(0, 100, 4),
                                        interpolation='midpoint')
 
                 # get a list of possible rules

--- a/tests/classification_binary_test.py
+++ b/tests/classification_binary_test.py
@@ -34,7 +34,7 @@ class TestClassClassificationBinary:
                 init_kwargs['max_samples_features'] = 1.
             if model_type == SlipperClassifier:
                 model_type = BoostedRulesClassifier
-                init_kwargs['n_estimators'] = 3
+                init_kwargs['n_estimators'] = 1
                 init_kwargs['estimator'] = partial(SlipperClassifier)
             m = model_type(**init_kwargs)
 


### PR DESCRIPTION
This fixes the pytest fail and I also caught an incorrect percentile for the grow rule routine, which expands the feature space for appending conditions to rules (what Cohen and Singer used.)