### PR TITLE
Add support for pandas 2.2.2 by avoiding duplicating columns

### DIFF
--- a/imodels/rule_set/rule_fit.py
+++ b/imodels/rule_set/rule_fit.py
@@ -180,10 +180,11 @@ class RuleFit(BaseEstimator, TransformerMixin, RuleSet):
             Transformed data set
         """
         df = pd.DataFrame(X, columns=self.feature_placeholders)
-        print('df', df.dtypes, df.head())
+        # print('df', df.dtypes, df.head())
         X_transformed = np.zeros((X.shape[0], len(rules)))
+
         for i, r in enumerate(rules):
-            features_r_uses = [term.split(' ')[0] for term in r.split(' and ')]
+            features_r_uses = list(set(term.split(' ')[0] for term in r.split(' and ')))
             # print('r', r)
             # print('feats', df[features_r_uses])
             # print('ans', df[features_r_uses].query(r))

--- a/imodels/rule_set/rule_set.py
+++ b/imodels/rule_set/rule_set.py
@@ -29,7 +29,7 @@ class RuleSet:
 
         scores = np.zeros(X.shape[0])
         for r in selected_rules: 
-            features_r_uses = list(map(lambda x: x[0], r.agg_dict.keys()))
+            features_r_uses = list(set(map(lambda x: x[0], r.agg_dict.keys())))
             scores[df[features_r_uses].query(str(r)).index.values] += r.args[0]
 
         return scores

--- a/imodels/util/score.py
+++ b/imodels/util/score.py
@@ -36,9 +36,10 @@ def score_precision_recall(X,
 
         # XXX todo: idem without dataframe
 
+        curr_features_to_use = np.unique(curr_features)
         X_oob = pd.DataFrame(
-            (X[mask, :])[:, curr_features],
-            columns=np.array(feature_names)[curr_features]
+            (X[mask, :])[:, curr_features_to_use],
+            columns=np.array(feature_names)[curr_features_to_use]
         )
 
         if X_oob.shape[1] <= 1:  # otherwise pandas bug (cf. issue #16363)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ required_pypi = [
     'matplotlib',
     'mlxtend>=0.18.0',  # some lower versions are missing fpgrowth
     'numpy',
-    'pandas<=2.1.4',  # pandas 2.2 introduced some issues with the query function
+    'pandas<=2.2.2',  # tested with pandas 2.2.2
     'requests',  # used in c4.5
     'scipy',
     'scikit-learn>=1.2.0',  # recently updated this


### PR DESCRIPTION
query pandas dataframe with duplicated columns create error 

dtype: object' not understood

tests passed
