### PR TITLE
Don't modify a tree_generator passed to RuleFit (#133)

### DIFF
--- a/imodels/rule_set/rule_fit.py
+++ b/imodels/rule_set/rule_fit.py
@@ -57,6 +57,10 @@ class RuleFit(BaseEstimator, TransformerMixin, RuleSet):
     tree_generator: Optional: this object will be used as provided to generate the rules. 
                     This will override almost all the other properties above. 
                     Must be GradientBoostingRegressor(), GradientBoostingClassifier(), or RandomForestRegressor()
+                    A copy is fitted on the training data, so the object passed in is left
+                    untouched (and any previous fit of it is not reused). Note that
+                    n_estimators, max_leaf_nodes and random_state are set on that copy while
+                    the trees are grown, so tuning them on the generator has no effect.
 
     Attributes
     ----------

--- a/imodels/util/extract.py
+++ b/imodels/util/extract.py
@@ -5,6 +5,7 @@ import pandas as pd
 from mlxtend import frequent_patterns as mlx
 from sklearn.ensemble import BaggingRegressor, GradientBoostingRegressor, RandomForestRegressor, \
     GradientBoostingClassifier, RandomForestClassifier
+from sklearn.base import clone
 from sklearn.tree import DecisionTreeRegressor
 from sklearn.utils.validation import check_array
 import inspect
@@ -49,6 +50,11 @@ def extract_rulefit(X, y, feature_names,
         raise ValueError(
             "RuleFit only works with GradientBoostingClassifier(), GradientBoostingRegressor(), "
             "RandomForestRegressor() or RandomForestClassifier()")
+
+    # work on a copy: rule extraction refits the generator and overrides some of
+    # its parameters, which would otherwise modify the caller's estimator. Cloning
+    # also drops any previous fit, which would clash with warm_start below.
+    tree_generator = clone(tree_generator)
 
     # fit tree generator
     if not exp_rand_tree_size:  # simply fit with constant tree size

--- a/tests/rulefit_test.py
+++ b/tests/rulefit_test.py
@@ -3,7 +3,7 @@ from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils._testing import ignore_warnings
 
-from imodels.rule_set.rule_fit import RuleFitRegressor
+from imodels.rule_set.rule_fit import RuleFitClassifier, RuleFitRegressor
 from imodels.util.transforms import FriedScale
 
 
@@ -73,3 +73,37 @@ def test_set_params_lin_trim_quantile():
     assert (via_init.friedscale.winsorizer.trim_quantile ==
             via_set_params.friedscale.winsorizer.trim_quantile)
     assert np.allclose(via_init.predict(X), via_set_params.predict(X))
+
+
+def test_tree_generator_is_not_modified():
+    """A supplied tree_generator should be left alone, fitted or not
+
+    Regression test for https://github.com/csinva/imodels/issues/133: rule
+    extraction set warm_start/n_estimators/max_leaf_nodes on the caller's
+    estimator, which both modified it and raised
+    "n_estimators=1 must be larger or equal to estimators_.shape[0]"
+    when the estimator had already been fitted.
+    """
+    from sklearn.ensemble import GradientBoostingClassifier
+
+    X = np.random.RandomState(0).randn(60, 3)
+    y = (X[:, 0] > 0).astype(int)
+
+    # a separately tuned and already-fitted generator
+    generator = GradientBoostingClassifier(n_estimators=20, random_state=0)
+    generator.fit(X, y)
+    params_before = dict(generator.get_params())
+    n_estimators_before = len(generator.estimators_)
+
+    model = RuleFitClassifier(tree_generator=generator, random_state=0)
+    model.fit(X, y)  # used to raise ValueError
+    assert len(model.rules_) > 0
+
+    # the caller's estimator is untouched
+    assert generator.get_params() == params_before
+    assert len(generator.estimators_) == n_estimators_before
+
+    # an unfitted generator still works
+    unfitted = GradientBoostingClassifier(n_estimators=20, random_state=0)
+    RuleFitClassifier(tree_generator=unfitted, random_state=0).fit(X, y)
+    assert not hasattr(unfitted, 'estimators_')


### PR DESCRIPTION
Fixes #133

## Problem

Passing a separately tuned `GradientBoostingClassifier` as `tree_generator` failed:

```
ValueError: n_estimators=1 must be larger or equal to estimators_.shape[0]=100 when warm_start==True
```

and, as the reporter noticed, their estimator came back with *different* hyperparameters than they tuned it with.

Both come from `extract_rulefit` fitting the caller's object in place. To grow trees of varying size (Friedman 2005 Sec 3.3) it sets `warm_start=True` and walks `n_estimators` up from 1, overwriting `n_estimators`, `max_leaf_nodes` and `random_state` on the caller's estimator as it goes. If that estimator was already fitted, `warm_start` can't shrink the existing ensemble, hence the error.

Reproduced on master — the caller's estimator was mutated as:

```
max_leaf_nodes: None -> 2
n_estimators:   100  -> 1
warm_start:     False -> True
```

## Fix

`clone` the generator before fitting. The caller's object is untouched, and the clone starts unfitted so the `warm_start` loop works whether or not the original was fitted.

I also answered the reporter's other question ("which properties are overridden?") in the docstring, which previously implied the generator overrides everything, when in fact RuleFit sets `n_estimators`, `max_leaf_nodes` and `random_state` on it while growing trees.

## Scope note

This deliberately does **not** change which parameters win. Making the generator's own `n_estimators` take precedence would arguably match the docstring better, but it would change results for anyone already passing a generator — worth deciding separately.

## Test plan
- [x] `test_tree_generator_is_not_modified` — a pre-fitted, tuned generator now fits (used to raise), the caller's params and fitted state are unchanged, and an unfitted generator is still left unfitted
- [x] Test fails on master, passes here
- [x] Verified `GradientBoostingClassifier` and `RandomForestRegressor` generators both still produce rules
- [x] `pytest tests` — 490 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf