### PR TITLE
Stop refitting the tree for every reg_param in HSTree CV (#175)

### DIFF
--- a/imodels/tree/hierarchical_shrinkage.py
+++ b/imodels/tree/hierarchical_shrinkage.py
@@ -453,8 +453,9 @@ class HSTreeClassifierCV(HSTreeClassifier):
             base_est = deepcopy(self.estimator_)
             base_est.fit(X_in, y_in)
             for i, reg_param in enumerate(self.reg_param_list):
-                est_hs = HSTreeClassifier(base_est, reg_param)
-                est_hs.fit(X_in, y_in, *args, **kwargs)
+                # shrinkage is post-hoc, so shrink a copy of the tree fitted
+                # above rather than refitting it for every reg_param
+                est_hs = HSTreeClassifier(deepcopy(base_est), reg_param)
                 self.scores_[i].append(
                     scorer(y_out, est_hs.predict_proba(X_out)))
         self.scores_ = [np.mean(s) for s in self.scores_]
@@ -542,8 +543,9 @@ class HSTreeRegressorCV(HSTreeRegressor):
             base_est = deepcopy(self.estimator_)
             base_est.fit(X_in, y_in)
             for i, reg_param in enumerate(self.reg_param_list):
-                est_hs = HSTreeRegressor(base_est, reg_param)
-                est_hs.fit(X_in, y_in)
+                # shrinkage is post-hoc, so shrink a copy of the tree fitted
+                # above rather than refitting it for every reg_param
+                est_hs = HSTreeRegressor(deepcopy(base_est), reg_param)
                 self.scores_[i].append(scorer(est_hs.predict(X_out), y_out))
         self.scores_ = [np.mean(s) for s in self.scores_]
         cv_criterion = _get_cv_criterion(scorer)

--- a/tests/shrinkage_test.py
+++ b/tests/shrinkage_test.py
@@ -243,3 +243,52 @@ def test_models_do_not_share_a_default_estimator():
     assert HSTreeRegressor().fit(X, X[:, 0]).predict(X).shape == (300,)
     assert isinstance(HSTreeRegressor().estimator_, DecisionTreeRegressor)
     assert isinstance(HSTreeClassifier().estimator_, DecisionTreeClassifier)
+
+
+def test_cv_fits_each_tree_once_per_fold():
+    """The CV search should not refit the tree for every reg_param
+
+    Shrinkage is post-hoc, so one fit per fold is enough; the tree used to be
+    refit for each candidate (see https://github.com/csinva/imodels/issues/175).
+    """
+    from sklearn.tree import DecisionTreeClassifier as _DTC
+
+    rng = np.random.RandomState(0)
+    X = rng.randn(600, 6)
+    y = (X[:, 0] + rng.randn(600) > 0).astype(int)
+
+    n_fits = []
+    original_fit = _DTC.fit
+
+    def counting_fit(self, *args, **kwargs):
+        n_fits.append(1)
+        return original_fit(self, *args, **kwargs)
+
+    _DTC.fit = counting_fit
+    try:
+        model = HSTreeClassifierCV(cv=3).fit(X, y)
+    finally:
+        _DTC.fit = original_fit
+
+    # one fit per fold, plus the final fit on all the data
+    assert len(n_fits) == model.cv + 1, f'{len(n_fits)} tree fits'
+    assert len(model.scores_) == len(model.reg_param_list)
+
+
+def test_cv_scores_are_unchanged():
+    """Scoring each reg_param on the same fitted tree gives the same answers"""
+    from sklearn.tree import DecisionTreeClassifier as _DTC
+
+    rng = np.random.RandomState(0)
+    X = rng.randn(1500, 10)
+    y = (X[:, 0] + rng.randn(1500) > 0).astype(int)
+
+    model = HSTreeClassifierCV(
+        estimator_=_DTC(max_leaf_nodes=20, random_state=0), cv=3).fit(X, y)
+
+    # values recorded from the previous implementation, which refit the tree
+    # for every reg_param; identical once the tree is deterministic
+    expected = [1.239293, 0.664447, 0.617181, 0.563517,
+                0.523661, 0.512812, 0.531620]
+    assert np.allclose(model.scores_, expected, atol=1e-5)
+    assert model.reg_param == 100.0


### PR DESCRIPTION
Addresses part of #175.

## Problem

`HSTreeClassifierCV` / `HSTreeRegressorCV` fit the base estimator once per fold, then for each candidate `reg_param` build an `HSTree` around it and call `fit` again — which refits the tree from scratch:

```python
base_est.fit(X_in, y_in)
for reg_param in self.reg_param_list:
    est_hs = HSTreeClassifier(base_est, reg_param)
    est_hs.fit(X_in, y_in)          # refits the tree, every time
```

Shrinkage is *post-hoc* — it rewrites node values on an already-fitted tree — so one fit per fold is enough.

## Fix

Shrink a copy of the tree fitted for that fold instead of refitting it.

| | tree fits | time |
|---|---|---|
| before | 25 | 1.29s |
| after | 4 | 0.47s |

(default 7 candidates × 3 folds; timing wrapping a 20-tree `RandomForestClassifier`, **2.8× faster**. The saving grows with the cost of fitting the base estimator.)

## Scores are unchanged — and now better controlled

With a **seeded** estimator, the selected `reg_param` and every entry of `scores_` are bit-identical to before:

```
old: [1.239293 0.664447 0.617181 0.563517 0.523661 0.512812 0.531620]
new: [1.239293 0.664447 0.617181 0.563517 0.523661 0.512812 0.531620]
```

With the **unseeded** default they previously differed slightly — because each refit drew a *different random tree*, so every candidate was scored on a different tree. Candidates are now compared on the same tree per fold, which is what the comparison is meant to do.

## Scope

This is the "vary only the regularization parameter rather than refit many trees" part of #175, which the CV path still wasn't doing. It does **not** implement the GCV ridge formula or the parallelization over trees also described there, so I've left the issue open rather than auto-closing it.

## Test plan
- [x] `test_cv_fits_each_tree_once_per_fold` — counts actual `DecisionTreeClassifier.fit` calls, asserts `cv + 1`
- [x] `test_cv_scores_are_unchanged` — pins the scores recorded from the previous implementation
- [x] `pytest tests` — 554 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf