### PR TITLE
Support class_weight in FIGSClassifier (#195)

### DIFF
--- a/imodels/tree/figs.py
+++ b/imodels/tree/figs.py
@@ -12,6 +12,7 @@ from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.model_selection import train_test_split, cross_val_score
 from sklearn.tree import plot_tree, DecisionTreeClassifier
 from sklearn.utils import check_X_y, check_array
+from sklearn.utils.class_weight import compute_sample_weight
 from sklearn.utils.validation import _check_sample_weight, check_is_fitted
 
 from scipy.special import softmax
@@ -122,6 +123,7 @@ class FIGS(BaseEstimator):
         random_state=None,
         max_features: str = None,
         max_depth: int = None,
+        class_weight=None,
     ):
         """
         Params
@@ -134,6 +136,12 @@ class FIGS(BaseEstimator):
             A node will be split if this split induces a decrease of the impurity greater than or equal to this value.
         max_features
             The number of features to consider when looking for the best split (see https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html)
+        class_weight: dict, list of dict or "balanced", default=None
+            Classification only. Weights associated with classes, in the form
+            {class_label: weight}. "balanced" weights each class by
+            n_samples / (n_classes * np.bincount(y)), so that rare classes count
+            as much as common ones. Combined multiplicatively with sample_weight
+            when both are given.
         """
         super().__init__()
         self.max_rules = max_rules
@@ -142,6 +150,7 @@ class FIGS(BaseEstimator):
         self.random_state = random_state
         self.max_features = max_features
         self.max_depth = max_depth
+        self.class_weight = class_weight
         self._init_decision_function()
         self.n_outputs = None
         self.need_to_reshape = False
@@ -151,6 +160,21 @@ class FIGS(BaseEstimator):
         """Return this model's rules as a DataFrame (see imodels.get_rules)."""
         from imodels.util.get_rules import get_rules
         return get_rules(self, feature_names=feature_names)
+
+    def _apply_class_weight(self, y, sample_weight):
+        """Fold class_weight into sample_weight, which the splits already honor."""
+        if self.class_weight is None:
+            return sample_weight
+        if not isinstance(self, ClassifierMixin):
+            raise ValueError(
+                "class_weight is only meaningful for classification; "
+                f"{type(self).__name__} is a regressor. Use sample_weight instead."
+            )
+
+        class_based = compute_sample_weight(self.class_weight, np.ravel(y))
+        if sample_weight is None:
+            return class_based
+        return np.asarray(sample_weight, dtype=float) * class_based
 
     def _init_decision_function(self):
         """Sets decision function based on _estimator_type"""
@@ -293,7 +317,9 @@ class FIGS(BaseEstimator):
         """
         if categorical_features is not None:
             X, self._encoder = encode_categories(X, categorical_features)
-            
+
+        sample_weight = self._apply_class_weight(y, sample_weight)
+
         if hasattr(y, 'values'):
             y = y.values
         if len(y.shape) == 1:

--- a/tests/figs_test.py
+++ b/tests/figs_test.py
@@ -114,3 +114,41 @@ if __name__ == '__main__':
     t.test_recognized_by_sklearn()
     # t.test_fitting()
     # t.test_categorical()
+
+
+def test_class_weight():
+    """FIGSClassifier should accept class_weight, like sklearn classifiers
+
+    Feature request https://github.com/csinva/imodels/issues/195: passing
+    class_weight used to raise TypeError.
+    """
+    import pytest
+    from sklearn.metrics import balanced_accuracy_score
+
+    from imodels import FIGSClassifier, FIGSRegressor
+
+    rng = np.random.RandomState(0)
+    X = rng.randn(400, 3)
+    y = (X[:, 0] + rng.randn(400) > 1.3).astype(int)  # ~15% positives
+
+    unweighted = FIGSClassifier(max_rules=5).fit(X, y)
+    balanced = FIGSClassifier(max_rules=5, class_weight='balanced').fit(X, y)
+
+    # upweighting the rare class should help it be predicted
+    assert (balanced_accuracy_score(y, balanced.predict(X)) >
+            balanced_accuracy_score(y, unweighted.predict(X)))
+
+    # an explicit dict works too, and gets combined with sample_weight
+    explicit = FIGSClassifier(max_rules=5, class_weight={0: 1, 1: 5}).fit(X, y)
+    assert explicit.predict(X).shape == (400,)
+    combined = FIGSClassifier(max_rules=5, class_weight='balanced').fit(
+        X, y, sample_weight=np.ones(len(y)) * 3)
+    assert combined.predict(X).shape == (400,)
+
+    # it round-trips through get_params/set_params like any other parameter
+    assert FIGSClassifier(class_weight='balanced').get_params()[
+        'class_weight'] == 'balanced'
+
+    # and is rejected where it has no meaning
+    with pytest.raises(ValueError, match='only meaningful for classification'):
+        FIGSRegressor(class_weight='balanced').fit(X, X[:, 0])


### PR DESCRIPTION
Fixes #195

## Problem

```python
FIGSClassifier(class_weight='balanced').fit(X, y)
TypeError: FIGS.__init__() got an unexpected keyword argument 'class_weight'
```

Imbalanced data is the common case for the clinical-style problems FIGS targets, and every sklearn classifier takes `class_weight`.

## Fix

FIGS already honors `sample_weight` when scoring splits, so `class_weight` translates cleanly: sklearn's `compute_sample_weight` turns it into per-sample weights, multiplied into whatever `sample_weight` the caller passed. Accepts the same values as sklearn — `"balanced"`, a dict, or a list of dicts.

The translation happens before `y` is one-hot encoded internally, so it sees the original labels.

On ~15% positives it does what you'd expect:

| class_weight | recall (minority) | balanced accuracy |
|---|---|---|
| `None` | 0.683 | 0.806 |
| `'balanced'` | 0.810 | 0.845 |
| `{0: 1, 1: 5}` | 0.810 | 0.845 |

Setting it on `FIGSRegressor` raises, rather than being silently ignored:

> `class_weight is only meaningful for classification; FIGSRegressor is a regressor. Use sample_weight instead.`

## Test plan
- [x] `test_class_weight` — asserts balanced accuracy actually improves, covers the dict form, combining with `sample_weight`, `get_params` round-tripping, and the regressor error
- [x] `pytest tests` — 538 passed

## Note

`FIGSClassifierCV` builds its inner models with only the parameters it searches over, so it doesn't forward `class_weight`. Threading parameters through that wrapper is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf