### PR TITLE
Let hierarchical shrinkage pass missing values to its estimator (#213)

### DIFF
--- a/imodels/tree/hierarchical_shrinkage.py
+++ b/imodels/tree/hierarchical_shrinkage.py
@@ -91,7 +91,10 @@ class HSTree(BaseEstimator):
         # remove feature_names if it exists (note: only works as keyword-arg)
         # None returned if not passed
         feature_names = kwargs.pop("feature_names", None)
-        X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
+        # missing values are left to the wrapped estimator, which handles them for
+        # sklearn decision trees and forests and raises for those that cannot
+        X, y, feature_names = check_fit_arguments(
+            self, X, y, feature_names, allow_nan=True)
         if feature_names is not None:
             self.feature_names = feature_names
         self.estimator_ = self.estimator_.fit(

--- a/imodels/util/arguments.py
+++ b/imodels/util/arguments.py
@@ -1,3 +1,5 @@
+from inspect import signature
+
 import numpy as np
 import pandas as pd
 from sklearn.base import ClassifierMixin
@@ -6,13 +8,18 @@ from sklearn.utils.multiclass import check_classification_targets
 import scipy.sparse
 
 
-def check_fit_arguments(model, X, y, feature_names, multi_output=False, is_classmixin=True):
+def check_fit_arguments(model, X, y, feature_names, multi_output=False, is_classmixin=True,
+                        allow_nan=False):
     """Process arguments for fit and predict methods.
 
     For classifiers, sets ``model.classes_`` and encodes y as integers 0..n_classes-1
     (use `decode_labels` to map predictions back onto the original labels).
     Always sets ``model.feature_names_`` and ``model.n_features_in_``, and sets the
     sklearn-standard ``model.feature_names_in_`` when X carries column names.
+
+    allow_nan: pass missing values in X through instead of rejecting them, for models
+        that delegate to an estimator able to handle them (e.g. an sklearn decision
+        tree). That estimator still raises if it cannot.
     """
     if isinstance(model, ClassifierMixin) and is_classmixin:
         model.classes_, y = np.unique(y, return_inverse=True)  # deals with str inputs
@@ -32,11 +39,25 @@ def check_fit_arguments(model, X, y, feature_names, multi_output=False, is_class
 
     if scipy.sparse.issparse(X):
         X = X.toarray()
-    X, y = check_X_y(X=X, y=y, multi_output=multi_output)
+    X, y = check_X_y(X=X, y=y, multi_output=multi_output,
+                     **_finite_check_kwarg(allow_nan))
     _, model.n_features_in_ = X.shape
     assert len(model.feature_names_) == model.n_features_in_, 'feature_names should be same size as X.shape[1]'
     y = y.astype(float)
     return X, y, model.feature_names_
+
+
+def _finite_check_kwarg(allow_nan):
+    """Spell the "allow NaN" option the way the installed sklearn expects.
+
+    force_all_finite was renamed to ensure_all_finite in sklearn 1.6.
+    """
+    if not allow_nan:
+        return {}
+    name = ("ensure_all_finite"
+            if "ensure_all_finite" in signature(check_X_y).parameters
+            else "force_all_finite")
+    return {name: "allow-nan"}
 
 
 def set_feature_names_in(model, X):

--- a/tests/shrinkage_test.py
+++ b/tests/shrinkage_test.py
@@ -155,3 +155,38 @@ def test_supported_estimators_still_shrink():
         shrunk = HSTreeRegressor(deepcopy(estimator), reg_param=50).fit(X, y)
         assert not np.allclose(unshrunk.predict(X), shrunk.predict(X)), \
             f'shrinkage had no effect on {type(estimator).__name__}'
+
+
+def test_missing_values_are_passed_to_the_estimator():
+    """Shrinkage should not reject NaN that the wrapped estimator can handle
+
+    Regression test for https://github.com/csinva/imodels/issues/213: imodels
+    validated X itself and raised "Input contains NaN" before the estimator --
+    which for sklearn trees and forests supports missing values -- saw the data.
+    """
+    import pytest
+    from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier
+    from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
+
+    rng = np.random.RandomState(0)
+    X = rng.randn(80, 3)
+    y = (X[:, 0] > 0).astype(int)
+    X_nan = X.copy()
+    X_nan[::7, 1] = np.nan
+
+    for estimator in [DecisionTreeClassifier(max_leaf_nodes=8),
+                      RandomForestClassifier(n_estimators=3, random_state=0)]:
+        model = HSTreeClassifier(estimator, reg_param=10).fit(X_nan, y)
+        assert model.predict(X_nan).shape == (80,)
+
+    model = HSTreeRegressor(
+        DecisionTreeRegressor(max_leaf_nodes=8), reg_param=10).fit(X_nan, X[:, 0])
+    assert model.predict(X_nan).shape == (80,)
+
+    # the CV variants score internally, so exercise those too
+    assert HSTreeClassifierCV().fit(X_nan, y).predict(X_nan).shape == (80,)
+
+    # estimators that can't handle missing values still say so themselves
+    with pytest.raises(ValueError, match='NaN'):
+        HSTreeClassifier(
+            GradientBoostingClassifier(n_estimators=3)).fit(X_nan, y)


### PR DESCRIPTION
Fixes #213

## Problem

`HSTreeClassifier.fit` raised `ValueError: Input contains NaN` from imodels' own `check_fit_arguments`, before the wrapped estimator ever saw the data. That's imodels' restriction, not the estimator's — sklearn decision trees and random forests have supported missing values natively since 1.3:

```python
DecisionTreeClassifier().fit(X_with_nan, y)   # fine
HSTreeClassifier(DecisionTreeClassifier()).fit(X_with_nan, y)   # ValueError
```

## Fix

`check_fit_arguments` gains an opt-in `allow_nan` flag, and `HSTree` uses it so missing values reach the estimator. Estimators that genuinely can't handle them still raise their own, clearer error:

> `ValueError: Input X contains NaN. GradientBoostingClassifier does not accept missing values encoded as NaN natively.`

The flag is opt-in specifically so this doesn't change other models — rule lists, rule sets and the rest keep rejecting NaN exactly as before.

The flag is spelled for the installed sklearn, which renamed `force_all_finite` to `ensure_all_finite` in 1.6.

## Scope note

The reporter's own example wraps a **CatBoost** model, which is still not supported — hierarchical shrinkage only works on sklearn tree structures. Since #235 that now fails with an explicit message rather than silently doing nothing. This PR fixes the NaN restriction for the estimators shrinkage *does* support.

## Test plan
- [x] `test_missing_values_are_passed_to_the_estimator` — NaN through `HSTreeClassifier`/`HSTreeRegressor` with trees and forests, plus `HSTreeClassifierCV` (which scores internally), and asserts `GradientBoostingClassifier` still raises
- [x] Test fails on master, passes here
- [x] `pytest tests` — 490 passed on **sklearn 1.5.2** (CI pinned) and **1.9.0**, covering both spellings of the parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf