### PR TITLE
Fit FIGS on data with a single feature

### DIFF
--- a/imodels/tree/figs.py
+++ b/imodels/tree/figs.py
@@ -541,6 +541,11 @@ class FIGS(BaseEstimator):
                               value_sklearn=value_sklearn,
                               n_samples_=X.shape[0])
 
+                if node.left is None and node.right is None:
+                    # a leaf splits on nothing: its feature is the -2 placeholder,
+                    # which indexes the wrong column (or raises, with one feature)
+                    return
+
                 idxs_left = X[:, node.feature] <= node.threshold
                 _annotate_node(node.left, X[idxs_left], y[idxs_left],
                                weights[idxs_left], is_classmixin)

--- a/tests/figs_test.py
+++ b/tests/figs_test.py
@@ -234,3 +234,32 @@ def test_verbose_progress_reporting():
 
     # and it round-trips as a normal parameter
     assert FIGSRegressor(verbose=1).get_params()['verbose'] == 1
+
+
+def test_single_feature_input():
+    """FIGS should fit data with one feature
+
+    Annotating the tree indexed X by the node's split feature even for leaves,
+    whose feature is the -2 placeholder. With several features that silently
+    picked the wrong column; with one it raised IndexError.
+    """
+    from imodels import FIGSClassifier, FIGSClassifierCV, FIGSRegressor
+
+    rng = np.random.RandomState(0)
+    X = rng.randn(120, 1)
+    y = (X[:, 0] > 0).astype(int)
+
+    classifier = FIGSClassifier(max_rules=5).fit(X, y)
+    assert classifier.predict(X).shape == (120,)
+    assert np.mean(classifier.predict(X) == y) > 0.9
+    assert classifier.feature_importances_.shape == (1,)
+
+    regressor = FIGSRegressor(max_rules=5).fit(X, X[:, 0])
+    assert regressor.predict(X).shape == (120,)
+
+    cv = FIGSClassifierCV(n_rules_list=[3], n_trees_list=[2], cv=2).fit(X, y)
+    assert cv.predict(X).shape == (120,)
+
+    # leaf membership and rules work too
+    assert classifier.apply(X).shape[0] == 120
+    assert len(classifier.get_rules()) > 0


### PR DESCRIPTION
Found by sweeping every model against edge-case inputs. No linked issue.

## Problem

```python
FIGSClassifier().fit(X_with_one_column, y)
IndexError: index -2 is out of bounds for axis 1 with size 1
```

Annotating the fitted tree walks every node and splits the rows by its feature:

```python
idxs_left = X[:, node.feature] <= node.threshold
```

Leaves split on nothing, so their `feature` is the `-2` placeholder. With several features that quietly indexes the second-to-last column; with one feature it's out of bounds. FIGS could not be fitted on single-feature data at all — classifier, regressor or CV.

## Fix

Stop the recursion at leaves, before the index. A leaf has no children to split rows for, so the value was never needed.

## No change for multi-feature data

The wrong column was only ever used to build row subsets for children a leaf doesn't have, so nothing downstream consumed it. Verified directly on 5-feature data — `feature_importances_`, `predict_proba` and `complexity_` are byte-identical before and after.

## Test plan
- [x] `test_single_feature_input` — classifier, regressor and CV all fit one-column data, plus `apply()` and `get_rules()` on it
- [x] Fails on master, passes here
- [x] 663 passed on sklearn 1.5.2 and 1.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PWG8LboAM9TsyHCxRi2Bk