### PR TITLE
Stop HSTree models from sharing one default estimator

### DIFF
--- a/imodels/tree/hierarchical_shrinkage.py
+++ b/imodels/tree/hierarchical_shrinkage.py
@@ -35,7 +35,7 @@ def _values_are_normalized(tree):
 class HSTree(BaseEstimator):
     def __init__(
         self,
-        estimator_: BaseEstimator = DecisionTreeClassifier(max_leaf_nodes=20),
+        estimator_: BaseEstimator = None,
         reg_param: float = 1,
         shrinkage_scheme_: str = "node_based",
         max_leaf_nodes: int = None,
@@ -67,6 +67,10 @@ class HSTree(BaseEstimator):
         """
         super().__init__()
         self.reg_param = reg_param
+        # constructed here rather than defaulted in the signature, so that
+        # separate models don't share (and refit) one estimator object
+        if estimator_ is None:
+            estimator_ = DecisionTreeClassifier(max_leaf_nodes=20)
         self.estimator_ = estimator_
         self.shrinkage_scheme_ = shrinkage_scheme_
         self.random_state = random_state
@@ -333,12 +337,16 @@ class HSTree(BaseEstimator):
 class HSTreeRegressor(RegressorMixin, HSTree):
     def __init__(
         self,
-        estimator_: BaseEstimator = DecisionTreeRegressor(max_leaf_nodes=20),
+        estimator_: BaseEstimator = None,
         reg_param: float = 1,
         shrinkage_scheme_: str = "node_based",
         max_leaf_nodes: int = None,
         random_state: int = None,
     ):
+        if estimator_ is None:
+            estimator_ = DecisionTreeRegressor(max_leaf_nodes=20)
+        if estimator_ is None:
+            estimator_ = DecisionTreeClassifier(max_leaf_nodes=20)
         super().__init__(
             estimator_=estimator_,
             reg_param=reg_param,
@@ -351,7 +359,7 @@ class HSTreeRegressor(RegressorMixin, HSTree):
 class HSTreeClassifier(ClassifierMixin, HSTree):
     def __init__(
         self,
-        estimator_: BaseEstimator = DecisionTreeClassifier(max_leaf_nodes=20),
+        estimator_: BaseEstimator = None,
         reg_param: float = 1,
         shrinkage_scheme_: str = "node_based",
         max_leaf_nodes: int = None,

--- a/tests/shrinkage_test.py
+++ b/tests/shrinkage_test.py
@@ -216,3 +216,30 @@ def test_missing_values_are_passed_to_the_estimator():
     with pytest.raises(ValueError, match='NaN'):
         HSTreeClassifier(
             GradientBoostingClassifier(n_estimators=3)).fit(X_nan, y)
+
+
+def test_models_do_not_share_a_default_estimator():
+    """Two HSTree models must not wrap the same estimator object
+
+    The default estimator used to be built once in the signature, so every
+    HSTreeClassifier() shared it and fitting one model refit another's tree.
+    """
+    assert HSTreeClassifier().estimator_ is not HSTreeClassifier().estimator_
+    assert HSTreeRegressor().estimator_ is not HSTreeRegressor().estimator_
+
+    rng = np.random.RandomState(0)
+    X = rng.randn(300, 4)
+    y = (X[:, 0] + 1.5 * rng.randn(300) > 0).astype(int)
+
+    first = HSTreeClassifier().fit(X, y)
+    before = first.predict_proba(X).copy()
+
+    HSTreeClassifier().fit(X, np.roll(y, 7))  # a different model, different labels
+
+    assert np.allclose(before, first.predict_proba(X)), \
+        'fitting one model changed another already-fitted model'
+
+    # the defaults themselves still behave
+    assert HSTreeRegressor().fit(X, X[:, 0]).predict(X).shape == (300,)
+    assert isinstance(HSTreeRegressor().estimator_, DecisionTreeRegressor)
+    assert isinstance(HSTreeClassifier().estimator_, DecisionTreeClassifier)


### PR DESCRIPTION
## Problem

The default estimator was built in the function signature:

```python
def __init__(self, estimator_: BaseEstimator = DecisionTreeClassifier(max_leaf_nodes=20), ...):
```

Python evaluates that **once, at import**. So every `HSTreeClassifier()` wraps the *same* `DecisionTreeClassifier` instance:

```python
>>> HSTreeClassifier().estimator_ is HSTreeClassifier().estimator_
True
```

Fitting one model therefore refits the tree belonging to another, already-fitted model, silently changing its predictions:

```python
a = HSTreeClassifier().fit(X, y)
before = a.predict_proba(X)
b = HSTreeClassifier().fit(X, other_y)   # a completely separate model
np.allclose(before, a.predict_proba(X))  # False  <- a changed
```

This corrupts anything that fits several default HSTree models and keeps them around — comparing models, manual cross-validation loops, ensembling.

## How I found it

Twice while testing other changes, two models that should have differed compared as identical. Both times the cause was one estimator object shared between them. The third time I checked whether the library was doing it too — and it was.

## Fix

Default to `None` and construct per instance, which is what `HSTreeClassifierCV` and `HSTreeRegressorCV` already do. Applied to `HSTree`, `HSTreeClassifier` and `HSTreeRegressor`.

Passing your own estimator is unchanged, including the documented behaviour that it is modified in place.

## Test plan
- [x] `test_models_do_not_share_a_default_estimator` — distinct objects per instance, fitting one model leaving another untouched, and the defaults still being the right type and still working
- [x] Test fails on master, passes here
- [x] `pytest tests` — 550 passed on sklearn 1.5.2 and 1.9.0

No linked issue — found while auditing sample_weight support for #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf