### PR TITLE
Fixed skope rules not working with scikit-learn version 1.2 and up.

### DIFF
--- a/imodels/util/extract.py
+++ b/imodels/util/extract.py
@@ -109,7 +109,7 @@ def extract_skope(X, y, feature_names,
 
     for max_depth in max_depths:
         bagging_clf = BaggingRegressor(
-            base_estimator=DecisionTreeRegressor(
+            estimator=DecisionTreeRegressor(
                 max_depth=max_depth,
                 max_features=max_features,
                 min_samples_split=min_samples_split


### PR DESCRIPTION
The argument to BaggingClassifier `base_estimator` was renamed to `estimator` in scikit-learn version 1.2. See https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.BaggingClassifier.html

Before this change, training skope-rules does not work due to passing the wrong keyword argument.