### PR TITLE
init impl

### DIFF
--- a/imodels/util/arguments.py
+++ b/imodels/util/arguments.py
@@ -2,8 +2,8 @@ import numpy as np
 import pandas as pd
 from sklearn.base import ClassifierMixin
 from sklearn.utils.validation import check_X_y
-from sklearn.utils.validation import _check_sample_weight
 from sklearn.utils.multiclass import check_classification_targets
+
 
 def check_fit_arguments(model, X, y, feature_names):
     """Process arguments for fit and predict methods.
@@ -26,3 +26,5 @@ def check_fit_arguments(model, X, y, feature_names):
     return X, y, model.feature_names_
     # if sample_weight is not None:
         # sample_weight = _check_sample_weight(sample_weight, X)
+
+

--- a/tests/figs_test.py
+++ b/tests/figs_test.py
@@ -3,6 +3,7 @@ import random
 from functools import partial
 
 import numpy as np
+import pandas as pd
 from sklearn.tree import DecisionTreeRegressor
 
 from imodels import FIGSClassifier, FIGSRegressor, FIGSClassifierCV, FIGSRegressorCV
@@ -35,6 +36,25 @@ class TestFIGS:
                                      n_jobs=10,
                                      verbose=2)
         comb_model.fit(self.X, self.y_reg)
+
+    def test_categorical(self):
+        """Test FIGS with categorical data"""
+        categories = ['cat', 'dog', 'bird', 'fish']
+        categories_2 = ['bear', 'chicken', 'cow']
+
+        self.X_cat = pd.DataFrame(self.X)
+        self.X_cat['pet1'] = np.random.choice(categories, size=(self.n, 1))
+        self.X_cat['pet2'] = np.random.choice(categories_2, size=(self.n, 1))
+
+        figs_reg = FIGSRegressor()
+        figs_cls = FIGSClassifier()
+
+        figs_reg.fit(self.X_cat, self.y_reg, categorical_features=["pet1", 'pet2'])
+        figs_reg.predict(self.X_cat, categorical_features=["pet1", 'pet2'])
+
+        figs_cls.fit(self.X_cat, self.y_reg, categorical_features=["pet1", 'pet2'])
+        figs_cls.predict_proba(self.X_cat, categorical_features=["pet1", 'pet2'])
+
 
     def test_fitting(self):
         '''Test on a real (small) dataset
@@ -87,3 +107,4 @@ if __name__ == '__main__':
     t = TestFIGS()
     t.setup()
     t.test_fitting()
+    t.test_categorical()


### PR DESCRIPTION
@csinva I added support for categorical variables for FIGS.

The interface is that the user should specify the names of the columns that are categorical (we assume that X is a `pd.DataFrame` in this case).
Then I created a function `encode_categories ` in the `imodels.util.data_util` file that transforms the data matrix into one-hot encoding and saves the encoder. Then if only some of the categories are available for inference the matrix would still have the same dimension.
I also added a basic test for it.

The clalit people asked for this functionality, let me know what you think!