### PR TITLE
Added support for regressors to [extract_sklearn_tree_from_figs].

### DIFF
--- a/imodels/tree/viz_utils.py
+++ b/imodels/tree/viz_utils.py
@@ -78,6 +78,9 @@ def extract_sklearn_tree_from_figs(figs, tree_num, n_classes, with_leaf_predicti
     # reshape value_sklearn_array to match the expected shape of (n_nodes,1,2) for values
     value_sklearns = value_sklearn_array.reshape(value_sklearn_array.shape[0], 1, value_sklearn_array.shape[1])
 
+    if n_classes == 1:
+        value_sklearns = np.ascontiguousarray(value_sklearns[:, :, 0:1])
+
     # get the max_depth
     def get_max_depth(node):
         if node is None:
@@ -120,7 +123,7 @@ def extract_sklearn_tree_from_figs(figs, tree_num, n_classes, with_leaf_predicti
     # construct sklearn object and __setstate__()
     if isinstance(figs, ClassifierMixin):
         dt = DecisionTreeClassifier(max_depth=max_depth)
-    elif isinstance(self, RegressorMixin):
+    elif isinstance(figs, RegressorMixin):
         dt = DecisionTreeRegressor(max_depth=max_depth)
 
     try:


### PR DESCRIPTION
I noticed that the function `extract_sklearn_tree_from_figs` does not support regressor targets - trees with a single class.

There was a bug / typo in the code. And shape of `value_sklearns` for classifiers is (N, 2), while for regressors it should be (N, 1). 

These two things prevented `ShadowSKDTree` from working properly.

Result:
`shadow_dtree.is_classifier()` now correctly returns False for regressors.
And it is possible to plot regressors using `ShadowSKDTree.plot()`
