### PR TITLE
Fix SLIPPER's boosting probabilities and reproducibility

### DIFF
--- a/imodels/rule_set/slipper_util.py
+++ b/imodels/rule_set/slipper_util.py
@@ -1,7 +1,7 @@
-import random
 
 import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
+from sklearn.utils import check_random_state
 from sklearn.model_selection import train_test_split
 
 from imodels.util.arguments import check_fit_arguments
@@ -13,7 +13,10 @@ class SlipperBaseEstimator(BaseEstimator, ClassifierMixin):
     as part of the SlipperRulesClassifier.
     """
 
-    def __init__(self):
+    def __init__(self, random_state=None):
+        # exposed so that the boosting ensemble seeds each clone of this
+        # estimator, which is how sklearn makes sub-estimators reproducible
+        self.random_state = random_state
         self.Z = None
         self.rule = None
         self.D = None
@@ -177,10 +180,10 @@ class SlipperBaseEstimator(BaseEstimator, ClassifierMixin):
         predict negative
         """
         default_rule = []
-        features = random.choices(
-            range(X.shape[1]),
-            k=random.randint(2, 8)
-        )
+        # drawn through random_state rather than the `random` module, which
+        # neither random_state nor np.random.seed can control
+        rng = check_random_state(self.random_state)
+        features = list(rng.choice(X.shape[1], size=rng.randint(2, 9)))
 
         default_rule.append({
             'feature': str(features[0]),
@@ -247,14 +250,11 @@ class SlipperBaseEstimator(BaseEstimator, ClassifierMixin):
         }
 
     def predict_proba(self, X):
-
-        proba = self.predict(X)
-        proba = proba.reshape(-1, 1)
-        proba = np.hstack([
-            np.zeros(proba.shape), proba
-        ])
-
-        return proba
+        # a rule either fires or it doesn't, so the two columns are the
+        # complementary probabilities; returning [0, prediction] instead left
+        # rows that don't sum to 1, which corrupts the boosting weights
+        proba = np.asarray(self.predict(X), dtype=float).reshape(-1, 1)
+        return np.hstack([1 - proba, proba])
 
     def predict(self, X):
         """
@@ -267,12 +267,16 @@ class SlipperBaseEstimator(BaseEstimator, ClassifierMixin):
         """
         Main loop for training
         """
-        X, y, feature_names = check_fit_arguments(self, X, y, feature_names) 
+        X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
         if sample_weight is not None:
             self.D = sample_weight
+        elif self.D is None:
+            # uniform weights, so the estimator also works outside the ensemble
+            self.D = np.full(len(y), 1 / len(y))
 
+        rng = check_random_state(self.random_state)
         X_grow, X_prune, y_grow, y_prune = \
-            train_test_split(X, y, test_size=0.33)
+            train_test_split(X, y, test_size=0.33, random_state=rng)
 
         self._make_feature_dict(X.shape[1], feature_names)
 

--- a/tests/slipper_test.py
+++ b/tests/slipper_test.py
@@ -1,0 +1,94 @@
+"""Tests for SLIPPER, which boosts single-rule estimators."""
+
+import random
+
+import numpy as np
+import pytest
+
+from imodels import SlipperClassifier
+from imodels.rule_set.slipper_util import SlipperBaseEstimator
+
+N_SAMPLES = 300
+
+
+def _data(seed=0):
+    rng = np.random.RandomState(seed)
+    X = rng.randn(N_SAMPLES, 4)
+    return X, (X[:, 0] > 0).astype(int)
+
+
+def test_random_state_makes_it_reproducible():
+    """random_state must control every random draw
+
+    The rule learner drew from python's `random` module and from an unseeded
+    train_test_split, neither of which random_state reaches, so the same
+    random_state gave different models.
+    """
+    X, y = _data()
+
+    first = SlipperClassifier(n_estimators=5, random_state=0).fit(X, y)
+
+    # a different global random state must not change the result
+    random.seed(123)
+    np.random.seed(123)
+    second = SlipperClassifier(n_estimators=5, random_state=0).fit(X, y)
+    assert np.array_equal(first.predict(X), second.predict(X))
+
+    # but a different random_state should
+    other = SlipperClassifier(n_estimators=5, random_state=3).fit(X, y)
+    assert not np.array_equal(first.predict(X), other.predict(X))
+
+
+def test_refitting_starts_over():
+    """Refitting on new data gives the same model as fitting it fresh"""
+    X, y = _data()
+    X_other = np.random.RandomState(7).randn(N_SAMPLES, 4)
+    y_other = (X_other[:, 1] > 0).astype(int)
+
+    refit = SlipperClassifier(n_estimators=5, random_state=0).fit(X, y)
+    refit.fit(X_other, y_other)
+    fresh = SlipperClassifier(n_estimators=5, random_state=0).fit(X_other, y_other)
+
+    assert np.array_equal(refit.predict(X_other), fresh.predict(X_other))
+
+
+def test_base_estimator_probabilities_are_a_distribution():
+    """Each rule's predict_proba must be a valid distribution
+
+    It returned [0, prediction], so rows did not sum to 1 and the first column
+    was always zero. Boosting derives its sample weights from these, so the
+    later estimators were fitted against corrupted weights.
+    """
+    X, y = _data()
+    model = SlipperClassifier(n_estimators=3, random_state=0).fit(X, y)
+
+    for estimator in model.estimators_:
+        proba = estimator.predict_proba(X)
+        assert proba.shape == (N_SAMPLES, 2)
+        assert np.allclose(proba.sum(axis=1), 1)
+        assert proba.min() >= 0 and proba.max() <= 1
+
+
+def test_adding_estimators_does_not_destroy_accuracy():
+    """More boosting rounds should not make the model worse than one rule
+
+    Accuracy used to collapse from 0.99 with a single rule to below chance with
+    three, because of the invalid probabilities above.
+    """
+    X, y = _data()
+    single = SlipperClassifier(n_estimators=1, random_state=0).fit(X, y)
+    several = SlipperClassifier(n_estimators=10, random_state=0).fit(X, y)
+
+    baseline = np.mean(single.predict(X) == y)
+    assert baseline > 0.9, 'a single rule should already fit this easy task'
+    assert np.mean(several.predict(X) == y) > 0.9
+
+    proba = several.predict_proba(X)
+    assert np.allclose(proba.sum(axis=1), 1)
+
+
+def test_base_estimator_works_without_sample_weight():
+    """The rule learner defaults to uniform weights instead of failing"""
+    X, y = _data()
+    estimator = SlipperBaseEstimator(random_state=0).fit(X, y)
+    assert np.mean(estimator.predict(X) == y) > 0.9


### PR DESCRIPTION
Continued audit, this time beyond the tree models. No linked issue.

## SLIPPER got worse as it boosted

On a clean, easily separable task:

| n_estimators | accuracy (before) |
|---|---|
| 1 | 0.99 |
| 3 | **0.48** ← below chance |
| 10 | varies |

Inspecting the ensemble: estimator 0 scored 0.997, estimators 1 and 2 scored 0.48 with `estimator_errors_` of **0.981 and 0.987** — they were ~98% *wrong*.

**Cause:** `SlipperBaseEstimator.predict_proba` returned `[0, prediction]`:

```python
proba = self.predict(X)                       # hard 0/1
proba = np.hstack([np.zeros(proba.shape), proba])
```

Rows didn't sum to 1 and the first column was always zero. Boosting derives its sample weights from these probabilities, so every estimator after the first was fitted against corrupted weights. It now returns the complementary probabilities.

| n_estimators | before | after (sklearn 1.9) |
|---|---|---|
| 1 | 0.98 | 0.98 |
| 3 | 0.48 | **0.963** |
| 10 | 0.48 | **0.997** |

## `random_state` didn't reach the rule learner

`SlipperClassifier(random_state=0)` produced a different model on every run. Two uncontrolled sources:

- `random.choices` / `random.randint` from **python's `random` module**, which neither `random_state` nor `np.random.seed` controls
- an unseeded `train_test_split` inside `fit`

Both now draw through `random_state`. Exposing it on the base estimator means the ensemble seeds each clone, which is how sklearn makes sub-estimators reproducible. Refitting also now reproduces a fresh fit, which it previously didn't.

## Also

`SlipperBaseEstimator` couldn't be used on its own — it indexed sample weights only set when the ensemble passed them, so a direct `fit` died with `TypeError: 'NoneType' object is not subscriptable`. It now defaults to uniform weights.

## Test plan
- [x] New `tests/slipper_test.py`: reproducibility across global RNG state, refit-equals-fresh, valid probability rows, accuracy not collapsing as rounds increase, standalone base estimator
- [x] **4 of the 5 fail on master**, on both dependency sets
- [x] 662 passed on sklearn 1.5.2 and 1.9.0

## Honest limitation

The rule learner still sometimes returns a rule that is almost entirely wrong (`estimator_errors_` near 1.0). Modern sklearn's SAMME discards those, so the ensemble is fine, but on sklearn ≤1.5's deprecated SAMME.R — which weights every estimator equally — three rounds can still dip. CI resolves sklearn ≥1.7, where SAMME.R no longer exists. Fixing the rule learner itself is a separate, deeper change I haven't attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PWG8LboAM9TsyHCxRi2Bk