### PR TITLE
Expose MDI feature importances on more tree-based models (#127)

### DIFF
--- a/imodels/tree/cart_ccp.py
+++ b/imodels/tree/cart_ccp.py
@@ -83,6 +83,11 @@ class DecisionTreeCCPClassifier(ClassifierMixin, BaseEstimator):
         from imodels.util.get_rules import get_rules
         return get_rules(self, feature_names=feature_names)
 
+    @property
+    def feature_importances_(self):
+        """Mean decrease in impurity of the pruned tree, as in sklearn."""
+        return self.estimator_.feature_importances_
+
     def _get_complexity(self, BaseEstimator, complexity_measure):
         return compute_tree_complexity(BaseEstimator.tree_, complexity_measure)
 
@@ -173,6 +178,11 @@ class DecisionTreeCCPRegressor(BaseEstimator):
         self.estimator_.fit(X, y, sample_weight=sample_weight)
         self._copy_fitted_attributes()
         return self
+
+    @property
+    def feature_importances_(self):
+        """Mean decrease in impurity of the pruned tree, as in sklearn."""
+        return self.estimator_.feature_importances_
 
     def _get_complexity(self, BaseEstimator, complexity_measure):
         return compute_tree_complexity(BaseEstimator.tree_, self.complexity_measure)

--- a/imodels/tree/figs.py
+++ b/imodels/tree/figs.py
@@ -822,6 +822,11 @@ class FIGSCV(BaseEstimator):
         from imodels.util.get_rules import get_rules
         return get_rules(self, feature_names=feature_names)
 
+    @property
+    def feature_importances_(self):
+        """Mean decrease in impurity of the selected FIGS model."""
+        return self.figs.feature_importances_
+
     def get_params(self, deep=True):
         # defined explicitly because __init__ takes *args/**kwargs, which sklearn's
         # automatic parameter introspection rejects

--- a/imodels/tree/hierarchical_shrinkage.py
+++ b/imodels/tree/hierarchical_shrinkage.py
@@ -13,6 +13,8 @@ from sklearn.ensemble import (
     GradientBoostingRegressor,
 )
 
+from sklearn.utils.validation import check_is_fitted
+
 from imodels.util import checks
 from imodels.util.arguments import check_fit_arguments
 from imodels.util.tree import compute_tree_complexity
@@ -90,6 +92,16 @@ class HSTree(BaseEstimator):
         """Return the leaf each sample reaches (see imodels.util.apply.apply_leaves)."""
         from imodels.util.apply import apply_leaves
         return apply_leaves(self, X)
+
+    @property
+    def feature_importances_(self):
+        """Mean decrease in impurity, as in sklearn's tree models.
+
+        Shrinkage rewrites node values but not the tree structure or its
+        impurities, so these match the underlying fitted estimator's.
+        """
+        check_is_fitted(self.estimator_ if hasattr(self, 'estimator_') else self)
+        return self.estimator_.feature_importances_
 
     def get_params(self, deep=True):
         d = {

--- a/imodels/tree/tao.py
+++ b/imodels/tree/tao.py
@@ -380,6 +380,11 @@ class TaoTree(BaseEstimator):
         from imodels.util.apply import apply_leaves
         return apply_leaves(self, X)
 
+    @property
+    def feature_importances_(self):
+        """Mean decrease in impurity of the fitted tree, as in sklearn."""
+        return self.model.feature_importances_
+
     def predict(self, X):
         preds = self.model.predict(X)
         if hasattr(self, "classes_"):

--- a/readme.md
+++ b/readme.md
@@ -219,6 +219,9 @@ function, `imodels.get_rules(model)`, and takes an optional `feature_names` argu
 to rename the features. Models that aren't rule-based raise a clear error.
 
 
+Tree-based models expose `feature_importances_` (mean decrease in impurity), the
+same measure sklearn's tree models report, so they can be compared directly.
+
 Tree-based models also expose `apply(X)`, which reports which leaf each sample
 falls into, using the same node numbering as scikit-learn. A single tree returns
 one index per sample; a model made of several trees (FIGS, boosted rules) returns

--- a/tests/feature_importances_test.py
+++ b/tests/feature_importances_test.py
@@ -1,0 +1,79 @@
+"""Tests for MDI feature importances on tree-based models (issue #127)."""
+
+import numpy as np
+import pytest
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
+
+import imodels
+
+N_SAMPLES = 300
+
+
+def _data():
+    rng = np.random.RandomState(0)
+    X = rng.randn(N_SAMPLES, 4)
+    # only the first two features carry signal
+    y = ((X[:, 0] > 0) | (X[:, 1] > 1)).astype(int)
+    return X, y
+
+
+def _models():
+    return {
+        'HSTreeClassifier': imodels.HSTreeClassifier(),
+        'HSTreeClassifierCV': imodels.HSTreeClassifierCV(cv=3),
+        'FIGSClassifierCV': imodels.FIGSClassifierCV(
+            n_rules_list=[3], n_trees_list=[2], cv=2),
+        'DecisionTreeCCPClassifier': imodels.DecisionTreeCCPClassifier(
+            estimator_=DecisionTreeClassifier(random_state=0), desired_complexity=4),
+        'TaoTreeClassifier': imodels.TaoTreeClassifier(),
+    }
+
+
+@pytest.mark.parametrize('model_name', sorted(_models()))
+def test_feature_importances(model_name):
+    """Importances look like sklearn's: non-negative, summing to 1, informative"""
+    X, y = _data()
+    model = _models()[model_name].fit(X, y)
+
+    importances = model.feature_importances_
+    assert importances.shape == (4,)
+    assert (importances >= 0).all()
+    assert np.isclose(importances.sum(), 1)
+
+    # the two signal-carrying features should dominate the noise ones
+    assert importances[:2].sum() > importances[2:].sum()
+
+
+def test_shrinkage_matches_its_estimator():
+    """Shrinkage doesn't change tree structure, so MDI matches the plain tree"""
+    X, y = _data()
+    shrunk = imodels.HSTreeClassifier(
+        DecisionTreeClassifier(max_leaf_nodes=8, random_state=0),
+        reg_param=100).fit(X, y)
+    plain = DecisionTreeClassifier(max_leaf_nodes=8, random_state=0).fit(X, y)
+
+    assert np.allclose(shrunk.feature_importances_, plain.feature_importances_)
+
+
+def test_shrunk_forest_importances():
+    """Wrapping an ensemble delegates to the ensemble's own importances"""
+    X, y = _data()
+    model = imodels.HSTreeClassifier(
+        RandomForestClassifier(n_estimators=5, random_state=0)).fit(X, y)
+
+    assert np.isclose(model.feature_importances_.sum(), 1)
+    assert model.feature_importances_[:2].sum() > 0.5
+
+
+def test_regressors_expose_importances():
+    X, y = _data()
+    y_continuous = X[:, 0] + 0.1 * np.random.RandomState(1).randn(N_SAMPLES)
+
+    for model in [imodels.HSTreeRegressor(),
+                  imodels.DecisionTreeCCPRegressor(
+                      estimator_=DecisionTreeRegressor(random_state=0),
+                      desired_complexity=4)]:
+        importances = model.fit(X, y_continuous).feature_importances_
+        assert np.isclose(importances.sum(), 1)
+        assert np.argmax(importances) == 0


### PR DESCRIPTION
Fixes #127

## Why

The issue asks for MDI / Gini importances on tree-based models so they can be compared with sklearn's `RandomForestClassifier` and `GradientBoostingClassifier`. It was added for FIGS in #154, but the other tree models still lacked it — of the registered models, only FIGS, CART and boosted rules had `feature_importances_`.

## What

Added it to the tree-based models that were missing it, each delegating to the fitted sklearn tree or ensemble underneath:

- `HSTreeClassifier` / `HSTreeRegressor` (and the `CV` variants)
- `FIGSClassifierCV` / `FIGSRegressorCV`
- `DecisionTreeCCPClassifier` / `DecisionTreeCCPRegressor`
- `TaoTreeClassifier` / `TaoTreeRegressor`

Hierarchical shrinkage is the interesting case: it rewrites node *values* but leaves the tree structure and its impurities untouched, so its importances match those of the tree it wraps. The tests assert that equality rather than leaving it implied, and wrapping a `RandomForestClassifier` works too.

## TreeGAM is deliberately excluded

I implemented it, saw `[0.25, 0.25, 0.25, 0.25]` on data where only two of four features carry signal, and checked why:

```
tree 0: uses feature(s) [0]    tree 4: uses feature(s) [0]
tree 1: uses feature(s) [1]    tree 5: uses feature(s) [1]
tree 2: uses feature(s) [2]    tree 6: uses feature(s) [2]
tree 3: uses feature(s) [3]    tree 7: uses feature(s) [3]
```

Cyclic boosting fits exactly one tree per feature in rotation, so averaging per-tree MDI returns uniform importances *whatever the data*. That would look like a result without being one, so I dropped it rather than ship a misleading number. A meaningful GAM importance would weight each shape function by the error it actually removes — a separate piece of work.

## Test plan
- [x] New `tests/feature_importances_test.py`: non-negative, sums to 1, and the two signal-carrying features dominate the two noise features — across 5 models plus the regressors
- [x] Shrinkage importances equal the wrapped tree's; a shrunk `RandomForest` also works
- [x] `pytest tests` — 547 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf