### PR TITLE
Fix accuracy and efficiency issues in hierarchical shrinkage

### DIFF
--- a/imodels/tree/hierarchical_shrinkage.py
+++ b/imodels/tree/hierarchical_shrinkage.py
@@ -122,8 +122,8 @@ class HSTree(BaseEstimator):
             self.complexity_ = compute_tree_complexity(self.estimator_.tree_)
         elif hasattr(self.estimator_, "estimators_"):
             self.complexity_ = 0
-            for i in range(len(self.estimator_.estimators_)):
-                t = deepcopy(self.estimator_.estimators_[i])
+            for t in self.estimator_.estimators_:
+                # read-only, so no need to copy the tree
                 if isinstance(t, np.ndarray):
                     assert t.size == 1, "multiple trees stored under tree_?"
                     t = t[0]
@@ -157,7 +157,7 @@ class HSTree(BaseEstimator):
             or isinstance(self.estimator_, GradientBoostingClassifier)
             or values_normalized
         ):
-            val = deepcopy(tree.value[i, :, :])
+            val = tree.value[i, :, :].copy()
         else:  # If classification, counts need normalizing into a probability vector
             val = tree.value[i, :, :] / n_samples
 
@@ -199,7 +199,7 @@ class HSTree(BaseEstimator):
                 left,
                 parent_val=val,
                 parent_num=n_samples,
-                cum_sum=deepcopy(cum_sum),
+                cum_sum=np.copy(cum_sum),
                 values_normalized=values_normalized,
             )
             self._shrink_tree(
@@ -208,7 +208,7 @@ class HSTree(BaseEstimator):
                 right,
                 parent_val=val,
                 parent_num=n_samples,
-                cum_sum=deepcopy(cum_sum),
+                cum_sum=np.copy(cum_sum),
                 values_normalized=values_normalized,
             )
 
@@ -257,7 +257,10 @@ class HSTree(BaseEstimator):
 
     def predict(self, X, *args, **kwargs):
         preds = self.estimator_.predict(X, *args, **kwargs)
-        if hasattr(self.estimator_, "classes_"):
+        # fit encodes y as 0..n_classes-1, so map back onto the original labels.
+        # When the estimator was fitted elsewhere and passed in already fitted,
+        # there is no such encoding and its predictions are already labels.
+        if hasattr(self, "classes_") and hasattr(self.estimator_, "classes_"):
             return np.array([self.classes_[int(i)] for i in preds])
         else:
             return preds
@@ -375,18 +378,27 @@ class HSTreeClassifier(ClassifierMixin, HSTree):
 
 
 def _get_cv_criterion(scorer):
-    y_true = np.random.binomial(n=1, p=0.5, size=100)
+    """Whether the best score is the highest or the lowest one.
 
-    y_pred_good = y_true
-    y_pred_bad = np.random.uniform(0, 1, 100)
+    Probed on fixed data: a scorer's direction does not depend on the draw, and
+    sampling here would advance the caller's global numpy random stream.
+    """
+    y_true = np.tile([0, 1], 50)
 
-    score_good = scorer(y_true, y_pred_good)
-    score_bad = scorer(y_true, y_pred_bad)
+    score_good = scorer(y_true, y_true)
+    score_bad = scorer(y_true, 1 - y_true)
 
     if score_good > score_bad:
         return np.argmax
     elif score_good < score_bad:
         return np.argmin
+
+    raise ValueError(
+        f"Cannot tell whether higher or lower scores from "
+        f"{getattr(scorer, '__name__', scorer)} are better: it scored a perfect "
+        "and a fully incorrect prediction the same. Pass a scoring function that "
+        "separates them."
+    )
 
 
 class HSTreeClassifierCV(HSTreeClassifier):

--- a/imodels/tree/viz_utils.py
+++ b/imodels/tree/viz_utils.py
@@ -130,9 +130,12 @@ def extract_sklearn_tree_from_figs(figs, tree_num, n_classes, with_leaf_predicti
         dt = DecisionTreeRegressor(max_depth=max_depth)
 
     try:
-        dt.__setstate__(_state);
-    except:
-        raise Exception(f'Did not successfully run __setstate__() when translating to {type(dt)}, did sklearn update?')
+        dt.__setstate__(_state)
+    except Exception as e:
+        # chain the original error: what actually went wrong is the useful part
+        raise Exception(
+            f'Did not successfully run __setstate__() when translating to '
+            f'{type(dt)}, did sklearn update?') from e
 
     if not with_leaf_predictions:
         return dt

--- a/tests/shrinkage_test.py
+++ b/tests/shrinkage_test.py
@@ -8,6 +8,7 @@ from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from imodels import HSTreeClassifier, HSTreeClassifierCV, \
     HSTreeRegressor, HSTreeRegressorCV, C45TreeClassifier
 from imodels.tree.c45_tree.c45_tree import HSC45TreeClassifierCV
+from imodels.util.tree import compute_tree_complexity
 import random
 from functools import partial
 
@@ -289,3 +290,84 @@ def test_cv_scores_are_unchanged():
                 0.523661, 0.512812, 0.531620]
     assert np.allclose(model.scores_, expected, atol=1e-5)
     assert model.reg_param == 100.0
+
+
+def test_predict_with_an_already_fitted_estimator():
+    """Wrapping a fitted estimator is documented, and predict must work on it
+
+    HSTree.predict mapped the estimator's output through classes_, which only
+    exists when HSTree did the fitting, so this raised AttributeError. The CV
+    classes rely on this path internally when scoring candidate reg_params.
+    """
+    from copy import deepcopy
+
+    rng = np.random.RandomState(0)
+    X = rng.randn(300, 4)
+    y = (X[:, 0] + rng.randn(300) > 0).astype(int)
+
+    base = DecisionTreeClassifier(max_leaf_nodes=8, random_state=0).fit(X, y)
+    shrunk = HSTreeClassifier(deepcopy(base), reg_param=10)
+
+    preds = shrunk.predict(X)
+    assert preds.shape == (300,)
+    assert np.array_equal(preds, shrunk.estimator_.predict(X))
+
+    # when HSTree does the fitting, labels are still decoded
+    labelled = HSTreeClassifier(DecisionTreeClassifier(max_leaf_nodes=8)).fit(
+        X, np.where(y == 1, 'yes', 'no'))
+    assert set(np.unique(labelled.predict(X))) == {'yes', 'no'}
+
+
+def test_cv_criterion_is_deterministic_and_explicit():
+    """Choosing the best reg_param must not disturb the caller's randomness"""
+    import pytest
+    from sklearn.metrics import accuracy_score, log_loss, mean_squared_error
+
+    from imodels.tree.hierarchical_shrinkage import _get_cv_criterion
+
+    # the direction is read correctly for scorers used by the CV classes
+    assert _get_cv_criterion(log_loss) is np.argmin
+    assert _get_cv_criterion(mean_squared_error) is np.argmin
+    assert _get_cv_criterion(accuracy_score) is np.argmax
+
+    # probing the scorer draws no random numbers
+    np.random.seed(42)
+    expected = np.random.rand(3)
+    np.random.seed(42)
+    _get_cv_criterion(log_loss)
+    assert np.allclose(expected, np.random.rand(3))
+
+    # a seeded estimator means fitting leaves the global stream alone entirely
+    X = np.random.RandomState(0).randn(200, 4)
+    y = (X[:, 0] > 0).astype(int)
+    np.random.seed(42)
+    HSTreeClassifierCV(
+        estimator_=DecisionTreeClassifier(max_leaf_nodes=20, random_state=0),
+        reg_param_list=[0.1, 1, 10]).fit(X, y)
+    assert np.allclose(expected, np.random.rand(3))
+
+    # a scorer whose direction can't be read says so instead of failing later
+    with pytest.raises(ValueError, match='higher or lower'):
+        _get_cv_criterion(lambda y_true, y_pred: 0.5)
+
+
+def test_complexity_of_an_ensemble_does_not_touch_it():
+    """Complexity is read off the trees, so it must not modify the estimator"""
+    from sklearn.ensemble import RandomForestClassifier
+
+    rng = np.random.RandomState(0)
+    X = rng.randn(300, 4)
+    y = (X[:, 0] + rng.randn(300) > 0).astype(int)
+
+    forest = RandomForestClassifier(n_estimators=5, random_state=0)
+    model = HSTreeClassifier(forest, reg_param=10).fit(X, y)
+
+    per_tree = [compute_tree_complexity(t.tree_)
+                for t in model.estimator_.estimators_]
+    assert model.complexity_ == sum(per_tree)
+
+    # reading it again gives the same answer (nothing was consumed or changed)
+    predictions = model.predict_proba(X).copy()
+    assert model.complexity_ == sum(compute_tree_complexity(t.tree_)
+                                    for t in model.estimator_.estimators_)
+    assert np.allclose(predictions, model.predict_proba(X))


