### PR TITLE
Add a verbose parameter to FIGS (#92)

### DIFF
--- a/imodels/tree/figs.py
+++ b/imodels/tree/figs.py
@@ -124,6 +124,7 @@ class FIGS(BaseEstimator):
         max_features: str = None,
         max_depth: int = None,
         class_weight=None,
+        verbose: int = 0,
     ):
         """
         Params
@@ -136,6 +137,10 @@ class FIGS(BaseEstimator):
             A node will be split if this split induces a decrease of the impurity greater than or equal to this value.
         max_features
             The number of features to consider when looking for the best split (see https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html)
+        verbose: int, default=0
+            Controls progress reporting while fitting. 0 is silent; 1 reports each
+            rule as it is added, with the running total; 2 also prints the model
+            after every rule. Can be overridden per call via fit(verbose=...).
         class_weight: dict, list of dict or "balanced", default=None
             Classification only. Weights associated with classes, in the form
             {class_label: weight}. "balanced" weights each class by
@@ -151,6 +156,7 @@ class FIGS(BaseEstimator):
         self.max_features = max_features
         self.max_depth = max_depth
         self.class_weight = class_weight
+        self.verbose = verbose
         self._init_decision_function()
         self.n_outputs = None
         self.need_to_reshape = False
@@ -307,7 +313,7 @@ class FIGS(BaseEstimator):
         X,
         y=None,
         feature_names=None,
-        verbose=False,
+        verbose=None,
         sample_weight=None,
         categorical_features=None,
     ):
@@ -319,6 +325,9 @@ class FIGS(BaseEstimator):
             Splits that would create child nodes with net zero or negative weight
             are ignored while searching for a split in each node.
         """
+        # fit(verbose=...) still wins, so existing callers are unaffected
+        verbose = int(self.verbose if verbose is None else verbose)
+
         if categorical_features is not None:
             X, self._encoder = encode_categories(X, categorical_features)
 
@@ -405,8 +414,6 @@ class FIGS(BaseEstimator):
                 continue
 
             # split on node
-            if verbose:
-                print("\nadding " + str(split_node))
             self.complexity_ += 1
 
             # if added a tree root
@@ -434,6 +441,14 @@ class FIGS(BaseEstimator):
             # add children to potential_splits
             potential_splits.append(split_node.left)
             potential_splits.append(split_node.right)
+
+            if verbose >= 1:
+                # reported after the bookkeeping above, so the counts are final
+                budget = '' if self.max_rules is None else f'/{self.max_rules}'
+                condition = (f"X_{split_node.feature} <= {split_node.threshold:0.3f}"
+                             if split_node.feature is not None else str(split_node))
+                print(f"rule {self.complexity_}{budget} "
+                      f"({len(self.trees_)} tree(s)): {condition}")
 
             # update predictions for altered tree
             for tree_num_ in range(len(self.trees_)):
@@ -492,7 +507,7 @@ class FIGS(BaseEstimator):
             potential_splits = sorted(
                 potential_splits_new, key=lambda x: x.impurity_reduction
             )
-            if verbose:
+            if verbose >= 2:
                 print(self)
             if self.max_rules is not None and self.complexity_ >= self.max_rules:
                 finished = True

--- a/tests/figs_test.py
+++ b/tests/figs_test.py
@@ -192,3 +192,45 @@ def test_feature_importances_use_sample_weight():
     tree = extract_sklearn_tree_from_figs(weighted, 0, 2).tree_
     assert tree.n_node_samples[0] == len(y)
     assert np.isclose(tree.weighted_n_node_samples[0], weights.sum())
+
+
+def test_verbose_progress_reporting():
+    """FIGS should be able to report progress while fitting
+
+    Feature request https://github.com/csinva/imodels/issues/92: a long fit
+    gave no indication of progress.
+    """
+    import contextlib
+    import io
+
+    from imodels import FIGSRegressor
+
+    rng = np.random.RandomState(0)
+    X = rng.randn(200, 4)
+    y = X[:, 0] + (X[:, 1] > 0)
+
+    def fit_and_capture(model, **fit_kwargs):
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            model.fit(X, y, **fit_kwargs)
+        return buffer.getvalue()
+
+    # silent by default
+    assert fit_and_capture(FIGSRegressor(max_rules=4)) == ''
+
+    # verbose=1 reports each rule, with a running count against the budget
+    output = fit_and_capture(FIGSRegressor(max_rules=4, verbose=1))
+    lines = [line for line in output.splitlines() if line.startswith('rule ')]
+    assert len(lines) == 4
+    assert 'rule 1/4' in output and 'rule 4/4' in output
+    assert 'tree(s)' in output
+
+    # verbose=2 additionally prints the model
+    assert 'FIGS' in fit_and_capture(FIGSRegressor(max_rules=2, verbose=2))
+
+    # fit(verbose=...) still overrides, as it did before
+    assert fit_and_capture(FIGSRegressor(max_rules=2), verbose=1) != ''
+    assert fit_and_capture(FIGSRegressor(max_rules=2, verbose=1), verbose=0) == ''
+
+    # and it round-trips as a normal parameter
+    assert FIGSRegressor(verbose=1).get_params()['verbose'] == 1


### PR DESCRIPTION
Fixes #92

## Why

> I was trying to get FIGSRegressor to fit [1.5m records], and it's been running more than 2hrs without any indication about its progress.

FIGS had a `verbose` argument on `fit`, but not in the constructor where sklearn models put it — and what it printed was the whole model after every rule, which isn't progress reporting.

## What

`verbose` is now a constructor parameter:

- `0` (default) — silent, unchanged
- `1` — one line per rule, with the running count against `max_rules` and the number of trees so far
- `2` — also prints the model after each rule (the old `verbose=True` behaviour)

```
rule 1/5 (1 tree(s)): X_0 <= -0.158
rule 2/5 (1 tree(s)): X_0 <= 1.185
rule 3/5 (2 tree(s)): X_1 <= 0.001
```

With no `max_rules` the budget is omitted (`rule 42 (1 tree(s)): ...`), which is exactly the open-ended case from the report.

Passing `verbose` to `fit` still works and takes precedence, so existing callers are unaffected.

## A detail worth noting

My first version printed the raw node repr and the tree count *before* the tree bookkeeping, giving confusing output like `Tree #-1 root` and an off-by-one tree count. The report is now emitted after the bookkeeping, and prints the split condition rather than the node's internal repr.

## Scope

The issue asks for this on *every* model. I've done FIGS — the model in the report, and the one whose fit is a long opaque loop. Others (`BoostedRules`, `TreeGAM`) could follow the same pattern; `RuleFit` already inherits sklearn's own `verbose` through its tree generator. Happy to extend if you'd like it broader.

## Test plan
- [x] `test_verbose_progress_reporting` — silent by default, one line per rule at `verbose=1` with the right counts, model printed at `verbose=2`, `fit(verbose=...)` overriding in both directions, and `get_params` round-tripping
- [x] `pytest tests` — 540 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf