### PR TITLE
Include readme.md

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include license.md
+include readme.md


### PR DESCRIPTION
This would include `readme.md` in the sdist, which would prevent potential errors in building downstream (e.g. in conda forge)