### PR TITLE
Add apply() for leaf membership on tree-based models (#116)

### DIFF
--- a/imodels/algebraic/tree_gam.py
+++ b/imodels/algebraic/tree_gam.py
@@ -159,6 +159,11 @@ class TreeGAM(BaseEstimator):
         from imodels.util.get_rules import get_rules
         return get_rules(self, feature_names=feature_names)
 
+    def apply(self, X):
+        """Return the leaf each sample reaches (see imodels.util.apply.apply_leaves)."""
+        from imodels.util.apply import apply_leaves
+        return apply_leaves(self, X)
+
     def _marginal_fit(
         self,
         X_train,

--- a/imodels/rule_set/boosted_rules.py
+++ b/imodels/rule_set/boosted_rules.py
@@ -59,6 +59,11 @@ class BoostedRulesClassifier(AdaBoostClassifier):
         from imodels.util.get_rules import get_rules
         return get_rules(self, feature_names=feature_names)
 
+    def apply(self, X):
+        """Return the leaf each sample reaches (see imodels.util.apply.apply_leaves)."""
+        from imodels.util.apply import apply_leaves
+        return apply_leaves(self, X)
+
     def fit(self, X, y, feature_names=None, **kwargs):
         X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
         classes = self.classes_  # super().fit overwrites this with the encoded labels
@@ -109,6 +114,11 @@ class BoostedRulesRegressor(AdaBoostRegressor):
         """Return this model's rules as a DataFrame (see imodels.get_rules)."""
         from imodels.util.get_rules import get_rules
         return get_rules(self, feature_names=feature_names)
+
+    def apply(self, X):
+        """Return the leaf each sample reaches (see imodels.util.apply.apply_leaves)."""
+        from imodels.util.apply import apply_leaves
+        return apply_leaves(self, X)
 
     def fit(self, X, y, feature_names=None, **kwargs):
         X, y, feature_names = check_fit_arguments(self, X, y, feature_names)

--- a/imodels/tree/figs.py
+++ b/imodels/tree/figs.py
@@ -152,6 +152,11 @@ class FIGS(BaseEstimator):
         from imodels.util.get_rules import get_rules
         return get_rules(self, feature_names=feature_names)
 
+    def apply(self, X):
+        """Return the leaf each sample reaches (see imodels.util.apply.apply_leaves)."""
+        from imodels.util.apply import apply_leaves
+        return apply_leaves(self, X)
+
     def _init_decision_function(self):
         """Sets decision function based on _estimator_type"""
         # used by sklearn GridSearchCV, BaggingClassifier

--- a/imodels/tree/hierarchical_shrinkage.py
+++ b/imodels/tree/hierarchical_shrinkage.py
@@ -82,6 +82,11 @@ class HSTree(BaseEstimator):
         from imodels.util.get_rules import get_rules
         return get_rules(self, feature_names=feature_names)
 
+    def apply(self, X):
+        """Return the leaf each sample reaches (see imodels.util.apply.apply_leaves)."""
+        from imodels.util.apply import apply_leaves
+        return apply_leaves(self, X)
+
     def get_params(self, deep=True):
         d = {
             "reg_param": self.reg_param,

--- a/imodels/tree/tao.py
+++ b/imodels/tree/tao.py
@@ -375,6 +375,11 @@ class TaoTree(BaseEstimator):
         from imodels.util.get_rules import get_rules
         return get_rules(self, feature_names=feature_names)
 
+    def apply(self, X):
+        """Return the leaf each sample reaches (see imodels.util.apply.apply_leaves)."""
+        from imodels.util.apply import apply_leaves
+        return apply_leaves(self, X)
+
     def predict(self, X):
         preds = self.model.predict(X)
         if hasattr(self, "classes_"):

--- a/imodels/util/apply.py
+++ b/imodels/util/apply.py
@@ -1,0 +1,90 @@
+"""Map samples to the leaves they land in, like sklearn's `tree.apply`."""
+
+import numpy as np
+from sklearn.utils.validation import check_array
+
+
+def apply_leaves(model, X) -> np.ndarray:
+    """Return the leaf each sample reaches, for a tree-based model.
+
+    Parameters
+    ----------
+    model
+        A fitted tree-based imodels model.
+    X : array-like of shape (n_samples, n_features)
+
+    Returns
+    -------
+    numpy.ndarray
+        For a model built from a single tree, shape ``(n_samples,)``: the index
+        of the leaf each sample falls in, using the same node numbering as
+        scikit-learn's ``DecisionTree.apply``.
+
+        For a model built from several trees (FIGS, boosted rules, TreeGAM),
+        shape ``(n_samples, n_trees)``, matching ``RandomForest.apply``: column
+        ``t`` holds the leaf reached in tree ``t``.
+
+    Raises
+    ------
+    ValueError
+        If the model is not tree-based, or is not fitted yet.
+
+    Examples
+    --------
+    >>> model = FIGSClassifier(max_rules=3).fit(X, y)   # doctest: +SKIP
+    >>> model.apply(X).shape                            # doctest: +SKIP
+    (100, 2)
+    """
+    trees = _sklearn_trees(model)
+    if trees is None:
+        raise ValueError(
+            f"Don't know how to get leaf membership for {type(model).__name__}. "
+            "apply is defined for tree-based models; if the model is not fitted "
+            "yet, fit it first."
+        )
+
+    X = check_array(X, ensure_all_finite=False) if _accepts_nan() else check_array(X)
+    leaves = np.column_stack([tree.apply(X) for tree in trees])
+    return leaves[:, 0] if len(trees) == 1 else leaves
+
+
+def _accepts_nan():
+    from inspect import signature
+    return 'ensure_all_finite' in signature(check_array).parameters
+
+
+def _is_sklearn_tree(estimator):
+    return hasattr(getattr(estimator, 'tree_', None), 'feature')
+
+
+def _sklearn_trees(model):
+    """The fitted sklearn trees behind a model, or None if there are none."""
+    if hasattr(model, 'trees_'):  # FIGS: a sum of trees
+        from imodels.tree.viz_utils import extract_sklearn_tree_from_figs
+        n_classes = len(getattr(model, 'classes_', [0, 1]))
+        return [extract_sklearn_tree_from_figs(model, i, n_classes)
+                for i in range(len(model.trees_))]
+
+    if _is_sklearn_tree(model):
+        return [model]
+
+    # models that wrap or delegate to another fitted model
+    for attr in ('figs', 'estimator_', 'model'):
+        inner = getattr(model, attr, None)
+        if inner is not None and inner is not model:
+            trees = _sklearn_trees(inner)
+            if trees is not None:
+                return trees
+
+    subestimators = getattr(model, 'estimators_', None)
+    if subestimators is not None and len(subestimators) > 0:
+        trees = []
+        for estimator in subestimators:
+            if isinstance(estimator, np.ndarray):  # gradient boosting nests them
+                estimator = estimator[0]
+            if not _is_sklearn_tree(estimator):
+                return None
+            trees.append(estimator)
+        return trees
+
+    return None

--- a/readme.md
+++ b/readme.md
@@ -223,6 +223,12 @@ function, `imodels.get_rules(model)`, and takes an optional `feature_names` argu
 to rename the features. Models that aren't rule-based raise a clear error.
 
 
+Tree-based models also expose `apply(X)`, which reports which leaf each sample
+falls into, using the same node numbering as scikit-learn. A single tree returns
+one index per sample; a model made of several trees (FIGS, boosted rules) returns
+one column per tree, like `RandomForest.apply`.
+
+
 ### Extras
 
 <details>

--- a/tests/apply_test.py
+++ b/tests/apply_test.py
@@ -1,0 +1,97 @@
+"""Tests for the apply() method, which reports leaf membership like sklearn's."""
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.tree import DecisionTreeClassifier
+
+import imodels
+from imodels.util.apply import apply_leaves
+
+N_SAMPLES = 300
+
+
+def _data():
+    rng = np.random.RandomState(0)
+    X = pd.DataFrame(rng.randn(N_SAMPLES, 4), columns=list('abcd'))
+    # additive structure, so FIGS grows more than one tree
+    y = ((X['a'] > 0).astype(int) + (X['c'] > 0.5).astype(int) +
+         (X['d'] < -0.5).astype(int) >= 2).astype(int)
+    return X, y
+
+
+SINGLE_TREE_MODELS = {
+    'GreedyTreeClassifier': dict(max_leaf_nodes=4, random_state=0),
+    'HSTreeClassifier': {},
+    'TaoTreeClassifier': {},
+}
+MULTI_TREE_MODELS = {
+    'FIGSClassifier': dict(max_rules=8),
+    'BoostedRulesClassifier': dict(n_estimators=3),
+    'TreeGAMClassifier': dict(n_boosting_rounds=3, random_state=0),
+}
+
+
+@pytest.mark.parametrize('model_name', sorted(SINGLE_TREE_MODELS))
+def test_apply_single_tree(model_name):
+    """A single-tree model returns one leaf index per sample"""
+    X, y = _data()
+    model = getattr(imodels, model_name)(**SINGLE_TREE_MODELS[model_name]).fit(X, y)
+
+    leaves = model.apply(X)
+    assert leaves.shape == (N_SAMPLES,)
+    assert len(np.unique(leaves)) > 1, 'every sample landed in the same leaf'
+
+    # the module-level function agrees
+    assert np.array_equal(leaves, apply_leaves(model, X))
+
+
+@pytest.mark.parametrize('model_name', sorted(MULTI_TREE_MODELS))
+def test_apply_multiple_trees(model_name):
+    """A model made of several trees returns one column per tree"""
+    X, y = _data()
+    model = getattr(imodels, model_name)(**MULTI_TREE_MODELS[model_name]).fit(X, y)
+
+    leaves = model.apply(X)
+    assert leaves.ndim == 2
+    assert leaves.shape[0] == N_SAMPLES
+    assert leaves.shape[1] > 1, 'expected this model to hold several trees'
+
+
+def test_matches_sklearn_for_a_plain_tree():
+    """GreedyTree is a CART wrapper, so its leaves match sklearn's exactly"""
+    X, y = _data()
+    ours = imodels.GreedyTreeClassifier(
+        max_leaf_nodes=4, random_state=0).fit(X, y)
+    theirs = DecisionTreeClassifier(max_leaf_nodes=4, random_state=0).fit(X, y)
+
+    assert np.array_equal(ours.apply(X), theirs.apply(X))
+
+
+def test_samples_in_a_leaf_share_a_prediction():
+    """Leaf membership lines up with what the model predicts"""
+    X, y = _data()
+    model = imodels.GreedyTreeClassifier(max_leaf_nodes=4).fit(X, y)
+
+    leaves = model.apply(X)
+    probs = model.predict_proba(X)[:, 1]
+    for leaf in np.unique(leaves):
+        assert len(np.unique(probs[leaves == leaf])) == 1
+
+
+def test_shrinkage_keeps_the_underlying_leaves():
+    """Shrinkage changes leaf values, not which leaf a sample reaches"""
+    X, y = _data()
+    tree = DecisionTreeClassifier(max_leaf_nodes=6, random_state=0)
+    shrunk = imodels.HSTreeClassifier(tree, reg_param=100).fit(X, y)
+
+    unshrunk = DecisionTreeClassifier(
+        max_leaf_nodes=6, random_state=0).fit(X, y)
+    assert np.array_equal(shrunk.apply(X), unshrunk.apply(X))
+
+
+def test_unsupported_model_raises_a_clear_error():
+    X, y = _data()
+    model = imodels.SLIMClassifier().fit(X.values, y)
+    with pytest.raises(ValueError, match='SLIMClassifier'):
+        apply_leaves(model, X.values)


### PR DESCRIPTION
Fixes #116

## Why

The request was for "an `apply` method like in sklearn so that I can get leaf node membership for any data", and the reply was that it wasn't there but could go on the roadmap. Leaf membership is what you need to group samples by the region a model puts them in — for calibration, per-leaf statistics, or as features for another model.

## What

`model.apply(X)` on the tree-based models: FIGS, hierarchical shrinkage, CART, TAO, boosted rules and TreeGAM. It follows sklearn's conventions:

- **A single tree** returns shape `(n_samples,)`, using sklearn's own node numbering. For `GreedyTreeClassifier` — a CART wrapper — the output is *identical* to `DecisionTreeClassifier.apply`, which the tests assert.
- **Several trees** (FIGS, boosted rules, TreeGAM) returns `(n_samples, n_trees)`, matching `RandomForest.apply`.

Models that aren't tree-based raise an error naming the model.

```python
model = FIGSClassifier(max_rules=8).fit(X, y)
model.apply(X).shape      # (300, 3) -- three trees
GreedyTreeClassifier(max_leaf_nodes=4).fit(X, y).apply(X).shape   # (300,)
```

## Test plan
- [x] `tests/apply_test.py`: single-tree and multi-tree shapes across 6 models, exact equality with sklearn for the CART wrapper, samples sharing a leaf sharing a prediction, shrinkage leaving leaf *membership* unchanged while changing leaf values, and the error case
- [x] `pytest tests` — 547 passed on sklearn 1.5.2 (CI pinned) and 1.9.0
- [x] Verified the multi-tree path on data with additive structure, so FIGS actually grows 3 trees rather than collapsing to 1

## Note

Rule lists and rule sets are not covered — "leaf" has no direct meaning there. `get_rules()` (#248) is the natural way to inspect those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf