### PR TITLE
Fixed invalid escape sequence DeprecationWarning

### DIFF
--- a/imodels/tree/gosdt/pygosdt_helper.py
+++ b/imodels/tree/gosdt/pygosdt_helper.py
@@ -406,7 +406,7 @@ class TreeClassifier:
             return (
                 "[ ${}$ {} {} ]"
                     .format(name, self.latex(node["true"]), self.latex(node["false"]))
-                    .replace("==", " \eq ").replace(">=", " \ge ").replace("<=", " \le ")
+                    .replace("==", r" \eq ").replace(">=", r" \ge ").replace("<=", r" \le ")
             )
 
     def json(self):


### PR DESCRIPTION
Fixed the following warnings:

```
imodels/imodels/tree/gosdt/pygosdt_helper.py:409: DeprecationWarning: invalid escape sequence \e
  .replace("==", " \eq ").replace(">=", " \ge ").replace("<=", " \le ")
imodels/imodels/tree/gosdt/pygosdt_helper.py:409: DeprecationWarning: invalid escape sequence \g
  .replace("==", " \eq ").replace(">=", " \ge ").replace("<=", " \le ")
imodels/imodels/tree/gosdt/pygosdt_helper.py:409: DeprecationWarning: invalid escape sequence \l
  .replace("==", " \eq ").replace(">=", " \ge ").replace("<=", " \le ")
```