### PR TITLE
Remove discretization from BRL & Python updates

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2
@@ -20,10 +20,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pyversion=$(python -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
-        if [[ $pyversion == '3.6' ]]; then pip install 'numpy<1.20' 'scipy<1.6'; fi
+      run:
         pip install .[dev]
     - name: Test with pytest
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, 3.10.2]
 
     steps:
     - uses: actions/checkout@v2

--- a/imodels/discretization/discretizer.py
+++ b/imodels/discretization/discretizer.py
@@ -282,7 +282,7 @@ class ExtraBasicDiscretizer(TransformerMixin):
     n_bins : int or array-like of shape (len(dcols),), default=4
         Number of bins to discretize each feature into.
 
-    strategy : {‘uniform’, ‘quantile’, ‘kmeans’}, default='quantile'
+    strategy : {'uniform', 'quantile', 'kmeans'}, default='quantile'
         Strategy used to define the widths of the bins.
 
         uniform
@@ -293,16 +293,16 @@ class ExtraBasicDiscretizer(TransformerMixin):
             Values in each bin have the same nearest center of a 1D
             k-means cluster.
 
-    onehot_drop : {‘first’, ‘if_binary’} or a array-like of shape  (len(dcols),), default='if_binary'
+    onehot_drop : {'first', 'if_binary'} or a array-like of shape  (len(dcols),), default='if_binary'
         Specifies a methodology to use to drop one of the categories
         per feature when encode = "onehot".
 
         None
             Retain all features (the default).
-        ‘first’
+        'first'
             Drop the first y_str in each feature. If only one y_str
             is present, the feature will be dropped entirely.
-        ‘if_binary’
+        'if_binary'
             Drop the first y_str in each feature with two categories.
             Features with 1 or more than 2 categories are left intact.
 
@@ -417,7 +417,7 @@ class BasicDiscretizer(AbstractDiscretizer):
         The names of the columns to be discretized; by default,
         discretize all float and int columns in X.
 
-    encode : {‘onehot’, ‘ordinal’}, default=’onehot’
+    encode : {'onehot', 'ordinal'}, default='onehot'
         Method used to encode the transformed result.
 
         onehot
@@ -426,7 +426,7 @@ class BasicDiscretizer(AbstractDiscretizer):
         ordinal
             Return the bin identifier encoded as an integer value.
 
-    strategy : {‘uniform’, ‘quantile’, ‘kmeans’}, default=’quantile’
+    strategy : {'uniform', 'quantile', 'kmeans'}, default='quantile'
         Strategy used to define the widths of the bins.
 
         uniform

--- a/imodels/rule_list/bayesian_rule_list/bayesian_rule_list.py
+++ b/imodels/rule_list/bayesian_rule_list/bayesian_rule_list.py
@@ -60,8 +60,6 @@ class BayesianRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
                  listwidthprior=1,
                  maxcardinality=2,
                  minsupport=0.1,
-                 disc_strategy='mdlp',
-                 disc_kwargs={},
                  alpha=np.array([1., 1.]),
                  n_chains=3,
                  max_iter=50000,
@@ -72,8 +70,6 @@ class BayesianRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
         self.listwidthprior = listwidthprior
         self.maxcardinality = maxcardinality
         self.minsupport = minsupport
-        self.disc_strategy = disc_strategy
-        self.disc_kwargs = disc_kwargs
         self.alpha = alpha
         self.n_chains = n_chains
         self.max_iter = max_iter
@@ -84,7 +80,6 @@ class BayesianRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
         self.thinning = 1  # The thinning rate
         self.burnin = self.max_iter // 2  # the number of samples to drop as burn-in in-simulation
 
-        self.discretizer = None
         self.d_star = None
         self.random_state = random_state
         self.seed()
@@ -147,9 +142,7 @@ class BayesianRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
         self.feature_names = np.array(list(self.feature_dict_.values()))
 
         X_df = pd.DataFrame(X, columns=self.feature_placeholders)
-        itemsets = extract_fpgrowth(X_df, y,
-                                    feature_names=self.feature_placeholders,
-                                    minsupport=self.minsupport,
+        itemsets = extract_fpgrowth(X_df, minsupport=self.minsupport,
                                     maxcardinality=self.maxcardinality,
                                     verbose=verbose)
 
@@ -284,10 +277,7 @@ class BayesianRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
         check_is_fitted(self)
         X = check_array(X)
 
-        if self.discretizer:
-            D = self.discretizer.transform(X)
-        else:
-            D = pd.DataFrame(X, columns=self.feature_names)
+        D = pd.DataFrame(X, columns=self.feature_placeholders)
 
         N = len(D)
         X2 = self._to_itemset_indices(D)

--- a/imodels/rule_set/fplasso.py
+++ b/imodels/rule_set/fplasso.py
@@ -1,5 +1,6 @@
 from typing import List
 
+import pandas as pd
 from sklearn.base import ClassifierMixin, RegressorMixin
 
 from imodels.rule_set.rule_fit import RuleFit
@@ -12,8 +13,6 @@ class FPLasso(RuleFit):
     def __init__(self,
                  minsupport=0.1,
                  maxcardinality=2,
-                 disc_strategy='mdlp',
-                 disc_kwargs={},
                  verbose=False,
                  n_estimators=100,
                  tree_size=4,
@@ -39,8 +38,6 @@ class FPLasso(RuleFit):
                          include_linear,
                          alpha,
                          random_state)
-        self.disc_strategy = disc_strategy
-        self.disc_kwargs = disc_kwargs
         self.minsupport = minsupport
         self.maxcardinality = maxcardinality
         self.verbose = verbose
@@ -51,14 +48,10 @@ class FPLasso(RuleFit):
         return self
 
     def _extract_rules(self, X, y) -> List[str]:
-        itemsets = extract_fpgrowth(X, y,
-                                    feature_names=self.feature_placeholders,
-                                    minsupport=self.minsupport,
+        X = pd.DataFrame(X, columns=self.feature_placeholders)
+        itemsets = extract_fpgrowth(X, minsupport=self.minsupport,
                                     maxcardinality=self.maxcardinality,
-                                    undiscretized_features=self.undiscretized_features,
-                                    disc_strategy=self.disc_strategy,
-                                    disc_kwargs=self.disc_kwargs,
-                                    verbose=self.verbose)[0]
+                                    verbose=self.verbose)
         return itemsets_to_rules(itemsets)
 
 

--- a/imodels/rule_set/fpskope.py
+++ b/imodels/rule_set/fpskope.py
@@ -1,6 +1,7 @@
 from typing import List
 
 import numpy as np
+import pandas as pd
 
 from imodels.rule_set.skope_rules import SkopeRulesClassifier
 from imodels.util.convert import itemsets_to_rules
@@ -14,8 +15,6 @@ class FPSkopeClassifier(SkopeRulesClassifier):
     def __init__(self,
                  minsupport=0.1,
                  maxcardinality=2,
-                 disc_strategy='mdlp',
-                 disc_kwargs={},
                  verbose=False,
                  precision_min=0.5,
                  recall_min=0.01,
@@ -44,8 +43,6 @@ class FPSkopeClassifier(SkopeRulesClassifier):
                          n_jobs,
                          random_state,
                          verbose)
-        self.disc_strategy = disc_strategy
-        self.disc_kwargs = disc_kwargs
         self.minsupport = minsupport
         self.maxcardinality = maxcardinality
         self.verbose = verbose
@@ -56,14 +53,10 @@ class FPSkopeClassifier(SkopeRulesClassifier):
         return self
 
     def _extract_rules(self, X, y) -> List[str]:
-        itemsets = extract_fpgrowth(X, y,
-                                    feature_names=self.feature_placeholders,
-                                    minsupport=self.minsupport,
+        X = pd.DataFrame(X, columns=self.feature_placeholders)
+        itemsets = extract_fpgrowth(X, minsupport=self.minsupport,
                                     maxcardinality=self.maxcardinality,
-                                    undiscretized_features=self.undiscretized_features,
-                                    disc_strategy=self.disc_strategy,
-                                    disc_kwargs=self.disc_kwargs,
-                                    verbose=self.verbose)[0]
+                                    verbose=self.verbose)
         return [itemsets_to_rules(itemsets)], [np.arange(X.shape[0])], [np.arange(len(self.feature_names))]
 
     def _score_rules(self, X, y, rules) -> List[Rule]:

--- a/imodels/util/extract.py
+++ b/imodels/util/extract.py
@@ -2,13 +2,12 @@ from typing import Iterable, Tuple, List
 
 import numpy as np
 import pandas as pd
-from mlxtend.frequent_patterns import fpgrowth
+from mlxtend import frequent_patterns as mlx
 from sklearn.ensemble import BaggingRegressor, GradientBoostingRegressor, RandomForestRegressor, \
     GradientBoostingClassifier
 from sklearn.tree import DecisionTreeRegressor
 from sklearn.utils.validation import check_array
 
-from imodels.discretization import BRLDiscretizer, SimpleDiscretizer
 from imodels.util import rule, convert
 
 
@@ -16,36 +15,16 @@ def extract_fpgrowth(X, y,
                      feature_names,
                      minsupport=0.1,
                      maxcardinality=2,
-                     undiscretized_features=[],
-                     disc_strategy='simple',
-                     disc_kwargs={},
-                     verbose=False) -> Tuple[List[Tuple], BRLDiscretizer]:
-    # deal with pandas data
-    if type(X) in [pd.DataFrame, pd.Series]:
-        if feature_names is None:
-            feature_names = X.columns
-        X = X.values
-    if type(y) in [pd.DataFrame, pd.Series]:
-        y = y.values
-
-    if disc_strategy == 'mdlp':
-        discretizer = BRLDiscretizer(X, y, feature_labels=feature_names, verbose=verbose)
-        discretizer.fit(X, y, undiscretized_features)
-    else:
-        discretizer = SimpleDiscretizer(**disc_kwargs)
-        discretizer.fit(X, feature_names)
-
-    X_df_onehot = discretizer.transform(X)
-
-    # Now find frequent itemsets
-    itemsets_df = fpgrowth(X_df_onehot, min_support=minsupport, max_len=maxcardinality)
+                     verbose=False) -> List[Tuple]:
+    
+    itemsets_df = mlx.fpgrowth(X, min_support=minsupport, max_len=maxcardinality)
     itemsets_indices = [tuple(s[1]) for s in itemsets_df.values]
