### PR TITLE
Account for sample_weight in FIGS node statistics (#157)

### DIFF
--- a/imodels/tree/figs.py
+++ b/imodels/tree/figs.py
@@ -503,31 +503,39 @@ class FIGS(BaseEstimator):
         for tree_ in self.trees_:
             node_counter = iter(range(0, int(1e06)))
 
-            def _annotate_node(node: Node, X, y, is_classmixin=False):
+            def _annotate_node(node: Node, X, y, weights, is_classmixin=False):
                 #TODO: impurity decrease is correct
                 if node is None:
                     return
 
-                # TODO does not incorporate sample weights
+                # value_sklearn holds weighted class totals, matching what
+                # sklearn stores, so that importances and the converted tree
+                # both reflect sample_weight
                 #TODO: how to handdle for n_outputs> 1?
                 if is_classmixin:
-                    unique, counts = np.unique(np.argmax(y, axis = 1), return_counts=True)
-                    
                     value_sklearn = np.zeros(self.n_outputs)
-                    value_sklearn[unique] = counts
+                    classes = np.argmax(y, axis=1)
+                    for class_idx in np.unique(classes):
+                        value_sklearn[class_idx] = weights[classes == class_idx].sum()
                     value_sklearn = value_sklearn.astype(float)
-                
+
                 else:
-                    value_sklearn = np.array([X.shape[0]], dtype=float)
+                    value_sklearn = np.array([weights.sum()], dtype=float)
 
                 node.setattrs(node_id=next(node_counter),
-                              value_sklearn=value_sklearn)
+                              value_sklearn=value_sklearn,
+                              n_samples_=X.shape[0])
 
                 idxs_left = X[:, node.feature] <= node.threshold
-                _annotate_node(node.left, X[idxs_left], y[idxs_left], is_classmixin)
-                _annotate_node(node.right, X[~idxs_left], y[~idxs_left], is_classmixin)
-            
-            _annotate_node(tree_, X, y, isinstance(self, ClassifierMixin))
+                _annotate_node(node.left, X[idxs_left], y[idxs_left],
+                               weights[idxs_left], is_classmixin)
+                _annotate_node(node.right, X[~idxs_left], y[~idxs_left],
+                               weights[~idxs_left], is_classmixin)
+
+            annotate_weights = (np.ones(X.shape[0]) if sample_weight is None
+                                else np.asarray(sample_weight, dtype=float))
+            _annotate_node(tree_, X, y, annotate_weights,
+                           isinstance(self, ClassifierMixin))
 
             # now that the samples per node are known, we can start to compute the importances
             importance_data_tree = np.zeros(self.n_features)
@@ -536,7 +544,7 @@ class FIGS(BaseEstimator):
                 if node is None or node.left is None:
                     return 0.0
 
-                # TODO does not incorporate sample weights, but will if added to value_sklearn
+                # value_sklearn is weighted, so these importances are too
                 importance_data_tree[node.feature] += (
                     np.sum(node.value_sklearn) * node.impurity
                     - np.sum(node.left.value_sklearn) * node.left.impurity

--- a/imodels/tree/viz_utils.py
+++ b/imodels/tree/viz_utils.py
@@ -46,8 +46,10 @@ def _extract_arrays_from_figs_tree(figs_tree):
         tree_data.feature.append(feature)
         tree_data.threshold.append(threshold)
         tree_data.impurity.append(node.impurity)
-        tree_data.n_node_samples.append(np.sum(value_sklearn))
-        tree_data.weighted_n_node_samples.append(np.sum(value_sklearn)) # TODO add sample weights
+        # n_node_samples counts rows; the weighted version sums their weights
+        tree_data.n_node_samples.append(getattr(node, 'n_samples_',
+                                                np.sum(value_sklearn)))
+        tree_data.weighted_n_node_samples.append(np.sum(value_sklearn))
         tree_data.missing_go_to_left.append(1)
         value_sklearn_array.append(value_sklearn)
 

--- a/tests/figs_test.py
+++ b/tests/figs_test.py
@@ -152,3 +152,43 @@ def test_class_weight():
     # and is rejected where it has no meaning
     with pytest.raises(ValueError, match='only meaningful for classification'):
         FIGSRegressor(class_weight='balanced').fit(X, X[:, 0])
+
+
+def test_feature_importances_use_sample_weight():
+    """FIGS feature_importances_ should account for sample_weight
+
+    https://github.com/csinva/imodels/issues/157: the node statistics behind
+    importances (and behind the sklearn tree conversion used by plot) counted
+    rows, ignoring their weights.
+    """
+    from imodels import FIGSClassifier
+    from imodels.tree.viz_utils import extract_sklearn_tree_from_figs
+
+    rng = np.random.RandomState(0)
+    X = rng.randn(200, 3)
+    y = ((X[:, 0] > 0) | (X[:, 1] > 1)).astype(int)
+    weights = np.where(np.arange(200) % 3 == 0, 3.0, 1.0)
+
+    # weighting rows must match repeating them, which is what weights mean
+    weighted = FIGSClassifier(max_rules=5).fit(X, y, sample_weight=weights)
+    duplicated = FIGSClassifier(max_rules=5).fit(
+        np.repeat(X, weights.astype(int), axis=0),
+        np.repeat(y, weights.astype(int)))
+    assert np.allclose(weighted.feature_importances_,
+                       duplicated.feature_importances_)
+
+    # uniform weights change nothing
+    assert np.allclose(
+        FIGSClassifier(max_rules=5).fit(
+            X, y, sample_weight=np.ones(len(y))).feature_importances_,
+        FIGSClassifier(max_rules=5).fit(X, y).feature_importances_)
+
+    # and weighting actually moves them
+    assert not np.allclose(weighted.feature_importances_,
+                           FIGSClassifier(max_rules=5).fit(
+                               X, y).feature_importances_)
+
+    # the converted sklearn tree keeps raw counts and weighted totals apart
+    tree = extract_sklearn_tree_from_figs(weighted, 0, 2).tree_
+    assert tree.n_node_samples[0] == len(y)
+    assert np.isclose(tree.weighted_n_node_samples[0], weights.sum())


### PR DESCRIPTION
Fixes #157

## Problem

FIGS honors `sample_weight` when *choosing* splits, but the per-node statistics computed after fitting counted rows and ignored their weights. The source said as much:

```python
# TODO does not incorporate sample weights
# TODO does not incorporate sample weights, but will if added to value_sklearn
# TODO add sample weights        (viz_utils, weighted_n_node_samples)
```

Those statistics (`value_sklearn`) feed `feature_importances_` *and* the sklearn-tree conversion behind `plot()` and `apply()`, so a weighted fit reported unweighted numbers.

## Fix

Nodes now store **weighted** class totals in `value_sklearn` — what sklearn itself stores — and keep the raw row count separately as `n_samples_`, so `n_node_samples` stays an honest count while `weighted_n_node_samples` reflects the weights.

`feature_importances_` needed no change: it sums `value_sklearn`, so it became weight-aware automatically.

Upweighting the rows explained by feature 1 by 20× now moves importance toward it, as it should:

| | feature 0 | feature 1 |
|---|---|---|
| unweighted | 0.745 | 0.255 |
| weighted | 0.546 | 0.454 |

## Test plan

The key property: **integer weights must match duplicating rows.** They now do, exactly:

```
weighted   : [0.731 0.269 0.]
duplicated : [0.731 0.269 0.]
```

- [x] `test_feature_importances_use_sample_weight` — the duplication equivalence above, uniform weights being a no-op, weighting actually changing importances, and `n_node_samples` vs `weighted_n_node_samples` staying distinct in the converted tree
- [x] Verified `plot()` still works on a weighted fit
- [x] `pytest tests` — 549 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf