### PR TITLE
Detect an incompatible gosdt install instead of failing in fit (#219)

### DIFF
--- a/imodels/tree/gosdt/pygosdt.py
+++ b/imodels/tree/gosdt/pygosdt.py
@@ -10,12 +10,40 @@ from imodels import GreedyTreeClassifier
 from imodels.tree.gosdt.pygosdt_helper import TreeClassifier
 from imodels.util import rule
 
+# imodels uses the C++ extension API shipped by the gosdt-deprecated package.
+# The unrelated `gosdt` package on PyPI imports under the same name but exposes a
+# different API, so check for the functions actually used rather than the import
+# alone -- otherwise it fails much later with AttributeError (see issue #219).
+_GOSDT_REQUIRED_ATTRS = ("configure", "fit", "time", "iterations", "size")
+
 try:
     import gosdt
 
-    gosdt_supported = True
+    gosdt_installed = True
+    _gosdt_missing_attrs = [attr for attr in _GOSDT_REQUIRED_ATTRS
+                            if not hasattr(gosdt, attr)]
+    gosdt_supported = not _gosdt_missing_attrs
 except ImportError:
+    gosdt_installed = False
+    _gosdt_missing_attrs = list(_GOSDT_REQUIRED_ATTRS)
     gosdt_supported = False
+
+
+def _gosdt_unavailable_message():
+    if gosdt_installed:
+        return (
+            "The installed 'gosdt' package does not provide the extension API "
+            "imodels uses (missing: " + ", ".join(_gosdt_missing_attrs) + "). "
+            "imodels needs the gosdt-deprecated package: "
+            "'pip install gosdt-deprecated'. "
+            "Defaulting to Non-optimal DecisionTreeClassifier."
+        )
+    return (
+        "Should install gosdt extension. On x86_64 linux or macOS: "
+        "'pip install gosdt-deprecated'. On other platforms, see "
+        "https://github.com/keyan3/GeneralizedOptimalSparseDecisionTrees. "
+        "Defaulting to Non-optimal DecisionTreeClassifier."
+    )
 
 
 class OptimalTreeClassifier(GreedyTreeClassifier if not gosdt_supported else BaseEstimator):
@@ -101,6 +129,8 @@ class OptimalTreeClassifier(GreedyTreeClassifier if not gosdt_supported else Bas
         trains the model so that this model instance is ready for prediction
         """
         try:
+            if not gosdt_supported:
+                raise ImportError(_gosdt_unavailable_message())
             import gosdt
 
             if not isinstance(X, pd.DataFrame):
@@ -130,12 +160,7 @@ class OptimalTreeClassifier(GreedyTreeClassifier if not gosdt_supported else Bas
 
         except ImportError:
 
-            warnings.warn(
-                "Should install gosdt extension. On x86_64 linux or macOS: "
-                "'pip install gosdt-deprecated'. On other platforms, see "
-                "https://github.com/keyan3/GeneralizedOptimalSparseDecisionTrees. "
-                "Defaulting to Non-optimal DecisionTreeClassifier."
-            )
+            warnings.warn(_gosdt_unavailable_message())
 
             # dtree = DecisionTreeClassifierWithComplexity()
             # dtree.fit(X, y)

--- a/tests/classification_binary_inputs_test.py
+++ b/tests/classification_binary_inputs_test.py
@@ -42,3 +42,35 @@ def test_classification_binary_inputs(model_type, binary_data):
 
     acc = np.mean(preds == y)
     assert acc > 0.9, f"train accuracy {acc:0.2f} is too low for an easy task"
+
+
+def test_incompatible_gosdt_falls_back_with_clear_message():
+    """An incompatible gosdt install should not fail deep inside fit
+
+    Regression test for https://github.com/csinva/imodels/issues/219: the
+    unrelated `gosdt` package on PyPI imports under the same name but has a
+    different API, so `import gosdt` succeeding was not enough and fitting died
+    with `AttributeError: module 'gosdt' has no attribute 'configure'`.
+    """
+    import warnings
+
+    import numpy as np
+    from imodels import OptimalTreeClassifier
+    from imodels.tree.gosdt import pygosdt
+
+    X = np.random.RandomState(0).randn(60, 3)
+    y = (X[:, 0] > 0).astype(int)
+
+    installed, supported = pygosdt.gosdt_installed, pygosdt.gosdt_supported
+    try:
+        pygosdt.gosdt_installed, pygosdt.gosdt_supported = True, False
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            model = OptimalTreeClassifier().fit(X, y)
+            messages = [str(w.message) for w in caught]
+
+        # falls back to a working tree instead of raising
+        assert model.predict(X).shape == (60,)
+        assert any('gosdt-deprecated' in m for m in messages), messages
+    finally:
+        pygosdt.gosdt_installed, pygosdt.gosdt_supported = installed, supported


### PR DESCRIPTION
Fixes #219

## Problem

```
imodels/tree/gosdt/pygosdt.py", line 120, in fit
    gosdt.configure(json.dumps(configuration, separators=(',', ':')))
AttributeError: module 'gosdt' has no attribute 'configure'
```

The reporter did `pip install gosdt` — but imodels needs **`gosdt-deprecated`**. Those are different packages that both import as `gosdt`, with different APIs.

Availability was decided purely by whether `import gosdt` succeeded:

```python
try:
    import gosdt
    gosdt_supported = True
except ImportError:
    gosdt_supported = False
```

So with the wrong package installed, imodels believed the extension was present and only discovered otherwise deep inside `fit` — with an `AttributeError` that gives no hint about which package to install. The existing `except ImportError` fallback never triggered, because the import genuinely succeeded.

## Fix

Decide availability by the extension functions imodels actually calls (`configure`, `fit`, `time`, `iterations`, `size`). An incompatible install now falls back to the `DecisionTreeClassifier` path exactly like a missing one, and the warning distinguishes the two cases:

> The installed 'gosdt' package does not provide the extension API imodels uses (missing: configure, fit, time, iterations, size). imodels needs the gosdt-deprecated package: 'pip install gosdt-deprecated'. Defaulting to Non-optimal DecisionTreeClassifier.

versus the original "Should install gosdt extension…" when nothing is installed.

## Test plan
- [x] `test_incompatible_gosdt_falls_back_with_clear_message` — simulates the incompatible install, asserts `fit` succeeds via the fallback and the warning names `gosdt-deprecated`
- [x] Reproduced the issue end-to-end by injecting a stub `gosdt` module with the modern API: on master it raises `AttributeError`, here it fits with a clear warning
- [x] `pytest tests` — 490 passed

Note: writing the test caught a flaw in my first attempt — the message built its "missing" list by dereferencing the `gosdt` global lazily, which breaks when the module isn't importable. The list is now computed at import time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf