### PR TITLE
Fit the marginal shrinkage model on a single feature

### DIFF
--- a/imodels/algebraic/marginal_shrinkage_linear_model.py
+++ b/imodels/algebraic/marginal_shrinkage_linear_model.py
@@ -116,7 +116,9 @@ class MarginalShrinkageLinearModel(BaseEstimator):
                 est_marginal.fit(X[:, i].reshape(-1, 1), y,
                                  sample_weight=sample_weight)
                 coef_marginal_.append(deepcopy(est_marginal.coef_))
-            coef_marginal_ = np.vstack(coef_marginal_).squeeze()
+            # squeeze() alone collapses a single feature's coefficient to a
+            # scalar, which then cannot be multiplied with X
+            coef_marginal_ = np.vstack(coef_marginal_).squeeze(axis=1)
 
         # evenly divide effects among features
         if self.marginal_divide_by_d:

--- a/tests/regression_test.py
+++ b/tests/regression_test.py
@@ -43,3 +43,22 @@ class TestClassRegression:
             mse = np.mean(np.square(preds - self.y_regression))
             assert mse < np.var(self.y_regression), \
                 f"mse {mse:0.3f} is no better than predicting the mean"
+
+
+def test_marginal_shrinkage_single_feature():
+    """The marginal model should fit data with one feature
+
+    Stacking the per-feature coefficients used a bare squeeze(), which collapses
+    a single coefficient to a scalar, so X @ coef raised
+    "Input operand 1 does not have enough dimensions".
+    """
+    from imodels import MarginalShrinkageLinearModelRegressor
+
+    rng = np.random.RandomState(0)
+    X = rng.randn(200, 1)
+    y = 2 * X[:, 0] + 0.1 * rng.randn(200)
+
+    model = MarginalShrinkageLinearModelRegressor().fit(X, y)
+    assert np.shape(model.coef_marginal_) == (1,)
+    assert model.predict(X).shape == (200,)
+    assert np.mean((model.predict(X) - y) ** 2) < np.var(y)


### PR DESCRIPTION
Second of two single-feature crashes found sweeping every model against edge-case inputs (the other, in FIGS, is #262). No linked issue.

## Problem

```python
MarginalShrinkageLinearModelRegressor().fit(X_with_one_column, y)
ValueError: matmul: Input operand 1 does not have enough dimensions
             (has 0, gufunc core with signature (n?,k),(k,m?)->(n?,m?))
```

The per-feature marginal coefficients are stacked and then squeezed:

```python
coef_marginal_ = np.vstack(coef_marginal_).squeeze()
```

`vstack` gives `(n_features, 1)`. A bare `squeeze()` drops **every** length-1 axis, so with one feature `(1, 1)` becomes a 0-d scalar rather than `(1,)` — and `X @ coef_marginal_` then has nothing to contract over.

## Fix

`squeeze(axis=1)` removes only the coefficient axis, leaving a 1-d array for any number of features.

## No change for multi-feature data

`coef_marginal_` and `predict` output are identical before and after on 4-feature data — for `n_features > 1` the two spellings already agreed.

## Test plan
- [x] `test_marginal_shrinkage_single_feature` — asserts the coefficient shape is `(1,)`, prediction works, and the fit beats predicting the mean
- [x] Fails on master, passes here
- [x] Verified across 1, 2 and 5 features, and with `est_main_name=None`
- [x] 663 passed on sklearn 1.5.2 and 1.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PWG8LboAM9TsyHCxRi2Bk