### PR TITLE
Use sample_weight in cost-complexity-pruned trees (#89)

### DIFF
--- a/imodels/tree/cart_ccp.py
+++ b/imodels/tree/cart_ccp.py
@@ -39,7 +39,8 @@ class DecisionTreeCCPClassifier(ClassifierMixin, BaseEstimator):
                 setattr(self, attr, getattr(self.estimator_, attr))
 
     def _get_alpha(self, X, y, sample_weight=None, *args, **kwargs):
-        path = self.estimator_.cost_complexity_pruning_path(X, y)
+        path = self.estimator_.cost_complexity_pruning_path(
+            X, y, sample_weight=sample_weight)
         ccp_alphas, impurities = path.ccp_alphas, path.impurities
         complexities = {}
         low = 0
@@ -50,7 +51,7 @@ class DecisionTreeCCPClassifier(ClassifierMixin, BaseEstimator):
             est_params = self.estimator_.get_params()
             est_params['ccp_alpha'] = ccp_alphas[cur]
             copied_estimator = deepcopy(self.estimator_).set_params(**est_params)
-            copied_estimator.fit(X, y)
+            copied_estimator.fit(X, y, sample_weight=sample_weight)
             if self._get_complexity(copied_estimator, self.complexity_measure) < self.desired_complexity:
                 high = cur - 1
             elif self._get_complexity(copied_estimator, self.complexity_measure) > self.desired_complexity:
@@ -73,7 +74,7 @@ class DecisionTreeCCPClassifier(ClassifierMixin, BaseEstimator):
         self._get_alpha(X, y, sample_weight, *args, **kwargs)
         params_for_fitting['ccp_alpha'] = self.alpha
         self.estimator_.set_params(**params_for_fitting)
-        self.estimator_.fit(X, y, *args, **kwargs)
+        self.estimator_.fit(X, y, *args, sample_weight=sample_weight, **kwargs)
         self._copy_fitted_attributes()
         return self
 
@@ -131,7 +132,8 @@ class DecisionTreeCCPRegressor(BaseEstimator):
                 setattr(self, attr, getattr(self.estimator_, attr))
 
     def _get_alpha(self, X, y, sample_weight=None):
-        path = self.estimator_.cost_complexity_pruning_path(X, y)
+        path = self.estimator_.cost_complexity_pruning_path(
+            X, y, sample_weight=sample_weight)
         ccp_alphas, impurities = path.ccp_alphas, path.impurities
         complexities = {}
         low = 0
@@ -142,7 +144,7 @@ class DecisionTreeCCPRegressor(BaseEstimator):
             est_params = self.estimator_.get_params()
             est_params['ccp_alpha'] = ccp_alphas[cur]
             copied_estimator = deepcopy(self.estimator_).set_params(**est_params)
-            copied_estimator.fit(X, y)
+            copied_estimator.fit(X, y, sample_weight=sample_weight)
             if self._get_complexity(copied_estimator, self.complexity_measure) < self.desired_complexity:
                 high = cur - 1
             elif self._get_complexity(copied_estimator, self.complexity_measure) > self.desired_complexity:
@@ -168,7 +170,7 @@ class DecisionTreeCCPRegressor(BaseEstimator):
         self._get_alpha(X, y, sample_weight)
         params_for_fitting['ccp_alpha'] = self.alpha
         self.estimator_.set_params(**params_for_fitting)
-        self.estimator_.fit(X, y)
+        self.estimator_.fit(X, y, sample_weight=sample_weight)
         self._copy_fitted_attributes()
         return self
 

--- a/tests/cart_ccp_test.py
+++ b/tests/cart_ccp_test.py
@@ -1,0 +1,61 @@
+"""Tests for cost-complexity-pruned trees."""
+
+import numpy as np
+from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
+
+from imodels import DecisionTreeCCPClassifier, DecisionTreeCCPRegressor
+
+
+def _data():
+    rng = np.random.RandomState(0)
+    X = rng.randn(400, 4)
+    y = ((X[:, 0] > 0) ^ (rng.rand(400) < 0.25)).astype(int)
+    return X, y
+
+
+def _classifier():
+    # a fresh inner estimator each time: two models must not share one object
+    return DecisionTreeCCPClassifier(
+        estimator_=DecisionTreeClassifier(random_state=0), desired_complexity=4)
+
+
+def test_sample_weight_is_used():
+    """sample_weight was accepted but never reached the underlying fit
+
+    https://github.com/csinva/imodels/issues/89: DecisionTreeCCP took a
+    sample_weight argument and dropped it, so weighted fits silently matched
+    unweighted ones.
+    """
+    X, y = _data()
+    weights = np.where(X[:, 1] > 0, 25.0, 1.0)
+
+    unweighted = _classifier().fit(X, y)
+    weighted = _classifier().fit(X, y, sample_weight=weights)
+
+    assert not np.allclose(unweighted.predict_proba(X), weighted.predict_proba(X))
+    # the fitted tree records the weights it was given
+    assert np.isclose(
+        weighted.estimator_.tree_.weighted_n_node_samples[0], weights.sum())
+
+    # integer weights must match repeating the rows
+    int_weights = np.where(np.arange(len(y)) % 2 == 0, 3.0, 1.0)
+    by_weight = _classifier().fit(X, y, sample_weight=int_weights)
+    by_duplication = _classifier().fit(
+        np.repeat(X, int_weights.astype(int), axis=0),
+        np.repeat(y, int_weights.astype(int)))
+    assert np.array_equal(by_weight.estimator_.tree_.feature,
+                          by_duplication.estimator_.tree_.feature)
+
+
+def test_sample_weight_is_used_by_the_regressor():
+    X, y = _data()
+    rng = np.random.RandomState(1)
+    y = X[:, 0] + 0.5 * rng.randn(len(X))
+    weights = np.where(X[:, 1] > 0, 25.0, 1.0)
+
+    def regressor():
+        return DecisionTreeCCPRegressor(
+            estimator_=DecisionTreeRegressor(random_state=0), desired_complexity=4)
+
+    assert not np.allclose(regressor().fit(X, y).predict(X),
+                           regressor().fit(X, y, sample_weight=weights).predict(X))


### PR DESCRIPTION
Fixes #89

## Problem

I audited every registered model for whether `fit` accepts `sample_weight` **and** whether it actually changes the fit. `DecisionTreeCCPClassifier` / `DecisionTreeCCPRegressor` accept it and then drop it:

```python
def fit(self, X, y, sample_weight=None, *args, **kwargs):
    self._get_alpha(X, y, sample_weight, *args, **kwargs)
    ...
    self.estimator_.fit(X, y, *args, **kwargs)   # sample_weight never passed
```

`_get_alpha` took the argument but ignored it too, so neither `cost_complexity_pruning_path` nor the candidate fits used to search for alpha saw the weights. A weighted fit silently produced the unweighted model — the same class of silent no-op as #200.

## Fix

Pass `sample_weight` through all three places: the pruning path, the candidate fits during the alpha search, and the final fit.

Verified against the defining property — **integer weights give the same tree as repeating rows** — and the fitted tree's `weighted_n_node_samples[0]` now equals `sum(weights)` (4912) instead of the row count (400).

## Rest of the audit

Every other model either doesn't accept `sample_weight` or genuinely uses it. Two apparent failures were my own test harness reusing one estimator *object* across two models (see the note below), and one was an easy dataset where weights don't change the chosen splits.

## Test plan
- [x] New `tests/cart_ccp_test.py`: weighted vs unweighted predictions differ, `weighted_n_node_samples` matches `sum(weights)`, integer weights match duplication, and the regressor path too
- [x] Tests fail on master, pass here
- [x] `pytest tests` — 551 passed

## Related bug found while doing this

`HSTree`'s default estimator is a **mutable default argument**, so every `HSTreeClassifier()` shares one `DecisionTreeClassifier` instance and fitting one model changes another already-fitted one. That's separate from this PR; I'll open it on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf