### PR TITLE
Fix greedy rule list classifier bug raised in #167

### DIFF
--- a/imodels/rule_list/greedy_rule_list.py
+++ b/imodels/rule_list/greedy_rule_list.py
@@ -7,10 +7,8 @@ Currently only supports binary classification.
 import math
 from copy import deepcopy
 
-import pandas as pd
 import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
-from sklearn.utils import check_X_y
 from sklearn.utils.multiclass import unique_labels
 from sklearn.utils.validation import check_array, check_is_fitted
 from sklearn.tree import DecisionTreeClassifier
@@ -101,7 +99,7 @@ class GreedyRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
                 'col': self.feature_names_[col],
                 'index_col': col,
                 'cutoff': cutoff,
-                'val': np.mean(y),  # values before splitting
+                'val': np.mean(y_left),  # will be the values before splitting in the next lower level
                 'flip': flip,
                 'val_right': np.mean(y_right),
                 'num_pts': y.size,
@@ -128,7 +126,11 @@ class GreedyRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
             for j, rule in enumerate(self.rules_):
                 if j == len(self.rules_) - 1:
                     probs[i] = rule['val']
-                elif x[rule['index_col']] >= rule['cutoff']:
+                    continue
+                regular_condition = x[rule["index_col"]] >= rule["cutoff"]
+                flipped_condition = x[rule["index_col"]] < rule["cutoff"]
+                condition = flipped_condition if rule["flip"] else regular_condition
+                if condition:
                     probs[i] = rule['val_right']
                     break
         return np.vstack((1 - probs, probs)).transpose()  # probs (n, 2)

--- a/tests/grl_test.py
+++ b/tests/grl_test.py
@@ -1,13 +1,14 @@
 import unittest
-import traceback
 
 import numpy as np
-from sklearn.metrics import accuracy_score
 from imodels.rule_list.greedy_rule_list import GreedyRuleListClassifier
 import sklearn
 from sklearn.model_selection import train_test_split
 
 class TestGRL(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.m  = GreedyRuleListClassifier()
 
     def test_integration_stability(self):
         '''Test on synthetic dataset
@@ -22,11 +23,27 @@ class TestGRL(unittest.TestCase):
              [0, 1, 1, 1, 1],
              [1, 0, 1, 1, 1]])
         y = np.array([0, 0, 0, 0, 1, 1, 1, 1])
-        m = GreedyRuleListClassifier()
-        m.fit(X, y)
-        yhat = m.predict(X)
+        self.m.fit(X, y)
+        yhat = self.m.predict(X)
         acc = np.mean(y == yhat) * 100
-        assert acc > 99, 'acc must be 100'
+        assert acc > 99 # acc must be 100
+
+    def test_linear_separability(self):
+        """Test if the model can learn a linearly separable dataset"""
+        x = np.array([0.8, 0.8, 0.3, 0.3, 0.3, 0.3]).reshape(-1, 1)
+        y = np.array([0, 0, 1, 1, 1, 1])
+        self.m.fit(x, y, verbose=True)
+        yhat = self.m.predict(x)
+        acc = np.mean(y == yhat) * 100
+        assert len(self.m.rules_) == 2  
+        assert acc == 100 # acc must be 100
+
+    def test_y_left_conditional_probability(self):
+        """Test conditional probability of y given x in the left node"""
+        x = np.array([0.8, 0.8, 0.3, 0.3, 0.3, 0.3]).reshape(-1, 1)
+        y = np.array([0, 0, 1, 1, 1, 1])
+        self.m.fit(x, y, verbose=True)
+        assert self.m.rules_[1]["val"] == 0
 
 def test_breast_cancer():
     np.random.seed(13)


### PR DESCRIPTION
# Changes
- Update the `fit_node_recursive` method of the `GreedyRuleListClassifier` to propagate the `y_left` value as initial probabilty to the next lower level when fitting the model
- Apply the flipped condition if a rule has to be flipped during fitting. 
- Remove unused imports from the touched files
- Add tests for the fixes
# Notes
This PR fixes #167 