### PR DESCRIPTION
Continued audit of the recent merges. No linked issue — these are defects found by inspection.

## First, auditing #254

#254 stopped refitting the tree for every candidate `reg_param`. I checked it against a reimplementation of the previous loop: **scores are identical** (`3.769699, 1.051274, 0.849268, 0.669752, 0.583853, 0.574477, 0.622278`) and it selects the same `reg_param`. The optimization is sound — shrinkage is post-hoc.

But it now relies on constructing an `HSTree` around an already-fitted estimator *without* calling `fit`, which exposed a bug on that path.

## Accuracy

**1. `predict()` raised on a pre-fitted estimator.** Wrapping an already-fitted estimator is documented (`__init__` shrinks it on the spot), but:

```python
HSTreeClassifier(fitted_tree, reg_param=10).predict(X)
AttributeError: 'HSTreeClassifier' object has no attribute 'classes_'
```

`predict` mapped the estimator's output through `self.classes_`, which only exists when *HSTree* did the fitting and encoded `y`. When the estimator was fitted elsewhere its predictions are already labels, so they're now returned as-is. `predict_proba` happened to work, which is why the CV classes didn't trip over it.

**2. Choosing `reg_param` disturbed the caller's randomness.** `_get_cv_criterion` worked out whether higher or lower scores are better by scoring **random draws from the global numpy RNG**:

```python
y_true = np.random.binomial(n=1, p=0.5, size=100)
y_pred_bad = np.random.uniform(0, 1, 100)
```

So `np.random.seed(0); model.fit(...)` left the global stream in a different place than `np.random.seed(0)` alone. It now probes on fixed data — a scorer's direction doesn't depend on the draw. With a seeded estimator, fitting leaves the global stream completely untouched; what remains is sklearn's own unseeded tree fitting, which is expected.

It also **returned `None`** when a scorer couldn't be told apart, surfacing later as `TypeError: 'NoneType' object is not callable`. It now raises naming the scorer.

## Efficiency

Shrinking a 100-tree RandomForest: **0.289s → 0.218s**, same results.

- The shrink recursion used `deepcopy` on small numpy arrays — ~4× the cost of `.copy()` (0.366µs vs 0.097µs), three times per node.
- `complexity_` `deepcopy`'d **every tree in an ensemble** just to read its structure. `compute_tree_complexity` is read-only.

## Also

`extract_sklearn_tree_from_figs` caught bare `except` and raised a generic message, discarding what actually failed. It now chains the original error.

## Test plan
- [x] 3 tests added; the two behavioural ones fail on master, the third guards the complexity change
- [x] 648 passed on sklearn 1.5.2 (CI pinned) and 1.9.0
- [x] Verified string labels still decode when HSTree does the fitting

Note: touches `hierarchical_shrinkage.py`, which open PR #257 also edits (different functions — `feature_importances_`). Whichever merges second will need a trivial resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PWG8LboAM9TsyHCxRi2Bk