-    itemsets = [np.array(X_df_onehot.columns)[list(inds)] for inds in itemsets_indices]
+    itemsets = [np.array(X.columns)[list(inds)] for inds in itemsets_indices]
     itemsets = list(map(tuple, itemsets))
     if verbose:
         print(len(itemsets), 'rules mined')
 
-    return itemsets, discretizer
+    return itemsets
 
 
 def extract_rulefit(X, y, feature_names,

--- a/imodels/util/extract.py
+++ b/imodels/util/extract.py
@@ -11,8 +11,7 @@ from sklearn.utils.validation import check_array
 from imodels.util import rule, convert
 
 
-def extract_fpgrowth(X, y,
-                     feature_names,
+def extract_fpgrowth(X,
                      minsupport=0.1,
                      maxcardinality=2,
                      verbose=False) -> List[Tuple]:

--- a/notebooks/imodels_demo.ipynb
+++ b/notebooks/imodels_demo.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 17,
    "metadata": {
     "pycharm": {
      "is_executing": false
@@ -27,6 +27,7 @@
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
+    "import pandas as pd\n",
     "\n",
     "np.random.seed(13)\n",
     "from sklearn.datasets import fetch_openml\n",
@@ -38,11 +39,11 @@
     "# installable with: `pip install imodels`\n",
     "from imodels import SLIMRegressor, BayesianRuleListClassifier, RuleFitRegressor, GreedyRuleListClassifier\n",
     "from imodels import SLIMClassifier, OneRClassifier, BoostedRulesClassifier\n",
+    "from imodels.discretization import ExtraBasicDiscretizer\n",
     "\n",
     "# change working directory to project root\n",
     "if os.getcwd().split('/')[-1] != 'imodels':\n",
     "    os.chdir('..')\n",
-    "\n",
     "\n",
     "def get_ames_data():\n",
     "    housing = fetch_openml(name=\"house_prices\", as_frame=True)\n",
@@ -53,7 +54,6 @@
     "        housing_data_numeric.values, housing_target, test_size=0.75)\n",
     "    return X_train_reg, X_test_reg, y_train_reg, y_test_reg, feature_names\n",
     "    \n",
-    "\n",
     "def get_diabetes_data():\n",
     "    '''load (classification) data on diabetes\n",
     "    '''\n",
@@ -68,10 +68,8 @@
     "                     \"2-Hour serum insulin (mu U/ml)\", \"Body mass index\", \"Diabetes pedigree function\", \"Age (years)\"]\n",
     "    return X_train, X_test, y_train, y_test, feature_names\n",
     "\n",
-    "\n",
     "X_train_reg, X_test_reg, y_train_reg, y_test_reg, feat_names_reg = get_ames_data()\n",
     "X_train, X_test, y_train, y_test, feat_names = get_diabetes_data()\n",
-    "\n",
     "\n",
     "def viz_classification_preds(probs, y_test):\n",
     "    '''look at prediction breakdown\n",
@@ -380,15 +378,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
+    "disc = ExtraBasicDiscretizer(feat_names[:3], n_bins=3, strategy='uniform')\n",
+    "X_train_brl_df = disc.fit_transform(pd.DataFrame(X_train[:, :3], columns=feat_names[:3]))\n",
+    "X_test_brl_df = disc.transform(pd.DataFrame(X_test[:, :3], columns=feat_names[:3]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "training...\n",
+      "learned model:\n",
+      " Trained RuleListClassifier \n",
+      "============================\n",
+      "IF Glucose concentration test_147.33333333333331_to_199.0 > 0.5 THEN probability of class 1: 65.9% (50.9%-79.4%)\n",
+      "ELSE IF Glucose concentration test_44.0_to_95.66666666666666 > 0.5 THEN probability of class 1: 11.1% (3.8%-21.7%)\n",
+      "ELSE IF #Pregnant_0.0_to_4.666666666666667 > 0.5 THEN probability of class 1: 22.9% (13.9%-33.3%)\n",
+      "ELSE probability of class 1: 47.7% (33.3%-62.3%)\n",
+      "===========================\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAagAAAEYCAYAAAAJeGK1AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAA4HklEQVR4nO3dd5xU1f3/8ddb2iogHUQQFxSjYEFcsSu22GLBjo0iYk/QNBPzU7+aojHGktiw0BTBRsRoNBYUoyK7VAEbIsguCAgsInXL5/fHvQvDMrvMlpk7s/t5Ph772FvOnfuZcucz99xzz5GZ4ZxzzqWbnaIOwDnnnIvHE5Rzzrm05AnKOedcWvIE5ZxzLi15gnLOOZeWPEE555xLS56gnHPOpSVPUM65jCRpoaQNkn6U9J2kkZKalStzpKR3Ja2VtEbSq5J6lCuzq6QHJH0bPtbX4Xzb1D4jV54nKOdcJjvTzJoBvYCDgd+VrZB0BPBf4BVgd6ArMAv4UFK3sExj4B2gJ3AqsCtwBLAS6JOsoCU1TNZj1yWeoJxzGc/MvgPeJEhUZf4KjDazB81srZmtMrM/AFOAO8IyVwBdgH5mNs/MSs1suZndZWavx9uXpJ6S3pK0StIySb8Pl4+U9MeYcn0l5cfML5T0W0mzgXXh9IvlHvtBSQ+F0y0kPSVpqaQCSX+U1KBmr1Rm8QTlnMt4kjoDpwHzw/ldgCOBF+IUfx44OZw+CXjDzH5McD/NgbeBNwjOyvYmOANLVH/gDKAlMA44PXxMwuRzITA2LDsSKA73cTDwU2BIFfaV8TxBOecy2b8krQUWA8uB28PlrQm+35bG2WYpUHZ9qU0FZSryM+A7M7vPzDaGZ2afVGH7h8xssZltMLNFwHSgX7juBGC9mU2R1AE4HRhmZuvMbDlwP3BxFfaV8TxBOecy2Tlm1hzoC+zL1sSzGigFOsbZpiPwfTi9soIyFdkD+LpakQYWl5sfS3BWBXAJW8+e9gQaAUslFUoqBB4H2tdg3xnHE5RzLuOZ2fsEVWJ/C+fXAR8DF8QpfiFbq+XeBk6R1DTBXS0GulWwbh2wS8z8bvFCLTf/AtA3rKLsx9YEtRjYBLQ1s5bh365m1jPBOOsET1DOubriAeBkSQeF87cAAyT9XFJzSa3CRgxHAP8XlhlDkAxekrSvpJ0ktZH0e0mnx9nHv4GOkoZJahI+7mHhupkE15RaS9oNGLajgM1sBfAeMAL4xsw+C5cvJWiBeF/YDH4nSXtJOq6qL0om8wTlnKsTwi/70cBt4fz/gFOAcwmuMy0iaGxwtJl9FZbZRNBQ4nPgLeAHYCpBVeF215bMbC1BA4szge+Ar4Djw9VjCJqxLyRILuMTDH1sGMPYcsuvABoD8wiqLF+katWRGU8+YKFzzrl05GdQzjnn0pInKOecc2nJE5Rzzrm05AnKOedcWsroDgvbtm1r2dnZUYfh6qlp06Z9b2btoo6jOvzYcVGpynGT0QkqOzubvLy8qMNw9ZSkRVHHUF1+7LioVOW48So+55xzackTlHPOubSUtAQl6WlJyyXNiVk2XtLM8G+hpJnh8uxwZMyydY8lKy7nnHOZIZnXoEYC/yToegQAM7uobFrSfcCamPJfm1mvJMbjKlFUVER+fj4bN26MOpS0k5WVRefOnWnUqFHUoThXryQtQZnZZEnZ8dZJEkGPwicka/+uavLz82nevDnZ2dkEb48DMDNWrlxJfn4+Xbt2jToc5+qVqK5BHQMsK+uwMdRV0gxJ70s6pqINJQ2VlCcpb8WKFcmPtJ7YuHEjbdq08eRUjiTatGkT2ZllvKrycusl6SFJ8yXNltQ71TE6lyxRJaj+wHMx80uBLmZ2MHAzMFbSrvE2NLPhZpZjZjnt2mXkLShpy5NTfBG/LiOBUytZfxrQPfwbCjyagpicS4mUJyhJDQm6v9/SFb2ZbTKzleH0NIIRK/dJdWzOpRszmwysqqTI2cBoC0wBWkqqV0MyuPSydM0GXpqWXyuPFcWNuicBn5vZlmcgqR2wysxKJHUj+DW4IILYXCj7ltdq9fEW3n3GDst89913DBs2jNzcXFq2bEmHDh144IEHaNy4MT/72c+YMyduLVeNbNq0iSuuuIJp06bRpk0bxo8fT4b1sNCJbYcRzw+XLS1fUNJQgrMsunTpkpLgXP0yd8kaBo/MZf3mEo7ftz2tmzau0eMlLUFJeg7oC7SVlA/cbmZPARezbfUewLHAnZKKgFLgGjOr7Fdj2qruF3siX+B1mZnRr18/BgwYwLhx4wCYNWsWy5YtY4899kjafp966ilatWrF/PnzGTduHL/97W8ZPz7RceYyi5kNB4YD5OTk+EBwrlZN+mI5Nzw7nRY7N+KFa46ocXKCJFbxmVl/M+toZo3MrHOYnDCzgWb2WLmyL5lZTzPrZWa9zezVZMXl0tOkSZNo1KgR11xzzZZlBx10EMccs217mYULF3LMMcfQu3dvevfuzUcffQTA0qVLOfbYY+nVqxf7778/H3zwASUlJQwcOJD999+fAw44gPvvv3+7/b7yyisMGDAAgPPPP5933nmHDBvEswCIzeCdw2XOpcwzUxYxZFQe2W2bMuH6o9h3t7hNCKoso/vic3XHnDlzOOSQQ3ZYrn379rz11ltkZWXx1Vdf0b9/f/Ly8hg7diynnHIKt956KyUlJaxfv56ZM2dSUFCwpWqwsLBwu8crKCjYcobWsGFDWrRowcqVK2nbtm2tPr8kmgjcIGkccBiwxsy2q95zLhlKS4173vicxycv4IR92/OP/gfTtEntpRVPUC6jFBUVccMNNzBz5kwaNGjAl19+CcChhx7K4MGDKSoq4pxzzqFXr15069aNBQsWcOONN3LGGWfw05/+NOLoqy5eVTnQCCCsiXgdOB2YD6wHBkUTqatvNhaV8MvnZ/Hap0u5/PA9uf3MHjRsULuVct4Xn0sLPXv2ZNq0aTssd//999OhQwdmzZpFXl4emzdvBuDYY49l8uTJdOrUiYEDBzJ69GhatWrFrFmz6Nu3L4899hhDhgzZ7vE6derE4sVBG4Pi4mLWrFlDmzZtavfJ1UC8qnIze6ysmjxsvXe9me1lZgeYmXdR7pJu5Y+buOSJKbw+Zyl/OGM/7jy7Z60nJ/AE5dLECSecwKZNmxg+fPiWZbNnz+aDDz7YptyaNWvo2LEjO+20E2PGjKGkpASARYsW0aFDB6666iqGDBnC9OnT+f777yktLeW8887jj3/8I9OnT99uv2eddRajRo0C4MUXX+SEE06I+r4n59La1yt+pN8jHzF3yQ88emlvhhzTLWnHjFfxubhS3apQEhMmTGDYsGHcc889ZGVlkZ2dzQMPPLBNueuuu47zzjuP0aNHc+qpp9K0aVMA3nvvPe69914aNWpEs2bNGD16NAUFBQwaNIjS0lIA/vKXv2y33yuvvJLLL7+cvffem9atW29pQeic297Ub1Zx1eg8Gu4knht6OL27tErq/pRhLZa2kZOTY+k26FqmNjP/7LPP2G+//SKNIZ3Fe30kTTOznIhCqpF0PHZcentlZgG/fmE2nVvvzMiBfejSZpdqPU5Vjhs/g3LOOVchM+PhSfP523+/5LCurXn88kNouUvN73FKhCco55xzcRWVlHLrhE95Pi+ffgd34u7zDqBJwwYp278nKOecc9v5YWMR1z87nQ+++p6fn7A3N528T8obEHmCcs45t42Cwg0MHpHL1yt+5N7zD+SCnOR1N1YZT1DOOee2mFOwhkEjc9lYVMKowX04au/oelXxBOWccw6Adz5bxo3PzaDVLo15dshh7NOheaTxeIJy8T1+XO0+3tXv77BIFMNtTJ48mWHDhjF79mzGjRvH+eefX+v7cC4TjP54IXdMnMv+nVrw5IAc2jfPijokT1AuPUQ13EaXLl0YOXIkf/vb35K2D+fSWUmp8efXP+Op/33DSft14KH+vdilcXqkBu/qyKWFqIbbyM7O5sADD2SnnfxQcPXPhs0lXPfsNJ763zcMPDKbxy8/JG2SE/gZlEsTUQ234Vx9tWLtJoaMzmN2fiG3/awHg4/uGnVI2/EE5TJKfRtuw7lkmL98LQNH5PL9j5t4/LJD+GnP3aIOKS6v13BpIarhNpyrbz7+eiXnPvIRG4tKGD/0iLRNTuAJyqWJqIbbcK4+mTAjnyue/oT2u2Yx4bqjOGiPllGHVCmv4nPxJdAsvDZFNdxGbm4u/fr1Y/Xq1bz66qvcfvvtzJ07N+nP17lUMjMeemc+97/9JUd0a8Njlx9Ci50bRR3WDvlwG7XMh9uom3y4DZepNheX8ruXP+Wl6fmc27sTd597II0bRld5VpXjJmlRSnpa0nJJc2KW3SGpQNLM8O/0mHW/kzRf0heSTklWXM45V1+s2VDEwBFTeWl6PjedtA/3XXBQpMmpqpJZxTcS+Ccwutzy+81sm7siJfUALgZ6ArsDb0vax8xKkhifc87VWYtXrWfwyFwWrlzH3y88iHN7d446pCpLWoIys8mSshMsfjYwzsw2Ad9Img/0AT5OVnxue2aW8u70M0EmV4O7+ml2fiGDR+axubiE0YMP44i92kQdUrVEca53g6TZYRVg2YD2nYDFMWXyw2UuRbKysli5cqV/GZdjZqxcuZKsrOj7JXMuEf+d+x0XPT6FrEY78fJ1R2ZscoLUt+J7FLgLsPD/fcDgqjyApKHAUAj6UXO1o3PnzuTn57NixYqoQ0k7WVlZdO6cedUjrv55+n/fcNdr8ziwc0uevCKHds2bRB1SjaQ0QZnZsrJpSU8A/w5nC4DYHkE7h8viPcZwYDgELZGSE2n906hRI7p2Tb+uTpxzO1ZSatz173mM/Gghp/TswAMXHczOjVM3NHuypLSKT1LHmNl+QFkLv4nAxZKaSOoKdAempjI255zLROs3F3P1mGmM/GghVx7dlUcuPaROJCdI4hmUpOeAvkBbSfnA7UBfSb0IqvgWAlcDmNlcSc8D84Bi4Hpvweecc5VbvnYjQ0blMadgDXee3ZMrjsiOOqRalcxWfP3jLH6qkvJ/Av6UrHicc64u+XLZWgaNyGXVus08cUUOJ+7XIeqQap13deSccxnmo/nfc/Uz08hq1IDnrz6CAzq3iDqkpPAE5ZxzGeTFafnc8tJsurVryohBfejUcueoQ0oaT1DOOZcBzIz73/qSh96dz9F7t+WRy3qza1b6d/haE56gnHMuzW0qLuGWlz5lwowCLszpzJ/6HUCjBpnTp1511f1n6FyGk3Rq2InyfEm3xFnfRdIkSTPCXlpOj/c4LjOtWV/EFU9NZcKMAn71032457wD60VyAj+Dci6tSWoAPAycTNAFWK6kiWY2L6bYH4DnzezRsOPl14HslAfrat23K9czcORU8ldt4MGLe3F2r/rVA5wnKOfSWx9gvpktAJA0jqBz5dgEZcCu4XQLYElKI3RJMePb1QwZlUdxqTHmyj4c1i1z+9SrLk9QzqW3eB0pH1auzB3AfyXdCDQFTor3QN6PZeZ4Y85SfjFuJh12zWLEoEPZq12zqEOKRP2oyHSubusPjDSzzsDpwBhJ2x3bZjbczHLMLKddu3YpD9LtmJnx5AcLuPbZ6fTYfVcmXHdkvU1O4GdQzqW7RDpSvhI4FcDMPpaUBbQFlqckQlcriktK+b9X5zFmyiJO23837r+oF1mN6kafetXlZ1DOpbdcoLukrpIaE4w8PbFcmW+BEwEk7QdkAT5uSgZZt6mYoWOmMWbKIq4+thsPX9K73icn8DMo59KamRVLugF4E2gAPB12rnwnkGdmE4FfAk9IuomgwcRA85EnM8ayHzYyeGQuny39gT+esz+XHb5n1CGlDU9QzqU5M3udoOl47LLbYqbnAUelOi5Xc59/9wODR+RSuKGIpwYcyvH7to86pLTiCco55yLwwVcruPaZ6TRtEnT4un+nutnha014gnLOuRQbn/stt06Yw97tmzFi0KF0bFF3O3ytCU9QzjmXIqWlxn1vfcHDk77m2H3a8fAlB9O8jnf4WhOeoJxzLgU2FpXw6xdn8+qsJfTvswd3nr1/velTr7o8QTnnXJKtXreZoWPyyF24mt+eui/XHNcNSVGHlfY8QTnnXBIt/H4dg0bmUlC4gX/0P5gzD9o96pAyhico55xLkmmLVnHV6GmYGWOHHEZOduuoQ8oonqCccy4JXpu9lJuen8nuLbIYMagPXds2jTqkjOMJyjnnapGZ8fjkBdz9n8/J2bMVw6/IoXXTxlGHlZGS1oRE0tOSlkuaE7PsXkmfh6N+TpDUMlyeLWmDpJnh32PJiss555KluKSUW/81h7v/8zk/O7Ajzww5zJNTDSSzjeNIwh6WY7wF7G9mBwJfAr+LWfe1mfUK/65JYlzOOVfrftxUzJWj8hj7ybdc23cvHrr4YO/wtYaSVsVnZpMlZZdb9t+Y2SnA+cnav3POpcp3azYyaGQuXy5by1/OPYD+fXxAyNoQ5V1ig4H/xMx3lTRD0vuSjqloI0lDJeVJyluxwkcUcJlD0s6SfhJ1HK52zVvyA+c8/CGLV63n6YGHenKqRZEkKEm3AsXAs+GipUAXMzsYuBkYK2nXeNv6qKAuE0k6E5gJvBHO95JUflwnl2EmfbGcCx77CAleuOYIjtvHv5NqU8oTlKSBwM+AS8vGrDGzTWa2MpyeBnwN7JPq2JxLojuAPkAhgJnNBLpGF46rqbGffMuQUXns2aYpE647iv06xv1N7Wogpc3MJZ0K/AY4zszWxyxvB6wysxJJ3YDuwIJUxuZckhWZ2Zpy3dv4oIIZqLTUuOfNz3n8/QX0/Uk7/nlJb5o18Tt2kiFpr6qk54C+QFtJ+cDtBK32mgBvhQfqlLDF3rHAnZKKgFLgGjNblazYnIvAXEmXAA0kdQd+DnwUcUyuijYWlfDL52fx2qdLufSwLvzfWT1p6B2+Jk0yW/H1j7P4qQrKvgS8lKxYnEsDNwK3ApuAsQRDuN8VaUSuSlat28xVo/OYtmg1vz99X646xjt8TTY/L3UuNc4ws1sJkhQAki4AXoguJJeob75fx6ARU1m6ZiOPXNqb0w/oGHVI9YKfmzqXGr9LcJlLM7kLV9HvkQ/5YWMxY6863JNTCvkZlHNJJOk04HSgk6SHYlbtSnCrhUtjE2ct4VfPz6Jzq50ZMehQ9mzjHb6mkico55JrCZAHnAVMi1m+FrgpkojcDpkZj7z3Nfe++QV9slsz/IpDaLmL96mXap6gnEsiM5sFzJI01syKoo7H7VhRSSl/mDCH8XmLObvX7vz1/ANp0tD71IuCJyjnUiNb0l+AHkBW2UIz6xZdSK68HzYWcf2z0/ngq++58YS9ufnkfbylXoQ8QTmXGiMI7gW8HzgeGIQ3UkorSwo3MHhkLvOX/8hfzzuQCw/dI+qQ6j0/QJxLjZ3N7B1AZrbIzO4Azog4JheaU7CGcx7+kILVGxg5qI8npzThZ1DOpcYmSTsBX0m6ASgAmkUckwPe/XwZN4ydQcudG/HitUfyk92aRx2SC/kZlHOp8QtgF4Iujg4BLgMGRBqRY8zHCxkyKo9u7Zryr+uP8uSUZvwMyrkkk9QAuMjMfgX8SHD9yUWotNT4y38+44kPvuHEfdvzUP+DaeodvqYdf0ecS7Kwl/6jo47DBTZsLuGm8TN5Y+53DDhiT247sycNdvKWeunIE5RzqTEjHKDwBWBd2UIzezm6kOqf73/cxJBReczKL+T//awHg4/K9mbkacwTlHOpkQWsBE6IWWbADhNUOI7ag0AD4EkzuztOmQsJBkU0YJaZXVILMdcp85f/yKCRU1mxdhOPXnoIp+6/W9QhuR3wBOVcCphZta47hdevHgZOBvKBXEkTzWxeTJnuBB3PHmVmqyW1r42Y65IpC1Zy9ZhpNGogxg09gl57tIw6JJcAb8XnXHrrA8w3swVmthkYB5xdrsxVwMNmthrAzJanOMa0NmFGPpc/9QltmzVmwnVHeXLKIHX6DCr7lteqtd3Cu/3+SZc2OgGLY+bzgcPKldkHQNKHBNWAd5jZG+UfSNJQYChAly5dkhJsOjEz/vHufP7+1pcc3q01j1+WQ4tdGkUdlquCOp2gnKsnGgLdgb5AZ2CypAPMrDC2kJkNB4YD5OTkWIpjTKnNxaX8fsKnvDgtn3MP7sTd5x1I44ZeYZRp/B1zLgUkdZD0lKT/hPM9JF2ZwKYFQGy/O53DZbHygYlmVmRm3wBfEiSsemnNhiIGjpjKi9Py+cWJ3bnvwoM8OWUof9ecS42RwJvA7uH8l8CwBLbLBbpL6iqpMXAxMLFcmX8RnD0hqS1Bld+CmgacifJXr+f8Rz9i6jer+NsFB3GT90ae0TxBOZcabc3seaAUwMyKgZIdbRSWu4EguX0GPG9mcyXdKemssNibwEpJ84BJwK/NbGUynkQ6m51fSL9HPuK7HzYyenAfzj+kc9QhuRpK6jUoSU8DPwOWm9n+4bLWwHggG1gIXBg2jRXBvR6nA+uBgWY2PZnxOZdC6yS1IbhPCUmHA2sS2dDMXgdeL7fstphpA24O/+qlt+Yt4+fPzaB108aMHXIY3Tt4n3p1QbLPoEYCp5Zbdgvwjpl1B94J5wFOI6g3707Q0ujRJMfmXCr9kqBqbq+wtd1o4MZoQ6obRn74DUPH5NG9QzMmXH+kJ6c6JKlnUGY2WVJ2ucVnE9aXA6OA94DfhstHh78Gp0hqKamjmS1NZozOpYKZTZN0HPATQMAXPgR8zZSUGn967TOe/vAbTu7RgQcv7sUujb1hcl2S0BmUpKMSWZagDjFJ5zugQzgd736PTnH2O1RSnqS8FStWVDME51JL0mzgN8BGM5vjyalm1m8u5ppnpvH0h98w+KiuPHbZIZ6c6qBEq/j+keCyKgnPlqp0P4aZDTezHDPLadeuXU1DcC5VzgSKgecl5Ur6laS6f7dsEqxYu4n+w6fw9mfLuP3MHtx2Zg/vjbyOqvQnh6QjgCOBdpJiL8DuSnDHenUsK6u6k9QRKOuWJZH7PZzLSGa2CPgr8New77z/B9xD9Y+jeumrZWsZNDKXlT9uZvjlOZzco8OON3IZa0dnUI0JhqVuCDSP+fsBOL+a+5zI1pFEBwCvxCy/QoHDgTV+/cnVJZL2lPQbgv709iWo8nMJ+mj+95z76EdsLCpl/NWHe3KqByo9gzKz94H3JY0MfwFWiaTnCBpEtJWUD9wO3E1QzXElsAi4MCz+OkET8/kEzcx91FFXZ0j6BGhEMB7UBWZWL2+kra4Xp+Vzy0uz6dq2KSMGHUrnVrtEHZJLgUSvKjaRNJzg3qUt25jZCRVuEazvX8GqE+OUNeD6BONxLtNcYWZfRB1EpjEzHnj7Kx585yuO3KsNj152CC129g5f64tEE9QLwGPAkyRw97tzLiDpMjN7BjhD0nbd5JvZ3yMIKyNsLi7llpdm8/KMAs4/pDN/7neA96lXzySaoIrNzG+cda7qmob/4909Wqd7FK+JNeuLuPqZPKYsWMXNJ+/DjSfs7X3q1UOJJqhXJV0HTAA2lS00s1VJicq5OsLMHg8n3zazD2PX1eBewjpt8ar1DBwxlW9Xref+iw6i38Hep159lWiCKmt19+uYZQZ0q91wnKuz/gH0TmBZvTZzcSFDRuVSVGKMufIwDu/WJuqQXIQSSlBm1jXZgThXFyXpXsI66Y053zFs/AzaNW/CuIF92Lt9s6hDchFLKEFJuiLecjMbXbvhOFfnlL+XsExN7iWsU8yMp/73DX96/TMO6tySJwfk0LZZk6jDcmkg0Sq+Q2OmswiaiU8n6JHZOVeBmt5LWNeVlBp3vjqXUR8v4tSeu3H/Rb3YubGfWLpAolV82wwLIKklwd3wzrlKSHrAzIYB/5S0Xas9Mztr+63qh3Wbivn5czN45/PlXHVMV3532n7s5H3quRjV7f53HeDXpZzbsTHh/79FGkWaWf7DRgaPymXekh+46+yeXH5EdtQhuTSU6DWoV9l6z0YDYD/g+WQF5VxdYWbTwv/vly2T1ArYw8xmRxZYhL74bi2DRkylcEMRT1yRw4n7eZ96Lr5Ez6Bif/0VA4vMLD8J8ThXJ0l6DziL4JibBiyX9KGZ1ath2v/31fdc+8w0dm7cgOevPoL9O7WIOiSXxhLqNyT89fc5QSukVsDmZAblXB3Uwsx+AM4lGDn6MOCkiGNKqedzFzNwxFR2b7kz/7r+KE9ObocSHVH3QmAqcAFB7+OfSPImss4lrmE4/tmFwL+jDiaVzIy/vfkFv3lpNkfs1YYXrj2C3VvuHHVYLgMkWsV3K3ComS0HkNQOeBt4MVmBOVfH3Am8CXxoZrmSugFfRRxT0m0qLuE3L87mlZlLuPjQPbjrnP1p1MA7fHWJSTRB7VSWnEIrSXy4eOei9fhx1dvu6vd3XCZBZvYCwagAZfMLgPNqbQdpaPW6zVw9ZhpTF67i16f8hOv67uUdvroqSTRBvSHpTeC5cP4iggEGnXMJkNSZoO+9sg5iPwB+UVcbGy1auY5BI3LJX72BBy/uxdm9OkUdkstAlSYoSXsDHczs15LOBY4OV30MPJvs4JyrQ0YAYwmu4wJcFi47ObKIkmTaotVcNTqPUjOeGXIYfbq2jjokl6F2VE33AEGfYZjZy2Z2c9gsdkK4zjmXmHZmNsLMisO/kUC7qIOqba9/upRLnphC86yGvHztkZ6cXI3sKEF1MLNPyy8Ml2UnJSLn6qaVki6T1CD8u4zgWm6dYGY8/v7XXPfsdHruvisvX3sk3dp5b+SuZnZ0DaplJeu8nahziRtMcA3q/nD+Q2BQdOHUnuKSUm6fOJdnP/mWMw7oyH0XHkRWI+/w1dXcjhJUnqSrzOyJ2IWShhDcDe+cS0DYk3md6xj2x03F3Dh2OpO+WMHVx3Xjt6fs6x2+ulqzowQ1DJgg6VK2JqQcgjFu+lVnh5J+AoyPWdQNuI3gbO0qYEW4/Pdm5i0FXZ0Q3vf0IHA4Qb+WHwM3hc3NM9J3azYyeGQuXyxby5/67c+lh+0ZdUiujqk0QZnZMuBISccD+4eLXzOzd6u7QzP7AugFIKkBUEDQ6GIQcL+Zea/Pri4aCzzM1h92FxPctnFYZBHVwPzlP3LZk5+wdmMRTw7I4fiftI86JFcHJdoX3yQz+0f4V+3kFMeJwNc+kJurB3YxszExrfieIRj8c4cknSrpC0nzJd1SSbnzJJmknFqLugJPfrCAtRuLeP6aIzw5uaSJujeIsl+RZW6QNFvS0+GQBM7VFf+RdIukbEl7SvoN8Lqk1pIqbIsd1jI8DJwG9AD6S+oRp1xz4BfAJ0mKfxv5qzfQvUNzeu7uHb665IksQUlqTHDRuKz7l0eBvQiq/5YC91Ww3VBJeZLyVqxYEa+Ic+noQuBqYBLwHnAtwQ+0aUBeJdv1Aeab2QIz20wwkvXZccrdBdwDbKzFmCtUULiBTt7hq0uyKM+gTgOmh9e5MLNlZlZiZqXAEwQH5nbMbLiZ5ZhZTrt2de4+R1dHmVnXSv66VbJpJ2BxzHx+uGwLSb0JBkB8rbIYauvHnZkFCaqVJyiXXFEmqP7EVO+FQxGU6QfMSXlEzmUYSTsBfwd+uaOytfXjbuW6zWwuLmX3FgldQnOu2hLtLLZWSWpK0AfZ1TGL/yqpF0ET3IXl1jlXXxUAe8TMdw6XlWlO0ML2vbCn8N2AiZLOMrPKqg6rbUnhBgAf08klXSQJyszWAW3KLbs8ilicS3O5QHdJXQkS08XAJWUrzWwN0LZsPhxa/lfJSk7gCcqlTtSt+JyrFxS4TNJt4XwXSXGvs8Yys2LgBoLBDj8DnjezuZLulBRJzxQFhUE7DG8k4ZItkjMo5+qhR4BS4ASC0XXXAi8Bh+5ow7BHldfLLbutgrJ9axrojiwp3MDOjRrQcpdGyd6Vq+c8Qbkqy76l0sZilVp49xm1GElGOczMekuaAWBmq8NbLTLOksIN7N4yy0fHdUnnVXzOpUZReNOtAUhqR3BGlXGCBOXVey75PEE5lxoPEfQ52V7Sn4D/AX+ONqTqKSjc6NefXEp4FZ9zKWBmz0qaRtD/pIBzzOyziMOqso1FJXz/4yY/g3Ip4QnKuRSQ1AVYD7wau8zMvo0uqqpbusZb8LnU8QTlXGq8RnD9SQS9mHcFvgB6RhlUVfk9UC6VPEE5lwJmdkDsfNh/3nURhVNtBWGC8jMolwreSMK5CJjZdDJwsMIlhRuQoEOLJlGH4uoBP4NyLgUk3RwzuxPQG1gSUTjVtqRwA+2aNaFJwwZRh+LqAU9QzqVG85jpYoJrUi9FFEu1LSnc6NefXMp4gnIuycIbdJub2a+ijqWmlhRuYL+Ou0Ydhqsn/BqUc0kkqaGZlQBHRR1LTZUNVLh7Sx8HyqWGn0HVsomNb63mlvW2j7q6birB9aaZkiYCLwDrylaa2ctRBVZVq9ZtZlNxqVfxuZTxBOVcamQBKwl6My+7H8qAjElQS8JhNjxBuVTxBOVccrUPW/DNYWtiKmPRhFQ9fg+USzVPUM4lVwOgGdsmpjKeoJyrhCco55JrqZndGXUQtcEHKnSp5q34nEuuOjOqnw9U6FLNE5RzyXVi1AHUFh+o0KWaJyjnksjMVkUdQ23xgQpdqkV2DUrSQmAtUAIUm1mOpNbAeCAbWAhcaGaro4rRORfwgQpdFKI+gzrezHqZWU44fwvwjpl1B94J551zEftujd8D5VIv6gRV3tnAqHB6FHBOdKE458psHajQuzlyqRNlM3MD/ivJgMfNbDjQwcyWhuu/AzqU30jSUGAoQJcuXVIVq4tR/e6cwLt0ykx+D5SLQpQJ6mgzK5DUHnhL0uexK83MwuRFueXDgeEAOTk5GXWjo3OZaknhRiTYrYWfQbnUiayKz8wKwv/LgQlAH2CZpI4A4f/lUcXnnNvKByp0UYgkQUlqKql52TTwU4K+yiYCA8JiA4BXoojPObetAr8HykUgqiq+DsCE8I70hsBYM3tDUi7wvKQrgUXAhRHF55yL4QMVuihEkqDMbAFwUJzlK6lDd947VxeUDVR44n7tow7F1TPp1szcOZdmfKBCFxVPUM65SvlAhS4qnqCcS3OSTpX0haT5krbrXUXSzZLmSZot6R1Je9bm/v0eKBcVT1DOpTFJDYCHgdOAHkB/ST3KFZsB5JjZgcCLwF9rM4atvUh4gnKp5QnKufTWB5hvZgvMbDMwjqBLsC3MbJKZrQ9npwCdazOAsoEKW/lAhS7FPEE5l946AYtj5vPDZRW5EvhPvBWShkrKk5S3YsWKhANYssYHKnTR8ATlXB0h6TIgB7g33nozG25mOWaW065du4Qft6Bwo1fvuUh4gnIuvRUAe8TMdw6XbUPSScCtwFlmtqlWA1i9wRtIuEh4gnIuveUC3SV1ldQYuJigS7AtJB0MPE6QnGq1/0ofqNBFyROUc2nMzIqBG4A3gc+A581srqQ7JZ0VFrsXaAa8IGmmpIkVPFyV+UCFLkpRDrfhnEuAmb0OvF5u2W0x0ycla98+UKGLkp9BOecq5Dfpuih5gnLOVaismyMfqNBFwROUc65CSwo30K65D1ToouEJyjlXoSVrvIm5i44nKOdchQoKPUG56HiCcs7FZWYsKdzgLfhcZDxBOefiWr2+iI1FPlChi44nKOdcXAWrfZgNFy1PUM65uPweKBc1T1DOubh8oEIXtZQnKEl7SJoUDlE9V9IvwuV3SCoI+xKbKen0VMfmnNtqSeEGshrt5AMVushE0RdfMfBLM5suqTkwTdJb4br7zexvEcTknCsnGKhwZx+o0EUm5QnKzJYCS8PptZI+o/IRQp1zESgo3OjXn1ykIu3NXFI2cDDwCXAUcIOkK4A8grOs1XG2GQoMBejSpUvqgnUZa3bBmmptd2Atx5FplhRuYL9920cdhqvHImskIakZ8BIwzMx+AB4F9gJ6EZxh3Rdvu+oOW+2cS9ym4hJWrPWBCl20IklQkhoRJKdnzexlADNbZmYlZlYKPAH0iSI255wPVOjSQxSt+AQ8BXxmZn+PWd4xplg/YE6qY3POBQp8oEKXBqK4BnUUcDnwqaSZ4bLfA/0l9QIMWAhcHUFszjm2jgPljSRclKJoxfc/IF671dfjLHPORaCsmyMfqNBFyXuScM5txwcqdOnAE5RzbjtlN+k6FyVPUM657QQDFXr1nouWJyjn3Da2DFTYws+gXLQ8QTnntlE2UGGnVp6gXLQ8QTnntuHDbLh04QnKObcNH6jQpQtPUM65bfgZlEsXnqCcc9vwgQpduvAE5ZzbxpLCjT5QoUsLnqCcc9vIL9zg159cWvAE5Zzbht8D5dKFJyjn0pykUyV9IWm+pFvirG8iaXy4/pNwpOpq8YEKXTqJdMj3ZJvY+NZqbnlGrcbhXHVJagA8DJwM5AO5kiaa2byYYlcCq81sb0kXA/cAF1Vnf1sHKvRujlz0/AzKufTWB5hvZgvMbDMwDji7XJmzgVHh9IvAiapmC4ct90B5LxIuDXiCci69dQIWx8znh8viljGzYmAN0Kb8A0kaKilPUt6KFSvi7qx108ZcdngXurVtVhuxO1cjnqCcqyfMbLiZ5ZhZTrt27eKW2Xe3XfnjOQf4QIUuLXiCci69FQB7xMx3DpfFLSOpIdACWJmS6JxLIk9QzqW3XKC7pK6SGgMXAxPLlZkIDAinzwfeNTNLYYzOJUWdbsXnXKYzs2JJNwBvAg2Ap81srqQ7gTwzmwg8BYyRNB9YRZDEnMt4nqCcS3Nm9jrwerllt8VMbwQuSHVcziWbV/E555xLS2mXoHZ017xzzrn6Ia0SVMxd86cBPYD+knpEG5VzzrkopFWCIrG75p1zztUDSqfWqJLOB041syHh/OXAYWZ2Q0yZocDQcPYnwBcpDzTQFvg+on0niz+nqtnTzOLf8ZrmJK0AFlWwOh0/B+kWk8dTucriSfi4ybhWfGY2HBgedRyS8swsJ+o4apM/p/qjsi+IdHzN0i0mj6dytRVPulXxJXLXvHPOuXog3RJUInfNO+ecqwfSqoqvorvmIw6rIpFXMyaBPycH6fmapVtMHk/laiWetGok4ZxzzpVJtyo+55xzDvAE5ZxzLk15gtqBHXW9JOlmSfMkzZb0jqQ9o4izKhLtTkrSeZJMUto0X61IIs9J0oXhezVX0thUx5gOEvg8N5E0Plz/iaTsmHW/C5d/IemUFMVT4fElqUTSzPCvVhpTJRDPQEkrYvY7JGbdAElfhX8Dym+bxJjuj4nnS0mFMetq9TWS9LSk5ZLmVLBekh4KY50tqXfMuqq/PmbmfxX8ETTU+BroBjQGZgE9ypU5HtglnL4WGB913DV9TmG55sBkYAqQE3XctfA+dQdmAK3C+fZRx52mr9N1wGPh9MVln2eCrsdmAU2AruHjNEhBPBUeX8CPEbw+A4F/xtm2NbAg/N8qnG6VipjKlb+RoHFZsl6jY4HewJwK1p8O/AcQcDjwSU1eHz+DqtwOu14ys0lmtj6cnUJw71Y6S7Q7qbuAe4CNqQyumhJ5TlcBD5vZagAzW57iGNNBIq/T2cCocPpF4ERJCpePM7NNZvYNMD98vKTGk+LjqyZdrZ0CvGVmq8LP2FvAqRHE1B94rhb2G5eZTSYYc6wiZwOjLTAFaCmpI9V8fTxBVa4TsDhmPj9cVpErCX49pLMdPqfwtHwPM3stlYHVQCLv0z7APpI+lDRFUm18eWSaRF6nLWXMrBhYA7RJcNtkxBOr/PGVJSkvfD/PqWEsVYnnvLD66kVJZR0LJOP1qdLjhtWfXYF3YxbX9mu0IxXFW63XJ63ug8pkki4DcoDjoo6lJiTtBPydoCqjLmlIUM3Xl+BX+GRJB5hZYZRBucRUcHztaWYFkroB70r61My+TnIorwLPmdkmSVcTnG2ekOR9Jupi4EUzK4lZFsVrVGv8DKpyCXW9JOkk4FbgLDPblKLYqmtHz6k5sD/wnqSFBPXIE9O8oUQi71M+MNHMisIqqi8JElZ9ksjrtKWMpIZAC2BlgtsmI54Kjy8zKwj/LwDeAw5OdjxmtjImhieBQxLdNlkxxbiYctV7SXiNdqSieKv3+tTmBbS69kfwq3sBwWlz2QXKnuXKHExwEbN71PHW1nMqV/490r+RRCLv06nAqHC6LUF1Q5uoY0/D1+l6tm0k8Xw43ZNtG0ksoOaNJKp9fBFcaG8S835+RSWNB2oxno4x0/2AKeF0a+CbMK5W4XTrVLxnYbl9gYWEnS8k6zUKHyubihtJnMG2jSSm1uT1ifygSfc/glYpX4YHya3hsjsJfs0BvA0sA2aGfxOjjrmmz6lc2fdI8wSV4PskgqrLecCnwMVRx5ymr1MW8AJBI4ipQLeYbW8Nt/sCOC1F8cQ9voAjw/dxVvj/yhTF8xdgbrjfScC+MdsODl+3+cCgVL1n4fwdwN3ltqv114jgDG0pUERQK3ElcA1wTbheBIPOfh3uMydm2yq/Pt7VkXPOubTk16Ccc86lJU9Qzjnn0pInKOecc2nJE5Rzzrm05AnKOedcWqpTCSqm5945kl6QtEsNHmukpPPD6Scl9aikbF9JR1ZjHwslta1ujLX1uJLukPSrOMt3l/RiON1X0r/D6bPKelWWdE5lr00V4943fP9mSNorgfIDJf2zNvYd57FvCHtktmS8R26rcj1uz1RMD+pxyv6YwtAqVO7Y6CXp9Jh1W46PFMWSLemSVO0vlepUggI2mFkvM9sf2EzQPn+L8M74KjOzIWY2r5IifQnuOUiZ6j6XqjCzJWZ2fpzlE83s7nD2HIKermvDOQRdtRxs0XfH8iFwErAo4jjqg7LjtuxvYdQB7Ui5Y6MXwb1KZetij49asYPjPRvwBJVhPgD2Dn/5fxCOhTJPUgNJ90rKDTt8vBq2jGPyz3DclbeB9mUPJOm9sq5+wrFZpkuapWB8mmyCRHhT+OvvGEntJL0U7iNX0lHhtm0k/VfBeERPEtzUth1JPyoY42VuuI92MXE8ICkP+IWkE8OzjU8VjNPSJOZhfhMunypp73D7MxWM8TND0tuSOsSUP0jSxwrGarkqLJ+tOOO+lJ25hGeNZwH3hs99L0nTY8p1j52PWd5LQeeVsyVNkNQq/AU6DLhW0qQ422zzusdZH/e5STou5pf5DEnNJXWUNFlbz7aPKf94ZjYjE74o6yJJzcLP/fTwM7xd790VvYeSfhp+jqcrqEVpFmfb9yQ9GLNtn3B5a0n/Cj+XUyQdGC6P9xnKDrdtTHDT7EXh+otijo8WkhYp6N8SSU0lLZbUKDxW3pA0TcH3075x4rxD0hhJHwJjwn1+ED636dpaa3M3cEy4/5tUwXdcRqqtu53T4Y9w7BOC7kFeIRg/pi+wDugarhsK/CGcbgLkEXQjci5BF/ANgN2BQuD8sNx7BB1VtiPoIqfssVrH3MX9q5g4xgJHh9NdgM/C6YeA28LpMwAD2sZ5HgZcGk7fRjj+TBjHI+F0VhjLPuH8aGBYOL2QrXecXwH8O5xuBVtuzh4C3BcT/yxgZ7Z2A7Q7MV2ahK9j2eMMjIlpZNnrFM5PAnqF038Gbozz/GYDx9nWO+IfiPc6xpSv6HWPjaOi5/YqcFQ43Yzgs/HLmNenAdC8ks/Uwnjvkf/V6nFbwtaeIiaE79Gu4bq2BD0PlL23Zcf4du9hWHYy0DRc/lvC463c/t4Dnginj435jP8DuD2cPgGYWclnKPbY2PI5jPO5fAU4Ppy+CHgynH6HsPsm4DDg3Thx3gFMA3YO53cBssLp7kBeON2X8NgM5+N+x0X9Plfnr671Zr6zpJnh9AfAUwRVb1Mt6CAU4KfAgQqvLxF0htmd4IP6nAU9AS+RFNtlfZnDgcllj2VmFY2LchLQQ9pygrRr+EvuWIJEiJm9Jml1BduXAuPD6WeAl2PWlS3/CfCNmX0Zzo8i6EftgXD+uZj/94fTnYHxCsZnaUzQH1aZV8xsA7AhPIPpQ/CFUVVPAoMk3UxwQG4zZpCkFkBLM3s/Ju4XdvCYibzuFT23D4G/S3oWeNnM8iXlAk9LagT8y8xmVvVJulq1wcx6lc2E78ufJR1LcCx0AjoA38Vss917KOk4gurmD8NjrzHwcQX7fA6C8Y0k7SqpJXA0cF64/F0FNR67Ev8zlOhzG09wHEwi6NvwkfC74EjghZjHaRJ/cyaGxyVAI+CfknoRJPV9Ktimou+4byoon7bqWoLa5oMOEH4A1sUuIvhV/2a5cqdTe3YCDjezbQb7q8KHurzY/qjWVViq4m3Kpv8B/N3MJkrqS/ALLV75ePOJegm4nWBMmmlmtrKaj1NVcZ+bmd0t6TWCawQfSjol/FI6luAsdqSkv5vZ6BTF6XbsUoKz5kPMrEhBr/pZsQXivYfAaoJB8fonsI+EP+/xPkMkPpDnRIJk25qg5/N3gaZAYfnvqgrEHu83EfRLeBDBd0xFMcT9jstEdfkaVEXeJLjO0QhA0j6SmhJUDVwU1t92JBhqurwpwLGSuobbtg6XryWoYijzX4KhlwnL9QonJxNezJR0GkG1VDw7AWW/fi4B/henzBdAtsLrS8DlwPsx6y+K+V/2K7IFW7u4H1Du8c6WlCWpDUGVQW4FsZW3zXMPk/KbwKPAiPKFzWwNsDrmuk/5uOOp6HWPFfe5SdrLzD41s3sIntO+CgZ2W2ZmTxCc8fXe4bN0qdQCWB4mp+OBPcsXqOA9nAIcpa3XXJtKqugs46KwzNHAmvBz+QFBciT8kfO9mf0Q7zNU7rHKH/9bmNmP4TYPElTDlZjZD8A3ki4I9yVJByX4uiw1s1KC46ZBBfuv6Dsu49THBPUkQY/W0xU0AHic4ExyAkF39PMIrudsVzVgZisI6ndfljSLrdVtrwL9wouUxwA/B3LCC5Tz2Nqa8P8IvmjnElT1fVtBjOuAPmF8JxBcpykfy0ZgEEE1wacEVSGPxRRpJWk28AuCX14QnFW8IGka8H25h5xNUA0xBbjLzJZUEFt544Bfa9um4c+G8fy3gm0GEDSsmE3QAmq75xerktc91h3Ef27DFFzMnk3QA/N/CBLwLEkzCL6oHiz/YJJ+LimfoOpwtoJGLS41niU4fj4luIb6eZwyfSn3Hoafk4HAc+H7/THbJ5MyG8NtHyPokRuCz9Ah4bZ3s/WHTrzPUKxJBFX6MyVdxPbGA5ex7ef2UuDK8PM8l8SGln8EGBBusy9bz65mAyUKGhDdRMXfcRnHezNPQ5J+NLPtWh9lCgX3VLUws/8XdSzOlSfpPYLGOHlRx+Iql5FZ1aUvSROAvUifYbCdcxnKz6Ccc86lpfp4Dco551wG8ATlnHMuLXmCcs45l5Y8QTnnnEtLnqCcc86lpf8PFOHvRS4fsEEAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
     "# train classifier (allow more iterations for better accuracy; use BigDataRuleListClassifier for large datasets)\n",
     "print('training...')\n",
-    "m = BayesianRuleListClassifier(max_iter=3000, class1label=\"diabetes\", verbose=False)\n",
-    "m.fit(X_train, y_train)\n",
-    "probs = m.predict_proba(X_test)\n",
+    "m = BayesianRuleListClassifier()\n",
+    "m.fit(X_train_brl_df.values, y_train, feature_names=X_train_brl_df.columns)\n",
+    "\n",
+    "probs = m.predict_proba(X_test_brl_df.values)\n",
     "print(\"learned model:\\n\", m)\n",
     "viz_classification_preds(probs, y_test)"
    ]
@@ -571,7 +610,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 </p>
 <p align="center">
   <img src="https://img.shields.io/badge/license-mit-blue.svg">
-  <img src="https://img.shields.io/badge/python-3.6--3.9-blue">
+  <img src="https://img.shields.io/badge/python-3.7--3.10-blue">
   <a href="https://doi.org/10.21105/joss.03192"><img src="https://joss.theoj.org/papers/10.21105/joss.03192/status.svg"></a>
   <a href="https://github.com/csinva/imodels/actions"><img src="https://github.com/csinva/imodels/workflows/tests/badge.svg"></a>
   <!--img src="https://img.shields.io/github/checks-status/csinva/imodels/master"-->

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ required_pypi = [
     'numpy',
     'pandas',
     'scipy',
-    'scikit-learn>=1.0',  # 0.23+ only works on py3.6+
+    'scikit-learn',  # 0.23+ only works on py3.6+
 ]
 
 extra_deps = [

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ required_pypi = [
     'numpy',
     'pandas',
     'scipy',
-    'scikit-learn>=0.23.0',  # 0.23+ only works on py3.6+
+    'scikit-learn>=1.0',  # 0.23+ only works on py3.6+
 ]
 
 extra_deps = [

--- a/tests/classification_binary_inputs_test.py
+++ b/tests/classification_binary_inputs_test.py
@@ -4,6 +4,8 @@ import numpy as np
 
 from imodels import OptimalRuleListClassifier
 from imodels import OptimalTreeClassifier
+from imodels.rule_set.fplasso import FPLassoClassifier
+from imodels.rule_set.fpskope import FPSkopeClassifier
 
 
 class TestClassClassificationBinary:
@@ -27,10 +29,13 @@ class TestClassClassificationBinary:
         '''Test imodels on basic binary classification task
         '''
         for model_type in [
-            OptimalRuleListClassifier, OptimalTreeClassifier
+            OptimalRuleListClassifier, OptimalTreeClassifier,
+            FPLassoClassifier, FPSkopeClassifier,
         ]:
 
             init_kwargs = {}
+            if model_type == FPSkopeClassifier:
+                init_kwargs['recall_min'] = 0.5
             m = model_type(**init_kwargs)
 
             X = self.X_classification_binary

--- a/tests/classification_binary_inputs_test.py
+++ b/tests/classification_binary_inputs_test.py
@@ -2,10 +2,8 @@ import random
 
 import numpy as np
 
-from imodels import OptimalRuleListClassifier
-from imodels import OptimalTreeClassifier
-from imodels.rule_set.fplasso import FPLassoClassifier
-from imodels.rule_set.fpskope import FPSkopeClassifier
+from imodels import (
+    OptimalRuleListClassifier, OptimalTreeClassifier, FPLassoClassifier, FPSkopeClassifier)
 
 
 class TestClassClassificationBinary:

--- a/tests/classification_continuous_inputs_test.py
+++ b/tests/classification_continuous_inputs_test.py
@@ -1,7 +1,9 @@
 import random
 import numpy as np
 
-from imodels import *  # noqa: F403
+from imodels import *
+from imodels.rule_set import fpskope
+from imodels.rule_set.fplasso import FPLasso  # noqa: F403
 
 
 class TestClassClassificationBinary:
@@ -27,13 +29,10 @@ class TestClassClassificationBinary:
 
         for model_type in [
             RuleFitClassifier, GreedyRuleListClassifier,
-            FPLassoClassifier, SkopeRulesClassifier,
-            FPSkopeClassifier, BoostedRulesClassifier,
+            SkopeRulesClassifier, BoostedRulesClassifier,
             OneRClassifier, SlipperClassifier,
-            GreedyTreeClassifier,
-            OptimalTreeClassifier,
-            C45TreeClassifier,
-            FIGSClassifier,
+            GreedyTreeClassifier, OptimalTreeClassifier,
+            C45TreeClassifier, FIGSClassifier,
         ]:  # IRFClassifier, SLIMClassifier, BayesianRuleSetClassifier,
 
             init_kwargs = {}

--- a/tests/classification_continuous_inputs_test.py
+++ b/tests/classification_continuous_inputs_test.py
@@ -1,9 +1,7 @@
 import random
 import numpy as np
 
-from imodels import *
-from imodels.rule_set import fpskope
-from imodels.rule_set.fplasso import FPLasso  # noqa: F403
+from imodels import *  # noqa: F403
 
 
 class TestClassClassificationBinary:


### PR DESCRIPTION
Now that we have the `discretization` module we no longer need to auto-discretize within BRL. Instead, we can ask users to discretize their own data using either ours or sklearn's utilities before calling BRL—this is what we do for `OptimalTreeClassifier` and it's probably cleaner long term (added a check for this in `.fit`). Fixes #81 

Also, sklearns below 1.0 don't work with `discretization` due to changes to `OneHotEncoder`, which means imodels is no longer fully compatible with Python 3.6. Since 3.6 had its EOL a month ago anyway, I switched our support to 3.7 - 3.10.