### PR TITLE
Backup model for gosdt; SLIM backup clarifications

### DIFF
--- a/imodels/__init__.py
+++ b/imodels/__init__.py
@@ -9,6 +9,7 @@ import os
 # from .tree.iterative_random_forest.iterative_random_forest import IRFClassifier
 # from .tree.optimal_classification_tree import OptimalTreeModel
 from .tree.cart_wrapper import GreedyTreeClassifier
+from .tree.gosdt.pygosdt import GOSDTClassifier
 from .algebraic.slim import SLIMRegressor, SLIMClassifier
 from .discretization.discretizer import RFDiscretizer, BasicDiscretizer
 from .discretization.mdlp import MDLPDiscretizer, BRLDiscretizer
@@ -25,11 +26,6 @@ from .rule_set.fpskope import FPSkopeClassifier
 from .rule_set.rule_fit import RuleFitRegressor, RuleFitClassifier
 from .rule_set.skope_rules import SkopeRulesClassifier
 from .rule_set.slipper import SlipperClassifier
-
-try:
-    from .tree.gosdt.pygosdt import GOSDTClassifier
-except ModuleNotFoundError:
-    pass
 
 from .util.explain_errors import explain_classification_errors
 

--- a/imodels/tests/classification_continuous_inputs_test.py
+++ b/imodels/tests/classification_continuous_inputs_test.py
@@ -14,8 +14,12 @@ class TestClassClassificationBinary:
         self.n = 40
         self.p = 2
         self.X_classification_binary = np.random.randn(self.n, self.p)
-        self.y_classification_binary = (self.X_classification_binary[:, 0] > 0).astype(int)  # y = x0 > 0
-        self.y_classification_binary[-2:] = 1 - self.y_classification_binary[-2:]  # flip labels for last few
+        
+        # y = x0 > 0
+        self.y_classification_binary = (self.X_classification_binary[:, 0] > 0).astype(int)
+
+        # flip labels for last few
+        self.y_classification_binary[-2:] = 1 - self.y_classification_binary[-2:]
 
     def test_classification_binary(self):
         '''Test imodels on basic binary classification task
@@ -49,7 +53,8 @@ class TestClassClassificationBinary:
                 assert len(preds_proba.shape) == 2, 'preds_proba has 2 columns'
                 assert preds_proba.shape[1] == 2, 'preds_proba has 2 columns'
                 assert np.max(preds_proba) < 1.1, 'preds_proba has no values over 1'
-                assert (np.argmax(preds_proba, axis=1) == preds).all(), "predict_proba and predict correspond"
+                assert (np.argmax(preds_proba, axis=1) == preds).all(), ("predict_proba and "
+                                                                         "predict agree")
 
             # test acc
             acc_train = np.mean(preds == self.y_classification_binary)

--- a/imodels/tree/gosdt/pygosdt.py
+++ b/imodels/tree/gosdt/pygosdt.py
@@ -2,9 +2,9 @@ import json
 import warnings
 
 import pandas as pd
-from sklearn.tree import DecisionTreeClassifier
 from sklearn.utils import validation
 
+from imodels.tree.gosdt.pygosdt_backup import DecisionTreeClassifierWithComplexity
 from imodels.tree.gosdt.tree_classifier import TreeClassifier
 from imodels.util import rule
 
@@ -122,7 +122,7 @@ class GOSDTClassifier:
                 "Using DecisionTreeClassifier instead."
             )
 
-            dtree = DecisionTreeClassifier()
+            dtree = DecisionTreeClassifierWithComplexity()
             dtree.fit(X, y)
             self.tree_ = dtree
             

--- a/imodels/tree/gosdt/pygosdt.py
+++ b/imodels/tree/gosdt/pygosdt.py
@@ -118,7 +118,7 @@ class GOSDTClassifier:
             warnings.warn(
                 "Should install gosdt C++ extenstion. On x86_64 linux or macOS: "
                 "'pip install gosdt'. On other platforms, see "
-                "https://github.com/keyan3/GeneralizedOptimalSparseDecisionTrees."
+                "https://github.com/keyan3/GeneralizedOptimalSparseDecisionTrees. "
                 "Using DecisionTreeClassifier instead."
             )
 

--- a/imodels/tree/gosdt/pygosdt.py
+++ b/imodels/tree/gosdt/pygosdt.py
@@ -1,8 +1,9 @@
 import json
-import pandas as pd
-from sklearn.utils import validation
+import warnings
 
-import gosdt
+import pandas as pd
+from sklearn.tree import DecisionTreeClassifier
+from sklearn.utils import validation
 
 from imodels.tree.gosdt.tree_classifier import TreeClassifier
 from imodels.util import rule
@@ -70,9 +71,6 @@ class GOSDTClassifier:
             result = model_source.read()
         result = json.loads(result)
         self.tree_ = TreeClassifier(result[0])
-        
-    def status(self):
-        return gosdt.status()
 
     def fit(self, X, y, feature_names=None):
         """
@@ -87,31 +85,47 @@ class GOSDTClassifier:
         ---
         trains the model so that this model instance is ready for prediction
         """
-        if not isinstance(X, pd.DataFrame):
-            self.feature_names_ = list(rule.get_feature_dict(X.shape[1], feature_names).keys())
-            X = pd.DataFrame(X, columns=self.feature_names_)
-        else:
-            self.feature_names_ = X.columns
-        
-        if not isinstance(y, pd.DataFrame):
-            y = pd.DataFrame(y, columns=['target'])
-        
-        # gosdt extension expects serialized CSV, which we generate via pandas
-        dataset_with_target = pd.concat((X, y), axis=1)
+        try:
+            import gosdt
 
-        # Perform C++ extension calls to train the model
-        configuration = self._get_configuration()
-        gosdt.configure(json.dumps(configuration, separators=(',', ':')))
-        result = gosdt.fit(dataset_with_target.to_csv(index=False))
+            if not isinstance(X, pd.DataFrame):
+                self.feature_names_ = list(rule.get_feature_dict(X.shape[1], feature_names).keys())
+                X = pd.DataFrame(X, columns=self.feature_names_)
+            else:
+                self.feature_names_ = X.columns
+            
+            if not isinstance(y, pd.DataFrame):
+                y = pd.DataFrame(y, columns=['target'])
+            
+            # gosdt extension expects serialized CSV, which we generate via pandas
+            dataset_with_target = pd.concat((X, y), axis=1)
 
-        result = json.loads(result)
-        self.tree_ = TreeClassifier(result[0])
+            # Perform C++ extension calls to train the model
+            configuration = self._get_configuration()
+            gosdt.configure(json.dumps(configuration, separators=(',', ':')))
+            result = gosdt.fit(dataset_with_target.to_csv(index=False))
 
-        # Record the training time, number of iterations, and graph size required
-        self.time_ = gosdt.time()
-        self.iterations_ = gosdt.iterations()
-        self.size_ = gosdt.size()
+            result = json.loads(result)
+            self.tree_ = TreeClassifier(result[0])
 
+            # Record the training time, number of iterations, and graph size required
+            self.time_ = gosdt.time()
+            self.iterations_ = gosdt.iterations()
+            self.size_ = gosdt.size()
+
+        except ImportError:
+
+            warnings.warn(
+                "Should install gosdt C++ extenstion. On x86_64 linux or macOS: "
+                "'pip install gosdt'. On other platforms, see "
+                "https://github.com/keyan3/GeneralizedOptimalSparseDecisionTrees."
+                "Using DecisionTreeClassifier instead."
+            )
+
+            dtree = DecisionTreeClassifier()
+            dtree.fit(X, y)
+            self.tree_ = dtree
+            
         return self
 
     def predict(self, X):
@@ -128,40 +142,19 @@ class GOSDTClassifier:
             associated with each row
         """
         validation.check_is_fitted(self)
-        if not isinstance(X, pd.DataFrame):
+        if type(self.tree_) is TreeClassifier and not isinstance(X, pd.DataFrame):
             X = pd.DataFrame(X, columns=self.feature_names_)
         return self.tree_.predict(X)
-
-    def error(self, X, y, weight=None):
-        """
-        Parameters
-        ---
-        X : matrix-like, shape = [n_samples by m_features]
-            an n-by-m matrix of sample and their features
-        y : array-like, shape = [n_samples by 1]
-            an n-by-1 column of labels associated with each sample
-        weight : real number
-            an n-by-1 column of weights to apply to each sample's misclassification
-
-        Returns
-        ---
-        real number : the inaccuracy produced by applying this model overthe given dataset, with
-            optionals for weighted inaccuracy
-        """
-        validation.check_is_fitted(self)
-        if not isinstance(X, pd.DataFrame):
-            X = pd.DataFrame(X, columns=self.feature_names_)
-        return self.tree_.error(X, y, weight=weight)
 
     def score(self, X, y, weight=None):
         """
         Parameters
         ---
-        X : matrix-like, shape = [n_samples by m_features]
+        X : matrix-like, shape = [n_samples, m_features]
             an n-by-m matrix of sample and their features
-        y : array-like, shape = [n_samples by 1]
+        y : array-like, shape = [n_samples,]
             an n-by-1 column of labels associated with each sample
-        weight : real number
+        weight : shape = [n_samples,]
             an n-by-1 column of weights to apply to each sample's misclassification
 
         Returns
@@ -170,9 +163,12 @@ class GOSDTClassifier:
             optionals for weighted accuracy
         """
         validation.check_is_fitted(self)
-        if not isinstance(X, pd.DataFrame):
-            X = pd.DataFrame(X, columns=self.feature_names_)
-        return self.tree_.score(X, y, weight=weight)
+        if type(self.tree_) is TreeClassifier:
+            if not isinstance(X, pd.DataFrame):
+                X = pd.DataFrame(X, columns=self.feature_names_)
+            return self.tree_.score(X, y, weight=weight)
+        else:
+            return self.tree_.score(X, y, sample_weight=weight)
 
     def __len__(self):
         """
@@ -181,7 +177,12 @@ class GOSDTClassifier:
         natural number : The number of terminal nodes present in this tree
         """
         validation.check_is_fitted(self)
-        return len(self.tree_)
+        if type(self.tree_) is TreeClassifier:
+            return len(self.tree_)
+        else:
+            warnings.warn("Using DecisionTreeClassifier due to absence of gosdt package. "
+                          "DecisionTreeClassifier does not have this method.")
+            return None
 
     def leaves(self):
         """
@@ -190,7 +191,10 @@ class GOSDTClassifier:
         natural number : The number of terminal nodes present in this tree
         """
         validation.check_is_fitted(self)
-        return self.tree_.leaves()
+        if type(self.tree_) is TreeClassifier:
+            return self.tree_.leaves()
+        else:
+            return self.tree_.get_n_leaves()
 
     def nodes(self):
         """
@@ -199,7 +203,12 @@ class GOSDTClassifier:
         natural number : The number of nodes present in this tree
         """
         validation.check_is_fitted(self)
-        return self.tree_.nodes()
+        if type(self.tree_) is TreeClassifier:
+            return self.tree_.nodes()
+        else:
+            warnings.warn("Using DecisionTreeClassifier due to absence of gosdt package. "
+                          "DecisionTreeClassifier does not have this method.")
+            return None
 
     def max_depth(self):
         """
@@ -209,7 +218,10 @@ class GOSDTClassifier:
             will return 1.
         """
         validation.check_is_fitted(self)
-        return self.tree_.maximum_depth()
+        if type(self.tree_) is TreeClassifier:
+            return self.tree_.maximum_depth()
+        else:
+            return self.tree_.get_depth()
 
     def latex(self):
         """
@@ -223,7 +235,12 @@ class GOSDTClassifier:
         string : A LaTeX string representing the model
         """
         validation.check_is_fitted(self)
-        return self.tree_.latex()
+        if type(self.tree_) is TreeClassifier:
+            return self.tree_.latex()
+        else:
+            warnings.warn("Using DecisionTreeClassifier due to absence of gosdt package. "
+                          "DecisionTreeClassifier does not have this method.")
+            return None
 
     def json(self):
         """
@@ -232,7 +249,12 @@ class GOSDTClassifier:
         string : A JSON string representing the model
         """
         validation.check_is_fitted(self)
-        return self.tree_.json()
+        if type(self.tree_) is TreeClassifier:
+            return self.tree_.json()
+        else:
+            warnings.warn("Using DecisionTreeClassifier due to absence of gosdt package. "
+                          "DecisionTreeClassifier does not have this method.")
+            return None
 
     def _get_configuration(self):
         return {

--- a/imodels/tree/gosdt/pygosdt_backup.py
+++ b/imodels/tree/gosdt/pygosdt_backup.py
@@ -3,7 +3,7 @@
 from sklearn.tree import DecisionTreeClassifier, export_text
 
 
-class GlobalSparseTreeClassifier(DecisionTreeClassifier):
+class DecisionTreeClassifierWithComplexity(DecisionTreeClassifier):
     """Placeholder for GOSDT classifier
     """
 
@@ -12,7 +12,12 @@ class GlobalSparseTreeClassifier(DecisionTreeClassifier):
         self.complexity_ = 0
         self.feature_names = None
 
-    def fit(self, X, y, feature_names=None, sample_weight=None, check_input=True, X_idx_sorted="deprecated"):
+    def fit(self, X, y,
+            feature_names=None,
+            sample_weight=None,
+            check_input=True,
+            X_idx_sorted="deprecated"):
+            
         """Build a decision tree classifier from the training set (X, y).
         Parameters
         ----------
@@ -57,7 +62,7 @@ class GlobalSparseTreeClassifier(DecisionTreeClassifier):
         tree = self.tree_
         children_left = tree.children_left
         children_right = tree.children_right
-        n_nodes = tree.node_count
+        # n_nodes = tree.node_count
         num_split_nodes = 0
         num_leaves = 0
 
@@ -83,6 +88,7 @@ class GlobalSparseTreeClassifier(DecisionTreeClassifier):
 
     def __str__(self):
         if self.feature_names is not None:
-            return 'OptimalTree:\n' + export_text(self, feature_names=self.feature_names, show_weights=True)
+            return 'OptimalTree:\n' + export_text(self, feature_names=self.feature_names, 
+                                                  show_weights=True)
         else:
             return 'OptimalTree:\n' + export_text(self, show_weights=True)

--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,10 @@ required_pypi = [
     'scipy',
     'scikit-learn>=0.23.0',  # 0.23+ only works on py3.6+
 ]
-excluded_dirs = ['imodels.tests', 'experiments', 'notebooks', 'docs', 'imodels.tree.gosdt']
 
 # gosdt is only supported on x86 64-bit systems
 if 'x86_64' in platform.platform() and platform.system() != 'Windows':
     required_pypi.append('gosdt')
-    excluded_dirs.pop()
 
 setuptools.setup(
     name="imodels",
@@ -32,7 +30,8 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/csinva/imodels",
-    packages=setuptools.find_packages(exclude=excluded_dirs),
+    packages=setuptools.find_packages(
+        exclude=['imodels.tests', 'experiments', 'notebooks', 'docs']),
     install_requires=required_pypi,
     extras_require={
         'dev': [


### PR DESCRIPTION
- in SLIM, differentiate between the case when user is missing `cvxpy` and the case when a user has `cvxpy` but doesn't have a powerful enough solver for mixed-integer linear or logistic regression
- make DecisionTreeClassifierWithComplexity the backup model when user doesn't have gosdt installed and provide a warning message
- no longer conditionally exclude `imodels.tree.gosdt` from the built package based on OS