### PR TITLE
Fix ExtraBasicDiscretizer with current scikit-learn (#211)

### DIFF
--- a/imodels/discretization/discretizer.py
+++ b/imodels/discretization/discretizer.py
@@ -1,6 +1,7 @@
 import numbers
 
 import numpy as np
+import scipy.sparse
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
 from sklearn.base import BaseEstimator, TransformerMixin
@@ -388,14 +389,21 @@ class ExtraBasicDiscretizer(TransformerMixin):
 
         # One-hot encode the ordinal DF
         disc_onehot_np = self.encoder_.transform(disc_ordinal_df_str)
+        if scipy.sparse.issparse(disc_onehot_np):
+            # OneHotEncoder returns a sparse matrix by default, which pandas
+            # would otherwise store as a single column of sparse rows
+            disc_onehot_np = disc_onehot_np.toarray()
         disc_onehot = pd.DataFrame(
-            disc_onehot_np, columns=self.encoder_.get_feature_names_out())
+            disc_onehot_np, columns=self.encoder_.get_feature_names_out(),
+            index=X.index)
 
         # Name columns after the interval they represent (e.g. 0.1_to_0.5)
         for col, bin_edges in zip(self.dcols, self.discretizer_.bin_edges_):
             bin_edges = bin_edges.astype(str)
 
-            for ordinal_value in disc_ordinal_df_str[col].unique():
+            # every bin learned during fit, not just the ones present in X, so
+            # that transform gives the same columns whatever data it is given
+            for ordinal_value in range(len(bin_edges) - 1):
                 bin_lb = bin_edges[int(ordinal_value)]
                 bin_ub = bin_edges[int(ordinal_value) + 1]
                 interval_string = f'{bin_lb}_to_{bin_ub}'

--- a/tests/discretizer_test.py
+++ b/tests/discretizer_test.py
@@ -145,3 +145,31 @@ path_to_tests = os.path.dirname(os.path.realpath(__file__))
 #     Xd_test.head()
 
 #     assert discretizer.n_bins.sum() == (len(discretizer.dcols) * 4)
+
+
+def test_extra_basic_discretizer_onehot_shape():
+    """ExtraBasicDiscretizer should return one column per bin
+
+    Regression test for https://github.com/csinva/imodels/issues/211: newer
+    scikit-learn returns a sparse matrix from OneHotEncoder, which pandas stored
+    as a single column, so building the output frame raised a shape error.
+    """
+    from imodels.discretization import ExtraBasicDiscretizer
+
+    rng = np.random.RandomState(0)
+    X = pd.DataFrame(rng.randn(40, 3), columns=['a', 'b', 'c'])
+
+    disc = ExtraBasicDiscretizer(['a', 'b'], n_bins=3, strategy='uniform')
+    Xd = disc.fit_transform(X)
+
+    # 3 bins for each of the 2 discretized columns, plus the untouched column
+    assert Xd.shape == (40, 3 * 2 + 1)
+    assert 'c' in Xd.columns
+    onehot_cols = [col for col in Xd.columns if col != 'c']
+    # each row falls in exactly one bin per discretized column
+    assert (Xd[onehot_cols].sum(axis=1) == 2).all()
+
+    # transform on new data gives the same columns
+    Xd_test = disc.transform(X.iloc[:10])
+    assert list(Xd_test.columns) == list(Xd.columns)
+    assert Xd_test.shape == (10, Xd.shape[1])


### PR DESCRIPTION
Fixes #211

## Problem

`ExtraBasicDiscretizer.fit_transform` raised `ValueError: Shape of passed values is (n, 1), indices imply (n, n_bins)` on current scikit-learn.

`OneHotEncoder` returns a **sparse matrix** by default, which pandas stores as a single column of sparse rows rather than expanding it. (The source had a `# , sparse=False` comment hinting at this.)

## Fix

Densify the encoded output before building the frame, and keep the original index so the discretized columns align with the untouched ones during `concat`. Rather than setting `sparse_output=False`, densifying at the call site works across sklearn versions (the parameter was renamed from `sparse` in 1.2).

## A second bug found while testing

The loop that renames columns after their bin interval only iterated over bins **present in the data being transformed**:

```python
for ordinal_value in disc_ordinal_df_str[col].unique():
```

So `transform` produced different column names depending on which bins its input happened to hit — e.g. `fit_transform(X)` gave `a_-1.98_to_-0.56` while `transform(X[:10])` gave `a_0` for a bin that was empty in the subset. It now iterates over every bin learned during `fit`.

## Test plan
- [x] `tests/discretizer_test.py` was **entirely commented out**, which is why this went unnoticed — added a real test covering output shape, one bin active per row, and stable column names between `fit_transform` and `transform`
- [x] The new test fails on master and passes here (it caught the second bug too)
- [x] `pytest tests` — 48 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf