### PR TITLE
Fix introspection API gaps found auditing the recent merges

### DIFF
--- a/imodels/tree/cart_ccp.py
+++ b/imodels/tree/cart_ccp.py
@@ -83,6 +83,11 @@ class DecisionTreeCCPClassifier(ClassifierMixin, BaseEstimator):
         from imodels.util.get_rules import get_rules
         return get_rules(self, feature_names=feature_names)
 
+    def apply(self, X):
+        """Return the leaf each sample reaches (see imodels.util.apply.apply_leaves)."""
+        from imodels.util.apply import apply_leaves
+        return apply_leaves(self, X)
+
     def _get_complexity(self, BaseEstimator, complexity_measure):
         return compute_tree_complexity(BaseEstimator.tree_, complexity_measure)
 
@@ -173,6 +178,16 @@ class DecisionTreeCCPRegressor(BaseEstimator):
         self.estimator_.fit(X, y, sample_weight=sample_weight)
         self._copy_fitted_attributes()
         return self
+
+    def get_rules(self, feature_names=None):
+        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
+        from imodels.util.get_rules import get_rules
+        return get_rules(self, feature_names=feature_names)
+
+    def apply(self, X):
+        """Return the leaf each sample reaches (see imodels.util.apply.apply_leaves)."""
+        from imodels.util.apply import apply_leaves
+        return apply_leaves(self, X)
 
     def _get_complexity(self, BaseEstimator, complexity_measure):
         return compute_tree_complexity(BaseEstimator.tree_, self.complexity_measure)

--- a/imodels/tree/figs.py
+++ b/imodels/tree/figs.py
@@ -822,6 +822,11 @@ class FIGSCV(BaseEstimator):
         from imodels.util.get_rules import get_rules
         return get_rules(self, feature_names=feature_names)
 
+    def apply(self, X):
+        """Return the leaf each sample reaches (see imodels.util.apply.apply_leaves)."""
+        from imodels.util.apply import apply_leaves
+        return apply_leaves(self, X)
+
     def get_params(self, deep=True):
         # defined explicitly because __init__ takes *args/**kwargs, which sklearn's
         # automatic parameter introspection rejects

--- a/imodels/tree/tao.py
+++ b/imodels/tree/tao.py
@@ -19,13 +19,13 @@ class TaoTree(BaseEstimator):
 
     def __init__(self, model_type: str = 'CART',
                  n_iters: int = 20,
-                 model_args: dict = {'max_leaf_nodes': 15},
+                 model_args: dict = None,
                  randomize_tree=False,
                  update_scoring='accuracy',
                  min_node_samples_tao=3,
                  min_leaf_samples_tao=2,
                  node_model='stump',
-                 node_model_args: dict = {},
+                 node_model_args: dict = None,
                  reg_param: float = 1e-3,
                  weight_errors: bool = False,
                  verbose: int = 0,
@@ -81,13 +81,16 @@ class TaoTree(BaseEstimator):
         super().__init__()
         self.model_type = model_type
         self.n_iters = n_iters
-        self.model_args = model_args
+        # built per instance: a dict default in the signature is shared by every
+        # model, so mutating one would change the others
+        self.model_args = ({'max_leaf_nodes': 15} if model_args is None
+                           else model_args)
         self.randomize_tree = randomize_tree
         self.update_scoring = update_scoring
         self.min_node_samples_tao = min_node_samples_tao
         self.min_leaf_samples_tao = min_leaf_samples_tao
         self.node_model = node_model
-        self.node_model_args = node_model_args
+        self.node_model_args = {} if node_model_args is None else node_model_args
         self.reg_param = reg_param
         self.weight_errors = weight_errors
         self.verbose = verbose

--- a/imodels/util/apply.py
+++ b/imodels/util/apply.py
@@ -3,6 +3,9 @@
 import numpy as np
 from sklearn.utils.validation import check_array
 
+from imodels.util.arguments import _finite_check_kwarg
+from imodels.util.model_trees import sklearn_trees
+
 
 def apply_leaves(model, X) -> np.ndarray:
     """Return the leaf each sample reaches, for a tree-based model.
@@ -35,7 +38,7 @@ def apply_leaves(model, X) -> np.ndarray:
     >>> model.apply(X).shape                            # doctest: +SKIP
     (100, 2)
     """
-    trees = _sklearn_trees(model)
+    trees = sklearn_trees(model)
     if trees is None:
         raise ValueError(
             f"Don't know how to get leaf membership for {type(model).__name__}. "
@@ -43,48 +46,8 @@ def apply_leaves(model, X) -> np.ndarray:
             "yet, fit it first."
         )
 
-    X = check_array(X, ensure_all_finite=False) if _accepts_nan() else check_array(X)
+    # missing values are left to the tree, which handles them for sklearn trees;
+    # fit and predict accept them, so apply must too
+    X = check_array(X, **_finite_check_kwarg(allow_nan=True))
     leaves = np.column_stack([tree.apply(X) for tree in trees])
     return leaves[:, 0] if len(trees) == 1 else leaves
-
-
-def _accepts_nan():
-    from inspect import signature
-    return 'ensure_all_finite' in signature(check_array).parameters
-
-
-def _is_sklearn_tree(estimator):
-    return hasattr(getattr(estimator, 'tree_', None), 'feature')
-
-
-def _sklearn_trees(model):
-    """The fitted sklearn trees behind a model, or None if there are none."""
-    if hasattr(model, 'trees_'):  # FIGS: a sum of trees
-        from imodels.tree.viz_utils import extract_sklearn_tree_from_figs
-        n_classes = len(getattr(model, 'classes_', [0, 1]))
-        return [extract_sklearn_tree_from_figs(model, i, n_classes)
-                for i in range(len(model.trees_))]
-
-    if _is_sklearn_tree(model):
-        return [model]
-
-    # models that wrap or delegate to another fitted model
-    for attr in ('figs', 'estimator_', 'model'):
-        inner = getattr(model, attr, None)
-        if inner is not None and inner is not model:
-            trees = _sklearn_trees(inner)
-            if trees is not None:
-                return trees
-
-    subestimators = getattr(model, 'estimators_', None)
-    if subestimators is not None and len(subestimators) > 0:
-        trees = []
-        for estimator in subestimators:
-            if isinstance(estimator, np.ndarray):  # gradient boosting nests them
-                estimator = estimator[0]
-            if not _is_sklearn_tree(estimator):
-                return None
-            trees.append(estimator)
-        return trees
-
-    return None

--- a/imodels/util/get_rules.py
+++ b/imodels/util/get_rules.py
@@ -10,6 +10,11 @@ import numpy as np
 import pandas as pd
 
 from imodels.util.convert import tree_to_rules
+from imodels.util.model_trees import (
+    WRAPPED_MODEL_ATTRS,
+    is_sklearn_tree,
+    sklearn_trees,
+)
 
 #: Columns every `get_rules` result has, in the order they appear.
 CORE_COLUMNS = ['rule', 'prediction']
@@ -33,9 +38,13 @@ def get_rules(model, feature_names=None) -> pd.DataFrame:
 
         - ``rule``: the condition as a string, e.g. ``"age <= 30.5 and bmi > 24.1"``.
           The catch-all final rule of a rule list is ``"else"``.
-        - ``prediction``: what the model predicts when that rule applies. For
-          classifiers this is the predicted value/probability held in the leaf;
-          it is ``NaN`` where a model defines no per-rule prediction.
+        - ``prediction``: what the rule itself predicts. For a single tree this is
+          the value held in the leaf, so it is the model's prediction. For models
+          that combine several rules the meaning follows the model: an additive
+          model like FIGS contributes its trees' values, so they sum to the
+          output, while a boosted ensemble takes a weighted vote and reports each
+          tree's own prediction alongside a ``weight`` column. It is ``NaN``
+          where a model defines no per-rule prediction.
 
         Models add their own columns on top of these, for example ``coef``,
         ``support`` and ``importance`` for RuleFit, or ``tree`` and ``depth`` for
@@ -99,7 +108,7 @@ def _get_feature_names(model, feature_names, n_features=None):
 
 def _rules_from_wrapped_model(model, feature_names):
     """Models that delegate to another fitted model (shrinkage, CV wrappers)."""
-    for attr in ('figs', 'estimator_', 'model'):
+    for attr in WRAPPED_MODEL_ATTRS:
         inner = getattr(model, attr, None)
         # an unfitted sklearn tree has no tree_; don't recurse into it
         if inner is not None and inner is not model and _has_rules(inner):
@@ -109,15 +118,10 @@ def _rules_from_wrapped_model(model, feature_names):
     return None
 
 
-def _is_sklearn_tree(model):
-    # C45TreeClassifier also has a tree_, but it holds XML rather than a tree
-    return hasattr(getattr(model, 'tree_', None), 'feature')
-
-
 def _has_rules(model):
     if getattr(model, 'rules_', None) is not None:
         return True
-    if _is_sklearn_tree(model):
+    if is_sklearn_tree(model):
         return True
     return any(hasattr(model, attr) for attr in ('trees_', 'estimators_'))
 
@@ -277,14 +281,23 @@ def _rules_from_trees(model, feature_names):
         n_features = trees[0].n_features_in_
     names = _get_feature_names(model, feature_names, n_features)
 
+    # boosted ensembles combine their trees by weighted vote, so report the
+    # weight alongside each tree's own prediction
+    tree_weights = getattr(model, 'estimator_weights_', None)
+    if tree_weights is not None and len(tree_weights) != len(trees):
+        tree_weights = None
+
     rows = []
     for tree_num, tree in enumerate(trees):
         for rule, value in tree_to_rules(tree, names, prediction_values=True):
-            rows.append({
+            row = {
                 'rule': rule,
                 'prediction': value[-1] if len(value) > 1 else value[0],
                 'tree': tree_num,
-            })
+            }
+            if tree_weights is not None:
+                row['weight'] = tree_weights[tree_num]
+            rows.append(row)
     rules = pd.DataFrame(rows)
     if len(trees) == 1:  # a single tree needs no tree index
         rules = rules.drop(columns='tree')
@@ -292,19 +305,9 @@ def _rules_from_trees(model, feature_names):
 
 
 def _collect_trees(model):
-    """The sklearn trees making up a model, or None if it isn't tree-based."""
-    if _is_sklearn_tree(model):
-        return [model]
+    """The sklearn trees making up a model, or None if it isn't tree-based.
 
-    subestimators = getattr(model, 'estimators_', None)
-    if subestimators is not None and len(subestimators) > 0:
-        trees = []
-        for estimator in subestimators:
-            if isinstance(estimator, np.ndarray):  # gradient boosting nests them
-                estimator = estimator[0]
-            if not _is_sklearn_tree(estimator):
-                return None
-            trees.append(estimator)
-        return trees
-
-    return None
+    FIGS is excluded: _rules_from_figs reads its nodes directly, because the
+    converted sklearn trees hold class counts rather than predictions.
+    """
+    return sklearn_trees(model, convert_figs=False)

--- a/imodels/util/model_trees.py
+++ b/imodels/util/model_trees.py
@@ -1,0 +1,75 @@
+"""Find the scikit-learn trees behind a fitted imodels model.
+
+Several features (rule extraction, leaf membership) need the same thing: the
+sklearn tree structures a model is built from, whatever shape the model takes.
+Keeping that in one place stops those features from disagreeing about which
+models are tree-based.
+"""
+
+import numpy as np
+
+#: attributes under which a model may keep the fitted model it delegates to
+WRAPPED_MODEL_ATTRS = ('figs', 'estimator_', 'model')
+
+
+def is_sklearn_tree(estimator) -> bool:
+    """Whether `estimator` holds a fitted sklearn tree.
+
+    Checks the tree structure itself, since C45TreeClassifier also has a `tree_`
+    but stores XML in it.
+    """
+    return hasattr(getattr(estimator, 'tree_', None), 'feature')
+
+
+def n_tree_outputs(model) -> int:
+    """Number of values each leaf of `model` holds (classes, or 1 for regression)."""
+    n_outputs = getattr(model, 'n_outputs', None)
+    if n_outputs:
+        return int(n_outputs)
+    classes = getattr(model, 'classes_', None)
+    return len(classes) if classes is not None else 1
+
+
+def sklearn_trees(model, convert_figs=True):
+    """The fitted sklearn trees making up `model`, or None if it has none.
+
+    Parameters
+    ----------
+    model
+        A fitted model.
+    convert_figs : bool
+        Whether to convert a FIGS model's own tree objects into sklearn trees.
+        Set False when the caller reads FIGS nodes directly (the converted trees
+        store class counts rather than predictions).
+    """
+    if hasattr(model, 'trees_'):  # FIGS: a sum of its own tree objects
+        if not convert_figs:
+            return None
+        from imodels.tree.viz_utils import extract_sklearn_tree_from_figs
+        n_outputs = n_tree_outputs(model)
+        return [extract_sklearn_tree_from_figs(model, i, n_outputs)
+                for i in range(len(model.trees_))]
+
+    if is_sklearn_tree(model):
+        return [model]
+
+    # models that delegate to another fitted model (shrinkage, CV wrappers, TAO)
+    for attr in WRAPPED_MODEL_ATTRS:
+        inner = getattr(model, attr, None)
+        if inner is not None and inner is not model:
+            trees = sklearn_trees(inner, convert_figs=convert_figs)
+            if trees is not None:
+                return trees
+
+    subestimators = getattr(model, 'estimators_', None)
+    if subestimators is not None and len(subestimators) > 0:
+        trees = []
+        for estimator in subestimators:
+            if isinstance(estimator, np.ndarray):  # gradient boosting nests them
+                estimator = estimator[0]
+            if not is_sklearn_tree(estimator):
+                return None
+            trees.append(estimator)
+        return trees
+
+    return None

--- a/readme.md
+++ b/readme.md
@@ -211,10 +211,11 @@ model.get_rules()
 ```
 
 Two columns are always present: `rule`, the condition as a string, and `prediction`,
-what the model predicts when that rule applies. Models add their own columns on top —
-`coef`, `support` and `importance` for RuleFit, `tree` for models made of several trees.
-Where a model is additive, as FIGS is, `prediction` is that tree's contribution, so the
-contributions of the matching rules sum to the model's output.
+what that rule predicts. Models add their own columns on top — `coef`, `support` and
+`importance` for RuleFit, `tree` for models made of several trees, and `weight` for
+boosted ensembles, which combine their trees by weighted vote. Where a model is
+additive, as FIGS is, `prediction` is that tree's contribution, so the contributions
+of the matching rules sum to the model's output.
 
 This works across rule sets, rule lists and tree-based models (RuleFit, SkopeRules,
 SLIPPER, greedy and Bayesian rule lists, FIGS, CART, C4.5, TAO, boosted rules, and

--- a/tests/model_introspection_test.py
+++ b/tests/model_introspection_test.py
@@ -1,0 +1,159 @@
+"""Checks that the introspection APIs (get_rules, apply) agree across all models.
+
+get_rules and apply both need to find the trees or rules behind a fitted model.
+These tests pin that they stay consistent with each other and with the methods
+models advertise, which is easy to break when a model is added or changed.
+"""
+
+import contextlib
+import io
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import imodels
+from imodels.util.apply import apply_leaves
+from imodels.util.get_rules import CORE_COLUMNS
+from tests.model_configs import (BINARY_INPUT_MODELS, EXCLUDED_MODELS,
+                                 MODEL_KWARGS)
+
+N_SAMPLES = 150
+FEATURE_NAMES = list('abcd')
+
+MODELS = [m for m in imodels.ESTIMATORS if m.__name__ not in EXCLUDED_MODELS]
+IDS = [m.__name__ for m in MODELS]
+
+# SLIPPER boosts single-rule estimators rather than trees, so it inherits an
+# apply method from BoostedRulesClassifier that cannot work; it reports that.
+NO_LEAVES_DESPITE_METHOD = {'SlipperClassifier'}
+
+
+def _data(model_type):
+    rng = np.random.RandomState(0)
+    X = pd.DataFrame(rng.randn(N_SAMPLES, 4), columns=FEATURE_NAMES)
+    if model_type.__name__ in BINARY_INPUT_MODELS:
+        X = (X > 0).astype(int)
+    if model_type in imodels.CLASSIFIERS:
+        y = (X.iloc[:, 0] > 0).astype(int)
+    else:
+        y = X.iloc[:, 0] + 0.01 * rng.randn(N_SAMPLES)
+    return X, y
+
+
+def _fit(model_type):
+    X, y = _data(model_type)
+    model = model_type(**MODEL_KWARGS.get(model_type.__name__, {}))
+    with contextlib.redirect_stdout(io.StringIO()):  # some models print
+        model.fit(X, y)
+    return model, X, y
+
+
+def _supported(fn):
+    """Whether an introspection function works, as opposed to saying it can't."""
+    try:
+        with contextlib.redirect_stdout(io.StringIO()):
+            fn()
+        return True
+    except ValueError:
+        return False
+
+
+@pytest.mark.parametrize('model_type', MODELS, ids=IDS)
+def test_get_rules_method_matches_function(model_type):
+    """A model has .get_rules() exactly when imodels.get_rules supports it"""
+    model, X, y = _fit(model_type)
+    works = _supported(lambda: imodels.get_rules(model))
+    assert hasattr(model, 'get_rules') == works
+
+
+@pytest.mark.parametrize('model_type', MODELS, ids=IDS)
+def test_apply_method_matches_function(model_type):
+    """A model has .apply() exactly when leaf membership is available for it"""
+    model, X, y = _fit(model_type)
+    if model_type.__name__ in NO_LEAVES_DESPITE_METHOD:
+        pytest.skip('inherits apply but is not built from trees')
+    works = _supported(lambda: apply_leaves(model, X))
+    assert hasattr(model, 'apply') == works
+
+
+@pytest.mark.parametrize('model_type', MODELS, ids=IDS)
+def test_introspection_never_fails_unexpectedly(model_type):
+    """These APIs either work or raise ValueError -- never anything else"""
+    model, X, y = _fit(model_type)
+    for fn in (lambda: imodels.get_rules(model), lambda: apply_leaves(model, X)):
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                fn()
+        except ValueError:
+            pass  # the documented "not supported" signal
+
+
+def test_regressors_support_leaf_membership():
+    """Tree-based regressors were broken while their classifiers worked"""
+    rng = np.random.RandomState(0)
+    X = rng.randn(N_SAMPLES, 4)
+    y = X[:, 0] + 0.1 * rng.randn(N_SAMPLES)
+
+    figs = imodels.FIGSRegressor(max_rules=5).fit(X, y)
+    assert figs.apply(X).shape[0] == N_SAMPLES
+
+    from sklearn.tree import DecisionTreeRegressor
+    ccp = imodels.DecisionTreeCCPRegressor(
+        estimator_=DecisionTreeRegressor(random_state=0),
+        desired_complexity=4).fit(X, y)
+    assert ccp.apply(X).shape == (N_SAMPLES,)
+    assert list(ccp.get_rules().columns[:len(CORE_COLUMNS)]) == CORE_COLUMNS
+
+
+def test_multiclass_leaf_membership():
+    """Leaf membership should work for more than two classes"""
+    from sklearn.datasets import load_iris
+    X, y = load_iris(return_X_y=True)
+    model = imodels.FIGSClassifier(max_rules=6).fit(X, y)
+    assert model.apply(X).shape[0] == len(y)
+
+
+def test_apply_accepts_missing_values():
+    """fit and predict accept NaN for sklearn trees, so apply must too"""
+    from sklearn.tree import DecisionTreeClassifier
+
+    rng = np.random.RandomState(0)
+    X = rng.randn(120, 3)
+    y = (X[:, 0] > 0).astype(int)
+    X[::9, 1] = np.nan
+
+    model = imodels.HSTreeClassifier(
+        DecisionTreeClassifier(max_leaf_nodes=6)).fit(X, y)
+    model.predict(X)
+    assert model.apply(X).shape == (120,)
+
+
+def test_boosted_rules_report_their_weights():
+    """A boosted ensemble votes by weight, so the weights must be reported"""
+    rng = np.random.RandomState(0)
+    X = pd.DataFrame(rng.randn(300, 3), columns=list('abc'))
+    y = (X['a'] + 0.8 * rng.randn(300) > 0).astype(int)
+
+    model = imodels.BoostedRulesClassifier(n_estimators=4).fit(X, y)
+    rules = model.get_rules()
+    assert 'weight' in rules.columns
+    assert rules.groupby('tree')['weight'].nunique().eq(1).all()
+
+    # each tree's reported weight is the one the model gives it, so a caller can
+    # weigh the rules the way the model does (how they are combined is the
+    # boosting algorithm's business, and varies by sklearn version)
+    reported = rules.groupby('tree')['weight'].first().to_numpy()
+    assert np.allclose(reported, model.estimator_weights_[:len(reported)])
+
+    # a single tree carries no weights
+    assert 'weight' not in imodels.GreedyTreeClassifier(
+        max_leaf_nodes=4).fit(X, y).get_rules().columns
+
+
+def test_models_do_not_share_mutable_defaults():
+    """Default arguments must not be shared between instances"""
+    first, second = imodels.TaoTreeClassifier(), imodels.TaoTreeClassifier()
+    assert first.model_args is not second.model_args
+    first.model_args['max_leaf_nodes'] = 999
+    assert second.model_args['max_leaf_nodes'] != 999


### PR DESCRIPTION
Audit of everything merged in the recent run (#229–#253), and fixes for what it turned up. No linked issue — these are defects in the merged code itself.

## Root cause

`get_rules` (#248) and `apply` (#250) were built in separate PRs, and each kept its **own private copy** of the logic that finds the trees behind a model. The copies had already drifted, and the drift hid real bugs. They now share `imodels/util/model_trees.py`.

## Bugs fixed

**1. `FIGSRegressor.apply()` always raised.** Tree extraction assumed two classes:

```python
n_classes = len(getattr(model, 'classes_', [0, 1]))   # regressors have no classes_
```

A FIGS regressor's leaves hold one value, so conversion died with `Wrong shape for value array from the pickle: expected (11, 1, 2), got (11, 1, 1)`. The *classifier* worked, which is exactly why it slipped through. Now uses the model's own `n_outputs`, so regressors and multiclass both work.

**2. `apply()` rejected missing values** although `fit` and `predict` accept them for sklearn trees since #247. The guard meant to allow NaN checked for `ensure_all_finite`, a parameter renamed in sklearn 1.6 — so it silently did nothing on the pinned version *and* behaved differently across versions. It now reuses the same helper `check_fit_arguments` uses.

**3. Missing methods.** `DecisionTreeCCPRegressor` advertised neither `get_rules` nor `apply`; `DecisionTreeCCPClassifier` and `FIGSCV` lacked `apply` — even though the underlying functions handled all of them. (Caused by an anchor-based edit that only matched the first of two classes in a file.)

**4. Boosted ensembles couldn't be recombined.** They combine trees by *weighted vote*, but `get_rules` reported only each tree's own prediction. On current sklearn those weights genuinely vary (SAMME: 1.33, 0.92, 0.63, 0.59), so the rules could not be weighed the way the model weighs them. `get_rules` now reports a `weight` column for them, and the docstring states what `prediction` means per model family instead of assuming a single tree.

**5. `TaoTreeClassifier` shared mutable defaults.** `model_args: dict = {'max_leaf_nodes': 15}` is built once at import, so every instance shared it and mutating one changed the rest — the same class of bug as the HSTree estimator default in #253.

## The test that would have caught all of this

`tests/model_introspection_test.py` asserts the invariant the two APIs must satisfy: **a model exposes `.get_rules()`/`.apply()` exactly when the corresponding function supports it**, checked across every registered model, plus that neither ever raises anything other than the documented `ValueError`.

All **9** of its new checks fail on master and pass here. 552 → 661 tests.

## Audited and found clean

Discretizers (#233/#234) including index preservation and stable columns; RuleFit's three fixes (#231/#237/#243) including clone-ability and that a caller's `tree_generator` stays unfitted; HSTree's four (#235/#236/#247/#253); FIGS `class_weight`/`sample_weight` (#249/#251) including surviving `clone`; CCP `sample_weight` (#252).

Two things I deliberately left alone: `BoostedRules`' shared default estimator template (sklearn clones it before fitting, so I could not demonstrate contamination — noted, not churned), and `SlipperClassifier` inheriting an `apply` it can't satisfy (it boosts single rules, not trees, and says so clearly).

## Test plan
- [x] 661 passed on **sklearn 1.5.2** (CI pinned) and **1.9.0** / pandas 3.0.5
- [x] New tests verified to fail against master's library code (9 failures) and pass with the fixes
- [x] Readme updated for the `weight` column

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PWG8LboAM9TsyHCxRi2Bk