### PR TITLE
Rulefix complexity & gosdt inheritance

### DIFF
--- a/imodels/rule_set/rule_fit.py
+++ b/imodels/rule_set/rule_fit.py
@@ -125,7 +125,12 @@ class RuleFit(BaseEstimator, TransformerMixin, RuleSet):
         self.rules_ = [
             replace_feature_name(rule, self.feature_dict_) for rule in self.rules_without_feature_names_
         ]
+
+        # count total rule terms, plus nonzero linear terms
         self.complexity_ = self._get_complexity()
+        if self.include_linear:
+            self.complexity_ += np.sum(
+                np.array(self.coef[:X.shape[1]]) != 0)
 
         return self
 

--- a/imodels/tree/gosdt/pygosdt.py
+++ b/imodels/tree/gosdt/pygosdt.py
@@ -45,7 +45,7 @@ class OptimalTreeClassifier(GreedyTreeClassifier if not gosdt_supported else Bas
                  timing="",
                  trace="",
                  tree=""):
-        # super().__init__(*args, **kwargs)
+        super().__init__()
         self.balance = balance
         self.cancellation = cancellation
         self.look_ahead = look_ahead

--- a/imodels/tree/gosdt/pygosdt.py
+++ b/imodels/tree/gosdt/pygosdt.py
@@ -3,6 +3,7 @@ import warnings
 
 import numpy as np
 import pandas as pd
+from sklearn.base import BaseEstimator
 from sklearn.utils import validation
 
 from imodels import GreedyTreeClassifier
@@ -10,7 +11,14 @@ from imodels.tree.gosdt.pygosdt_helper import TreeClassifier
 from imodels.util import rule
 
 
-class OptimalTreeClassifier(GreedyTreeClassifier):
+try:
+    import gosdt
+    gosdt_supported = True
+except ImportError:
+    gosdt_supported = False
+
+
+class OptimalTreeClassifier(GreedyTreeClassifier if not gosdt_supported else BaseEstimator):
     def __init__(self,
                  balance=False,
                  cancellation=True,
@@ -36,9 +44,8 @@ class OptimalTreeClassifier(GreedyTreeClassifier):
                  profile="",
                  timing="",
                  trace="",
-                 tree="",
-                 *args, **kwargs):
-        super().__init__(*args, **kwargs)
+                 tree=""):
+        # super().__init__(*args, **kwargs)
         self.balance = balance
         self.cancellation = cancellation
         self.look_ahead = look_ahead


### PR DESCRIPTION
Rulefit complexity wasn't counting linear terms when `include_linear=True`

Gosdt always inheriting from `GreedyTreeClassifier` can cause issues when you actually have `gosdt` installed, e.g. the print method will expect some attributes that specific to `GreedyTreeClassifier` and not created by `OptimalTreeClassifier.fit`. I switched it to the corels approach where we check if gosdt is supported before picking the parent class.