### PR TITLE
Add a shared get_rules() API across rule-based models

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -19,6 +19,12 @@ The tests are organized as:
 
 ### Adding a new model
 
+If the model is rule-based, make sure `get_rules()` works on it (see
+`imodels/util/get_rules.py`): inherit from `RuleSet`/`RuleList`, or add the small
+`get_rules` method that forwards to `imodels.get_rules`. Add it to
+`tests/get_rules_test.py`, which checks the shared contract for every rule model.
+
+
 1. Export it from `imodels/__init__.py` and add it to `CLASSIFIERS` or `REGRESSORS`.
 2. Add an entry to `MODEL_KWARGS` in `tests/model_configs.py` if the defaults are slow (keep each model well under a second), and to `BINARY_INPUT_MODELS` if it needs pre-discretized features.
 

--- a/imodels/__init__.py
+++ b/imodels/__init__.py
@@ -51,6 +51,7 @@ from .tree.hierarchical_shrinkage import (
 from .tree.tao import TaoTreeClassifier, TaoTreeRegressor
 from .util.automl import AutoInterpretableClassifier, AutoInterpretableRegressor
 from .util.data_util import get_clean_dataset
+from .util.get_rules import get_rules
 from .util.distillation import DistilledRegressor
 from .util.explain_errors import explain_classification_errors
 from .clustering.stableclustering import StableClustering

--- a/imodels/algebraic/tree_gam.py
+++ b/imodels/algebraic/tree_gam.py
@@ -154,6 +154,11 @@ class TreeGAM(BaseEstimator):
 
         return self
 
+    def get_rules(self, feature_names=None):
+        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
+        from imodels.util.get_rules import get_rules
+        return get_rules(self, feature_names=feature_names)
+
     def _marginal_fit(
         self,
         X_train,

--- a/imodels/rule_list/rule_list.py
+++ b/imodels/rule_list/rule_list.py
@@ -3,6 +3,11 @@ from sklearn.utils.validation import check_is_fitted
 
 class RuleList:
 
+    def get_rules(self, feature_names=None):
+        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
+        from imodels.util.get_rules import get_rules
+        return get_rules(self, feature_names=feature_names)
+
     def _get_complexity(self):
         check_is_fitted(self, ['rules_without_feature_names_'])
         return sum([len(rule.agg_dict) for rule in self.rules_without_feature_names_]) 

--- a/imodels/rule_set/boosted_rules.py
+++ b/imodels/rule_set/boosted_rules.py
@@ -53,6 +53,12 @@ class BoostedRulesClassifier(AdaBoostClassifier):
             self.estimator = estimator
 
 
+
+    def get_rules(self, feature_names=None):
+        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
+        from imodels.util.get_rules import get_rules
+        return get_rules(self, feature_names=feature_names)
+
     def fit(self, X, y, feature_names=None, **kwargs):
         X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
         classes = self.classes_  # super().fit overwrites this with the encoded labels
@@ -97,6 +103,12 @@ class BoostedRulesRegressor(AdaBoostRegressor):
                 random_state=random_state,
             )
             self.estimator = estimator
+
+
+    def get_rules(self, feature_names=None):
+        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
+        from imodels.util.get_rules import get_rules
+        return get_rules(self, feature_names=feature_names)
 
     def fit(self, X, y, feature_names=None, **kwargs):
         X, y, feature_names = check_fit_arguments(self, X, y, feature_names)

--- a/imodels/rule_set/rule_set.py
+++ b/imodels/rule_set/rule_set.py
@@ -5,6 +5,11 @@ from sklearn.utils.validation import check_array, check_is_fitted
 
 class RuleSet:
 
+    def get_rules(self, feature_names=None):
+        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
+        from imodels.util.get_rules import get_rules
+        return get_rules(self, feature_names=feature_names)
+
     def _extract_rules(self, X, y):
         pass
 

--- a/imodels/tree/c45_tree/c45_tree.py
+++ b/imodels/tree/c45_tree/c45_tree.py
@@ -170,6 +170,11 @@ class C45TreeClassifier(BaseEstimator, ClassifierMixin):
         self.dom_ = minidom.parseString(self.tree_)
         return self
 
+    def get_rules(self, feature_names=None):
+        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
+        from imodels.util.get_rules import get_rules
+        return get_rules(self, feature_names=feature_names)
+
     def impute_nodes(self, X, y):
         """
         Returns

--- a/imodels/tree/cart_ccp.py
+++ b/imodels/tree/cart_ccp.py
@@ -77,6 +77,11 @@ class DecisionTreeCCPClassifier(ClassifierMixin, BaseEstimator):
         self._copy_fitted_attributes()
         return self
 
+    def get_rules(self, feature_names=None):
+        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
+        from imodels.util.get_rules import get_rules
+        return get_rules(self, feature_names=feature_names)
+
     def _get_complexity(self, BaseEstimator, complexity_measure):
         return compute_tree_complexity(BaseEstimator.tree_, complexity_measure)
 

--- a/imodels/tree/cart_wrapper.py
+++ b/imodels/tree/cart_wrapper.py
@@ -48,6 +48,12 @@ class GreedyTreeClassifier(DecisionTreeClassifier):
         self._set_complexity()
         return self
 
+
+    def get_rules(self, feature_names=None):
+        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
+        from imodels.util.get_rules import get_rules
+        return get_rules(self, feature_names=feature_names)
+
     def _set_complexity(self):
         """Set complexity as number of non-leaf nodes
         """
@@ -99,6 +105,12 @@ class GreedyTreeRegressor(DecisionTreeRegressor):
             self.feature_names_in_ = names_in
         self._set_complexity()
         return self
+
+
+    def get_rules(self, feature_names=None):
+        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
+        from imodels.util.get_rules import get_rules
+        return get_rules(self, feature_names=feature_names)
 
     def _set_complexity(self):
         """Set complexity as number of non-leaf nodes

--- a/imodels/tree/figs.py
+++ b/imodels/tree/figs.py
@@ -146,6 +146,12 @@ class FIGS(BaseEstimator):
         self.n_outputs = None
         self.need_to_reshape = False
 
+
+    def get_rules(self, feature_names=None):
+        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
+        from imodels.util.get_rules import get_rules
+        return get_rules(self, feature_names=feature_names)
+
     def _init_decision_function(self):
         """Sets decision function based on _estimator_type"""
         # used by sklearn GridSearchCV, BaggingClassifier
@@ -771,6 +777,12 @@ class FIGSCV(BaseEstimator):
         self.min_impurity_decrease_list = min_impurity_decrease_list
         self.cv = cv
         self.scoring = scoring
+
+
+    def get_rules(self, feature_names=None):
+        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
+        from imodels.util.get_rules import get_rules
+        return get_rules(self, feature_names=feature_names)
 
     def get_params(self, deep=True):
         # defined explicitly because __init__ takes *args/**kwargs, which sklearn's

--- a/imodels/tree/hierarchical_shrinkage.py
+++ b/imodels/tree/hierarchical_shrinkage.py
@@ -76,6 +76,12 @@ class HSTree(BaseEstimator):
             self.estimator_.max_leaf_nodes = max_leaf_nodes
             self.estimator_.random_state = random_state
 
+
+    def get_rules(self, feature_names=None):
+        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
+        from imodels.util.get_rules import get_rules
+        return get_rules(self, feature_names=feature_names)
+
     def get_params(self, deep=True):
         d = {
             "reg_param": self.reg_param,

--- a/imodels/tree/tao.py
+++ b/imodels/tree/tao.py
@@ -370,6 +370,11 @@ class TaoTree(BaseEstimator):
 
         return num_updates
 
+    def get_rules(self, feature_names=None):
+        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
+        from imodels.util.get_rules import get_rules
+        return get_rules(self, feature_names=feature_names)
+
     def predict(self, X):
         preds = self.model.predict(X)
         if hasattr(self, "classes_"):

--- a/imodels/util/get_rules.py
+++ b/imodels/util/get_rules.py
@@ -1,0 +1,310 @@
+"""Extract the rules of a fitted model as a pandas DataFrame.
+
+imodels models store their rules in whatever form suits the algorithm: a list of
+`Rule` objects, a list of dicts, or scikit-learn tree structures. `get_rules`
+presents all of them the same way, so that inspecting a model doesn't require
+knowing which family it belongs to.
+"""
+
+import numpy as np
+import pandas as pd
+
+from imodels.util.convert import tree_to_rules
+
+#: Columns every `get_rules` result has, in the order they appear.
+CORE_COLUMNS = ['rule', 'prediction']
+
+
+def get_rules(model, feature_names=None) -> pd.DataFrame:
+    """Return the rules of a fitted model as a DataFrame, one row per rule.
+
+    Parameters
+    ----------
+    model
+        A fitted imodels (or scikit-learn tree) model.
+    feature_names : list of str, optional
+        Names to use in the rule strings. Defaults to the names the model was
+        fitted with, falling back to X0, X1, ... .
+
+    Returns
+    -------
+    pandas.DataFrame
+        One row per rule, always with these columns:
+
+        - ``rule``: the condition as a string, e.g. ``"age <= 30.5 and bmi > 24.1"``.
+          The catch-all final rule of a rule list is ``"else"``.
+        - ``prediction``: what the model predicts when that rule applies. For
+          classifiers this is the predicted value/probability held in the leaf;
+          it is ``NaN`` where a model defines no per-rule prediction.
+
+        Models add their own columns on top of these, for example ``coef``,
+        ``support`` and ``importance`` for RuleFit, or ``tree`` and ``depth`` for
+        tree-based models. Those extra columns vary by model; only ``rule`` and
+        ``prediction`` are guaranteed.
+
+    Raises
+    ------
+    ValueError
+        If the model does not expose rules in any recognized form.
+
+    Examples
+    --------
+    >>> from imodels import FIGSClassifier, get_rules
+    >>> model = FIGSClassifier(max_rules=3).fit(X, y)   # doctest: +SKIP
+    >>> get_rules(model)                                # doctest: +SKIP
+                                  rule  prediction  tree
+    0                  X0 <= 0.011           0.06     0
+    1                   X0 > 0.011           0.94     0
+    """
+    for extractor in (_rules_from_wrapped_model,
+                      _rules_from_rulefit,
+                      _rules_from_rule_objects,
+                      _rules_from_rule_dicts,
+                      _rules_from_boosted_single_rules,
+                      _rules_from_c45,
+                      _rules_from_figs,
+                      _rules_from_trees):
+        rules = extractor(model, feature_names)
+        if rules is not None:
+            return _order_columns(rules)
+
+    raise ValueError(
+        f"Don't know how to extract rules from {type(model).__name__}. "
+        "get_rules supports imodels rule sets, rule lists and tree-based models; "
+        "if the model is not fitted yet, fit it first."
+    )
+
+
+def _order_columns(rules: pd.DataFrame) -> pd.DataFrame:
+    """Put the guaranteed columns first, keeping any model-specific ones after."""
+    for col in CORE_COLUMNS:
+        if col not in rules:
+            rules[col] = np.nan
+    extra = [c for c in rules.columns if c not in CORE_COLUMNS]
+    return rules[CORE_COLUMNS + extra].reset_index(drop=True)
+
+
+def _get_feature_names(model, feature_names, n_features=None):
+    """Feature names to use in rule strings, preferring what the caller passed."""
+    if feature_names is not None:
+        return list(feature_names)
+    for attr in ('feature_names_in_', 'feature_names_', 'feature_names'):
+        names = getattr(model, attr, None)
+        if names is not None and len(names) > 0:
+            return [str(name) for name in names]
+    if n_features is None:
+        n_features = getattr(model, 'n_features_in_', 0)
+    return [f'X{i}' for i in range(n_features)]
+
+
+def _rules_from_wrapped_model(model, feature_names):
+    """Models that delegate to another fitted model (shrinkage, CV wrappers)."""
+    for attr in ('figs', 'estimator_', 'model'):
+        inner = getattr(model, attr, None)
+        # an unfitted sklearn tree has no tree_; don't recurse into it
+        if inner is not None and inner is not model and _has_rules(inner):
+            names = _get_feature_names(model, feature_names,
+                                       getattr(inner, 'n_features_in_', None))
+            return get_rules(inner, feature_names=names)
+    return None
+
+
+def _is_sklearn_tree(model):
+    # C45TreeClassifier also has a tree_, but it holds XML rather than a tree
+    return hasattr(getattr(model, 'tree_', None), 'feature')
+
+
+def _has_rules(model):
+    if getattr(model, 'rules_', None) is not None:
+        return True
+    if _is_sklearn_tree(model):
+        return True
+    return any(hasattr(model, attr) for attr in ('trees_', 'estimators_'))
+
+
+def _rules_from_rulefit(model, feature_names):
+    """RuleFit already builds a rules table, with coefficients and support."""
+    if not hasattr(model, '_get_rules') or getattr(model, 'coef', None) is None:
+        return None
+    rules = model._get_rules().copy()
+    if 'rule' not in rules:
+        return None
+    # 'coef' is RuleFit's per-rule prediction: its contribution to the output
+    rules['prediction'] = rules['coef']
+    return rules
+
+
+def _rules_from_rule_objects(model, feature_names):
+    """Rule sets and Bayesian rule lists, which store imodels Rule objects."""
+    rules = getattr(model, 'rules_', None)
+    if not rules or isinstance(rules[0], dict):
+        return None
+
+    rows = []
+    for rule in rules:
+        args = getattr(rule, 'args', None)
+        rows.append({
+            'rule': str(rule),
+            'prediction': args[0] if args else np.nan,
+        })
+    return pd.DataFrame(rows)
+
+
+def _rules_from_rule_dicts(model, feature_names):
+    """Greedy rule lists (and OneR), which store one dict per list entry."""
+    rules = getattr(model, 'rules_', None)
+    if not rules or not isinstance(rules[0], dict):
+        return None
+
+    names = _get_feature_names(model, feature_names)
+    rows = []
+    for rule in rules:
+        if 'col' not in rule:  # the catch-all entry at the end of the list
+            rows.append({'rule': 'else', 'prediction': rule.get('val', np.nan),
+                         'depth': len(rows), 'num_pts': rule.get('num_pts', np.nan)})
+            continue
+        col = rule['col']
+        if feature_names is not None and 'index_col' in rule:
+            col = names[rule['index_col']]
+        comparison = '<=' if rule.get('flip') else '>'
+        rows.append({
+            'rule': f"{col} {comparison} {np.round(rule['cutoff'], 5)}",
+            'prediction': rule.get('val_right', np.nan),
+            'depth': rule.get('depth', len(rows)),
+            'num_pts': rule.get('num_pts_right', np.nan),
+        })
+    return pd.DataFrame(rows)
+
+
+def _rules_from_boosted_single_rules(model, feature_names):
+    """SLIPPER boosts base estimators that each hold a single rule."""
+    subestimators = getattr(model, 'estimators_', None)
+    if not subestimators or not hasattr(subestimators[0], 'rule'):
+        return None
+
+    names = _get_feature_names(model, feature_names)
+    weights = getattr(model, 'estimator_weights_', None)
+    rows = []
+    for i, estimator in enumerate(subestimators):
+        conditions = []
+        for condition in estimator.rule or []:
+            name = names[int(condition['feature'])]
+            # pivots are sometimes stored as strings
+            threshold = np.round(float(condition['pivot']), 5)
+            conditions.append(f"{name} {condition['operator']} {threshold}")
+        rows.append({
+            'rule': ' and '.join(conditions) if conditions else 'else',
+            # each boosted rule contributes its weight when it fires
+            'prediction': weights[i] if weights is not None else np.nan,
+        })
+    return pd.DataFrame(rows)
+
+
+def _rules_from_c45(model, feature_names):
+    """C4.5 stores its tree as an XML document rather than an sklearn tree."""
+    dom = getattr(model, 'dom_', None)
+    if dom is None or not dom.childNodes:
+        return None
+
+    # flags mark how a child splits its parent: less-than, right (>=) or equal
+    comparisons = {'l': '<', 'r': '>=', 'm': '=='}
+    rows = []
+
+    def walk(node, conditions):
+        children = [c for c in node.childNodes if c.nodeType != c.TEXT_NODE]
+        if not children:  # a leaf holds its predicted value as text
+            text = node.firstChild.nodeValue if node.firstChild else None
+            rows.append({
+                'rule': ' and '.join(conditions) if conditions else 'else',
+                'prediction': float(text) if text is not None else np.nan,
+            })
+            return
+        for child in children:
+            flag = child.getAttribute('flag')
+            threshold = child.getAttribute('feature')
+            comparison = comparisons.get(flag, flag)
+            walk(child, conditions +
+                 [f"{child.nodeName} {comparison} {threshold}"])
+
+    walk(dom.childNodes[0], [])
+    return pd.DataFrame(rows)
+
+
+def _rules_from_figs(model, feature_names):
+    """FIGS: a sum of trees, walked directly so that leaf values are its own.
+
+    The converted sklearn tree stores class counts rather than predictions, so
+    read the FIGS nodes instead. Note a FIGS prediction is the sum over trees, so
+    `prediction` here is what this tree contributes when the rule applies.
+    """
+    trees = getattr(model, 'trees_', None)
+    if not trees:
+        return None
+
+    names = _get_feature_names(model, feature_names,
+                               getattr(model, 'n_features_in_', None))
+    rows = []
+
+    def walk(node, tree_num, conditions):
+        if node is None:
+            return
+        if node.left is None and node.right is None:  # leaf
+            value = np.ravel(node.value)
+            rows.append({
+                'rule': ' and '.join(conditions) if conditions else 'else',
+                'prediction': value[-1] if value.size > 1 else value[0],
+                'tree': tree_num,
+            })
+            return
+        threshold = np.round(node.threshold, 5)
+        name = names[node.feature]
+        walk(node.left, tree_num, conditions + [f"{name} <= {threshold}"])
+        walk(node.right, tree_num, conditions + [f"{name} > {threshold}"])
+
+    for tree_num, tree in enumerate(trees):
+        walk(tree, tree_num, [])
+    return pd.DataFrame(rows)
+
+
+def _rules_from_trees(model, feature_names):
+    """Single trees, tree ensembles, and FIGS sums of trees."""
+    trees = _collect_trees(model)
+    if trees is None:
+        return None
+
+    n_features = getattr(model, 'n_features_in_', None)
+    if n_features is None and trees:
+        n_features = trees[0].n_features_in_
+    names = _get_feature_names(model, feature_names, n_features)
+
+    rows = []
+    for tree_num, tree in enumerate(trees):
+        for rule, value in tree_to_rules(tree, names, prediction_values=True):
+            rows.append({
+                'rule': rule,
+                'prediction': value[-1] if len(value) > 1 else value[0],
+                'tree': tree_num,
+            })
+    rules = pd.DataFrame(rows)
+    if len(trees) == 1:  # a single tree needs no tree index
+        rules = rules.drop(columns='tree')
+    return rules
+
+
+def _collect_trees(model):
+    """The sklearn trees making up a model, or None if it isn't tree-based."""
+    if _is_sklearn_tree(model):
+        return [model]
+
+    subestimators = getattr(model, 'estimators_', None)
+    if subestimators is not None and len(subestimators) > 0:
+        trees = []
+        for estimator in subestimators:
+            if isinstance(estimator, np.ndarray):  # gradient boosting nests them
+                estimator = estimator[0]
+            if not _is_sklearn_tree(estimator):
+                return None
+            trees.append(estimator)
+        return trees
+
+    return None

--- a/readme.md
+++ b/readme.md
@@ -187,6 +187,42 @@ All of these models follow the standard sklearn estimator API, which is checked 
 | AutoML model | [AutoInterpretableClassifier️](https://csinva.io/imodels/util/automl.html)  | [AutoInterpretableRegressor️](https://csinva.io/imodels/util/automl.html) | |
 
 
+### Inspecting the rules a model learned
+
+Every rule-based model exposes its rules the same way, as a `pandas` DataFrame with
+one row per rule, via `get_rules()`:
+
+```python
+from imodels import FIGSClassifier
+
+model = FIGSClassifier(max_rules=4).fit(X_train, y_train, feature_names=feature_names)
+model.get_rules()
+```
+
+```
+                                               rule  prediction  tree
+0                        FocalNeuroFindings2 <= 0.5       0.117     0
+1                         FocalNeuroFindings2 > 0.5       0.427     0
+2                             HighriskDiving <= 0.5      -0.008     1
+3                              HighriskDiving > 0.5       0.550     1
+4  PainNeck2 <= 0.5 and AlteredMentalStatus2 <= 0.5      -0.083     2
+5   PainNeck2 <= 0.5 and AlteredMentalStatus2 > 0.5       0.048     2
+6                                   PainNeck2 > 0.5       0.058     2
+```
+
+Two columns are always present: `rule`, the condition as a string, and `prediction`,
+what the model predicts when that rule applies. Models add their own columns on top —
+`coef`, `support` and `importance` for RuleFit, `tree` for models made of several trees.
+Where a model is additive, as FIGS is, `prediction` is that tree's contribution, so the
+contributions of the matching rules sum to the model's output.
+
+This works across rule sets, rule lists and tree-based models (RuleFit, SkopeRules,
+SLIPPER, greedy and Bayesian rule lists, FIGS, CART, C4.5, TAO, boosted rules, and
+hierarchical shrinkage, including the `CV` variants). It is also available as a
+function, `imodels.get_rules(model)`, and takes an optional `feature_names` argument
+to rename the features. Models that aren't rule-based raise a clear error.
+
+
 ### Extras
 
 <details>

--- a/tests/get_rules_test.py
+++ b/tests/get_rules_test.py
@@ -1,0 +1,193 @@
+"""Tests for the shared get_rules API (imodels.get_rules / model.get_rules())."""
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.tree import DecisionTreeClassifier
+
+import imodels
+from imodels.util.get_rules import CORE_COLUMNS
+
+N_SAMPLES = 120
+FEATURE_NAMES = ['age', 'bmi', 'bp']
+
+# one model per way of storing rules, so every extraction path is covered
+RULE_MODELS = {
+    'RuleFitClassifier': dict(max_rules=4, random_state=0),
+    'SkopeRulesClassifier': dict(random_state=0, max_depth_duplication=1),
+    'SlipperClassifier': dict(n_estimators=2),
+    'GreedyRuleListClassifier': {},
+    'OneRClassifier': {},
+    'FIGSClassifier': dict(max_rules=4),
+    'FIGSClassifierCV': dict(n_rules_list=[3], n_trees_list=[2], cv=2),
+    'BoostedRulesClassifier': dict(n_estimators=3),
+    'GreedyTreeClassifier': dict(max_leaf_nodes=4),
+    'HSTreeClassifier': {},
+    'HSTreeClassifierCV': {},
+    'C45TreeClassifier': dict(max_rules=3),
+    'TaoTreeClassifier': {},
+    'TreeGAMClassifier': dict(n_boosting_rounds=3, random_state=0),
+    'DecisionTreeCCPClassifier': dict(
+        estimator_=DecisionTreeClassifier(random_state=0), desired_complexity=3),
+}
+
+# models whose rules are defined over pre-discretized features
+BINARY_INPUT_MODELS = {'BayesianRuleListClassifier', 'FPSkopeClassifier'}
+RULE_MODELS.update({
+    'BayesianRuleListClassifier': dict(max_iter=2000, n_chains=1),
+    'FPSkopeClassifier': dict(random_state=0, recall_min=0.5,
+                              max_depth_duplication=1),
+})
+
+IDS = sorted(RULE_MODELS)
+
+
+def _data(model_name):
+    rng = np.random.RandomState(0)
+    X = pd.DataFrame(rng.randn(N_SAMPLES, 3), columns=FEATURE_NAMES)
+    y = (X['age'] + 0.8 * rng.randn(N_SAMPLES) > 0).astype(int)
+    if model_name in BINARY_INPUT_MODELS:
+        X = (X > 0).astype(int)
+    return X, y
+
+
+def _fit(model_name):
+    X, y = _data(model_name)
+    model = getattr(imodels, model_name)(**RULE_MODELS[model_name])
+    model.fit(X, y)
+    return model, X, y
+
+
+@pytest.mark.parametrize('model_name', IDS)
+def test_get_rules_contract(model_name):
+    """Every rule model returns a non-empty frame with the documented columns"""
+    model, X, y = _fit(model_name)
+
+    rules = model.get_rules()
+    assert isinstance(rules, pd.DataFrame)
+    assert len(rules) > 0, 'a fitted model should expose at least one rule'
+
+    # the guaranteed columns come first, in order
+    assert list(rules.columns[:len(CORE_COLUMNS)]) == CORE_COLUMNS
+    assert rules['rule'].map(lambda r: isinstance(r, str)).all()
+    assert (rules['rule'].str.len() > 0).all()
+    assert list(rules.index) == list(range(len(rules)))
+
+    # the module-level function gives the same thing
+    pd.testing.assert_frame_equal(rules, imodels.get_rules(model))
+
+
+@pytest.mark.parametrize('model_name', IDS)
+def test_rules_use_feature_names(model_name):
+    """Rules are written in terms of the columns the model was fitted on"""
+    model, X, y = _fit(model_name)
+    rules_text = ' '.join(model.get_rules()['rule'])
+
+    # BayesianRuleList renames features internally, so only check the others
+    if model_name != 'BayesianRuleListClassifier':
+        assert any(name in rules_text for name in FEATURE_NAMES), rules_text
+
+
+def test_feature_names_can_be_overridden():
+    """Passing feature_names renames the features in the returned rules"""
+    model, X, y = _fit('GreedyTreeClassifier')
+    renamed = model.get_rules(feature_names=['A', 'B', 'C'])
+    assert any('A' in rule for rule in renamed['rule'])
+    assert not any('age' in rule for rule in renamed['rule'])
+
+
+def test_numpy_input_falls_back_to_positional_names():
+    """Without column names, rules refer to X0, X1, ..."""
+    rng = np.random.RandomState(0)
+    X = rng.randn(N_SAMPLES, 3)
+    y = (X[:, 0] > 0).astype(int)
+
+    model = imodels.GreedyTreeClassifier(max_leaf_nodes=4).fit(X, y)
+    assert any('X0' in rule for rule in model.get_rules()['rule'])
+
+
+def test_ensembles_label_each_tree():
+    """Models made of several trees say which tree each rule came from"""
+    model, X, y = _fit('BoostedRulesClassifier')
+    rules = model.get_rules()
+    assert 'tree' in rules.columns
+    assert rules['tree'].nunique() == len(model.estimators_)
+
+    # a single tree needs no such column
+    single, _, _ = _fit('GreedyTreeClassifier')
+    assert 'tree' not in single.get_rules().columns
+
+
+def test_rulefit_keeps_its_extra_columns():
+    """Model-specific columns are preserved alongside the core ones"""
+    model, X, y = _fit('RuleFitClassifier')
+    rules = model.get_rules()
+    for col in ['coef', 'support', 'importance']:
+        assert col in rules.columns
+
+
+def test_shrinkage_rules_reflect_shrinkage():
+    """HSTree reports the shrunk predictions, not the unshrunk tree's"""
+    X, y = _data('HSTreeClassifier')
+    tree = DecisionTreeClassifier(max_leaf_nodes=4, random_state=0)
+
+    unshrunk = imodels.GreedyTreeClassifier(
+        max_leaf_nodes=4, random_state=0).fit(X, y).get_rules()
+    shrunk = imodels.HSTreeClassifier(tree, reg_param=100).fit(X, y).get_rules()
+
+    assert list(shrunk['rule']) == list(unshrunk['rule'])  # same tree structure
+    assert not np.allclose(shrunk['prediction'], unshrunk['prediction'])
+
+
+def test_unsupported_model_raises_a_clear_error():
+    """Models that aren't rule-based say so, naming themselves"""
+    with pytest.raises(ValueError, match='SLIMClassifier'):
+        imodels.get_rules(imodels.SLIMClassifier())
+
+
+def test_unfitted_model_raises_a_clear_error():
+    with pytest.raises(ValueError, match='fit it first'):
+        imodels.get_rules(imodels.FIGSClassifier())
+
+
+def _fires(X, rule):
+    """Boolean mask of the rows a rule string matches."""
+    if rule == 'else':
+        return np.ones(len(X), dtype=bool)
+    return X.eval(rule.replace(' and ', ' & ')).values
+
+
+def test_figs_rule_predictions_reproduce_the_model():
+    """For FIGS, summing the fired rules' predictions gives the model's output
+
+    FIGS is a sum of trees, so each rule's `prediction` is the contribution of
+    its tree. This pins that documented meaning.
+    """
+    X, y = _data('FIGSClassifier')
+    model = imodels.FIGSClassifier(max_rules=5).fit(X, y)
+    rules = model.get_rules()
+
+    expected = np.sum([np.asarray(model._predict_tree(tree, X.values))
+                       .reshape(len(X), -1)[:, -1] for tree in model.trees_], axis=0)
+
+    total = np.zeros(len(X))
+    for _, tree_rules in rules.groupby('tree'):
+        contribution = np.zeros(len(X))
+        for _, rule in tree_rules.iterrows():
+            contribution[_fires(X, rule['rule'])] = rule['prediction']
+        total += contribution
+
+    assert np.allclose(total, expected)
+
+
+def test_tree_rule_predictions_match_predict_proba():
+    """For a single tree, each rule's prediction is that leaf's probability"""
+    X, y = _data('GreedyTreeClassifier')
+    model = imodels.GreedyTreeClassifier(max_leaf_nodes=4, random_state=0).fit(X, y)
+    rules = model.get_rules()
+
+    predicted = np.zeros(len(X))
+    for _, rule in rules.iterrows():
+        predicted[_fires(X, rule['rule'])] = rule['prediction']
+
+    assert np.allclose(predicted, model.predict_proba(X)[:, 1])


### PR DESCRIPTION
Fixes #198
Fixes #189
Fixes #193
Fixes #119

## Why

"How do I extract the rules from X?" is the most repeated question in the tracker — asked for `HSTreeClassifierCV` (#198, whose only comment is "same question for FIGS"), `FIGSClassifier` (#189), `BoostedRulesClassifier` (#193), and rule methods generally (#119). Each family stores rules differently — `Rule` objects, dicts, sklearn trees, FIGS nodes, C4.5 XML — so answering it meant knowing the internals of the specific model.

## What

`model.get_rules()` (or `imodels.get_rules(model)`) returns a DataFrame, one row per rule:

```python
model = FIGSClassifier(max_rules=4).fit(X_train, y_train, feature_names=feature_names)
model.get_rules()
```
```
                                               rule  prediction  tree
0                        FocalNeuroFindings2 <= 0.5       0.117     0
1                         FocalNeuroFindings2 > 0.5       0.427     0
2                             HighriskDiving <= 0.5      -0.008     1
3                              HighriskDiving > 0.5       0.550     1
4  PainNeck2 <= 0.5 and AlteredMentalStatus2 <= 0.5      -0.083     2
5   PainNeck2 <= 0.5 and AlteredMentalStatus2 > 0.5       0.048     2
6                                   PainNeck2 > 0.5       0.058     2
```

Two columns are guaranteed — `rule` and `prediction` — and models keep their own extras (`coef`/`support`/`importance` for RuleFit, `tree`/`depth` for tree models). An optional `feature_names` argument renames features.

**Supported:** RuleFit, SkopeRules, FPSkope, SLIPPER, greedy and Bayesian rule lists, OneR, FIGS (+CV), CART, C4.5, TAO, CCP-pruned trees, boosted rules, TreeGAM, and hierarchical shrinkage (+CV). Non-rule models (SLIM, BART, …) and unfitted models raise an error that names the model and says what to do.

## Getting `prediction` right

My first version read FIGS through its converted sklearn tree, which stores **class counts** — so the readme example came out as `247.0, 379.0` rather than probabilities. FIGS nodes are now walked directly, and since FIGS is a *sum* of trees, `prediction` is documented as that tree's contribution. `test_figs_rule_predictions_reproduce_the_model` verifies the matching rules' contributions sum exactly to the model's additive output, and `test_tree_rule_predictions_match_predict_proba` does the equivalent for a single tree.

## Documentation

- Module and function docstrings spelling out the schema, including which columns are guaranteed
- A readme section under "Supported models" — the output shown there is **real**, generated from the readme's own `csi_pecarn_pred` example, not hand-written
- A note in `docs/contributing.md` on making a new model work with it

## Test plan
- [x] New `tests/get_rules_test.py`: the contract is checked against **17 models** covering every extraction path, plus feature-name handling, numpy fallback, per-tree labelling, RuleFit's extra columns, shrinkage being reflected, and both error cases
- [x] `pytest tests` — 532 passed on sklearn 1.5.2 (CI pinned) and on 1.9.0 / pandas 3.0.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf