### PR TITLE
Reject multiclass targets in binary-only classifiers (#93)

### DIFF
--- a/imodels/algebraic/tree_gam.py
+++ b/imodels/algebraic/tree_gam.py
@@ -17,7 +17,8 @@ from tqdm import tqdm
 import imodels
 
 from sklearn.base import RegressorMixin, ClassifierMixin
-from imodels.util.arguments import decode_labels, set_feature_names_in
+from imodels.util.arguments import (check_binary_target, decode_labels,
+                                    set_feature_names_in)
 
 
 class TreeGAM(BaseEstimator):
@@ -105,6 +106,7 @@ class TreeGAM(BaseEstimator):
         self.n_features_in_ = X.shape[1]
         if isinstance(self, ClassifierMixin):
             check_classification_targets(y)
+            check_binary_target(self, y)
             self.classes_, y = np.unique(y, return_inverse=True)
 
         sample_weight = _check_sample_weight(sample_weight, X, dtype=None)

--- a/imodels/rule_list/greedy_rule_list.py
+++ b/imodels/rule_list/greedy_rule_list.py
@@ -12,7 +12,7 @@ from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.utils.validation import check_array, check_is_fitted
 from sklearn.tree import DecisionTreeClassifier
 from imodels.rule_list.rule_list import RuleList
-from imodels.util.arguments import check_fit_arguments, decode_labels
+from imodels.util.arguments import check_binary_target, check_fit_arguments, decode_labels
 
 
 class GreedyRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
@@ -44,6 +44,7 @@ class GreedyRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
         depth
             the depth of the current layer (used to recurse)
         """
+        check_binary_target(self, y)
         X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
         self.depth = 0  # reset so that refitting doesn't accumulate depth
         self.rules_ = self.fit_node_recursive(X, y, depth=0, verbose=verbose)

--- a/imodels/rule_list/one_r.py
+++ b/imodels/rule_list/one_r.py
@@ -13,7 +13,7 @@ from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
 
 from imodels import GreedyRuleListClassifier
 from imodels.rule_list.rule_list import RuleList
-from imodels.util.arguments import check_fit_arguments
+from imodels.util.arguments import check_binary_target, check_fit_arguments
 
 
 class OneRClassifier(GreedyRuleListClassifier):
@@ -27,6 +27,7 @@ class OneRClassifier(GreedyRuleListClassifier):
     def fit(self, X, y, feature_names=None):
         """Fit oneR
         """
+        check_binary_target(self, y)
         X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
 
         ms = []

--- a/imodels/rule_set/skope_rules.py
+++ b/imodels/rule_set/skope_rules.py
@@ -84,7 +84,7 @@ from sklearn.utils.multiclass import check_classification_targets, unique_labels
 from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
 
 from imodels.rule_set.rule_set import RuleSet
-from imodels.util.arguments import check_fit_arguments, decode_labels
+from imodels.util.arguments import check_binary_target, check_fit_arguments, decode_labels
 from imodels.util.rule import replace_feature_name, get_feature_dict, Rule
 from imodels.util.extract import extract_skope
 from imodels.util.score import score_precision_recall
@@ -267,6 +267,7 @@ class SkopeRulesClassifier(BaseEstimator, RuleSet, ClassifierMixin):
         self : object
             Returns self.
         """
+        check_binary_target(self, y)
         X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
         check_classification_targets(y)
         self.n_features_ = X.shape[1]

--- a/imodels/rule_set/slipper.py
+++ b/imodels/rule_set/slipper.py
@@ -1,5 +1,6 @@
 from imodels.rule_set.boosted_rules import BoostedRulesClassifier
 from imodels.rule_set.slipper_util import SlipperBaseEstimator
+from imodels.util.arguments import check_binary_target
 
 
 class SlipperClassifier(BoostedRulesClassifier):
@@ -13,3 +14,9 @@ class SlipperClassifier(BoostedRulesClassifier):
         '''
         super().__init__(estimator=SlipperBaseEstimator(), n_estimators=n_estimators, **kwargs)
         # super().__init__(n_estimators, SlipperBaseEstimator)
+
+    def fit(self, X, y, feature_names=None, **kwargs):
+        # its base estimator learns a single binary rule, so a multiclass target
+        # otherwise fails deep inside boosting with a shape mismatch
+        check_binary_target(self, y)
+        return super().fit(X, y, feature_names=feature_names, **kwargs)

--- a/imodels/tree/c45_tree/c45_tree.py
+++ b/imodels/tree/c45_tree/c45_tree.py
@@ -15,7 +15,7 @@ import pandas as pd
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.model_selection import cross_val_score
 from sklearn.utils.validation import check_array, check_is_fitted, check_X_y
-from imodels.util.arguments import check_fit_arguments, decode_labels
+from imodels.util.arguments import check_binary_target, check_fit_arguments, decode_labels
 
 from ..c45_tree.c45_utils import decision, is_numeric_feature, gain, gain_ratio, get_best_split, \
     set_as_leaf_node
@@ -139,6 +139,7 @@ class C45TreeClassifier(BaseEstimator, ClassifierMixin):
 
     def fit(self, X, y, feature_names: str = None):
         self.complexity_ = 0
+        check_binary_target(self, y)
         # X, y = check_X_y(X, y)
         X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
         self.resultType = type(y[0])

--- a/imodels/util/arguments.py
+++ b/imodels/util/arguments.py
@@ -47,6 +47,23 @@ def check_fit_arguments(model, X, y, feature_names, multi_output=False, is_class
     return X, y, model.feature_names_
 
 
+def check_binary_target(model, y):
+    """Raise if y has more than two classes, for models that only handle binary.
+
+    Without this a multiclass target is silently collapsed: the model fits, and
+    predict_proba returns two columns rather than one per class
+    (see https://github.com/csinva/imodels/issues/93).
+    """
+    n_classes = len(np.unique(y))
+    if n_classes > 2:
+        raise ValueError(
+            f"{type(model).__name__} only supports binary classification, but y "
+            f"has {n_classes} classes. Models in imodels that do support "
+            "multiclass include FIGSClassifier, GreedyTreeClassifier, "
+            "HSTreeClassifier, TaoTreeClassifier and BoostedRulesClassifier."
+        )
+
+
 def _finite_check_kwarg(allow_nan):
     """Spell the "allow NaN" option the way the installed sklearn expects.
 

--- a/readme.md
+++ b/readme.md
@@ -184,6 +184,14 @@ All of these models follow the standard sklearn estimator API, which is checked 
 | AutoML model | [AutoInterpretableClassifier️](https://csinva.io/imodels/util/automl.html)  | [AutoInterpretableRegressor️](https://csinva.io/imodels/util/automl.html) | |
 
 
+**Multiclass.** These classifiers handle more than two classes: `FIGSClassifier`,
+`GreedyTreeClassifier`, `HSTreeClassifier`, `TaoTreeClassifier`,
+`BoostedRulesClassifier`, `SLIMClassifier`, `DecisionTreeCCPClassifier` and the
+`CV` variants. The rule-set and rule-list models are binary-only and raise a
+clear error if given a multiclass target, rather than silently treating it as
+binary.
+
+
 ### Inspecting the rules a model learned
 
 Every rule-based model exposes its rules the same way, as a `pandas` DataFrame with

--- a/tests/multiclass_test.py
+++ b/tests/multiclass_test.py
@@ -1,0 +1,81 @@
+"""Multiclass support across classifiers (issue #93)."""
+
+import contextlib
+import io
+
+import numpy as np
+import pytest
+
+import imodels
+from tests.model_configs import BINARY_INPUT_MODELS, EXCLUDED_MODELS, MODEL_KWARGS
+
+# verified to produce one probability column per class
+MULTICLASS_MODELS = [
+    'BoostedRulesClassifier', 'SLIMClassifier', 'TaoTreeClassifier',
+    'FIGSClassifier', 'FIGSClassifierCV', 'HSTreeClassifier',
+    'HSTreeClassifierCV', 'GreedyTreeClassifier', 'DecisionTreeCCPClassifier',
+]
+
+# binary-only: these must say so rather than silently collapsing the target
+BINARY_ONLY_MODELS = [
+    'BayesianRuleListClassifier', 'RuleFitClassifier', 'FPLassoClassifier',
+    'GreedyRuleListClassifier', 'SkopeRulesClassifier', 'C45TreeClassifier',
+    'OneRClassifier', 'FPSkopeClassifier', 'TreeGAMClassifier',
+    'SlipperClassifier',
+]
+
+
+def _data(model_name, n_classes):
+    rng = np.random.RandomState(0)
+    X = rng.randn(150, 4)
+    if model_name in BINARY_INPUT_MODELS:
+        X = (X > 0).astype(int)
+    if n_classes == 3:
+        y = (X[:, 0] > 0).astype(int) + (X[:, 1] > 0).astype(int)
+    else:
+        y = (X[:, 0] > 0).astype(int)
+    return X, y
+
+
+def _fit(model_name, n_classes):
+    X, y = _data(model_name, n_classes)
+    model = getattr(imodels, model_name)(**MODEL_KWARGS.get(model_name, {}))
+    with contextlib.redirect_stdout(io.StringIO()):
+        model.fit(X, y)
+    return model, X, y
+
+
+@pytest.mark.parametrize('model_name', MULTICLASS_MODELS)
+def test_multiclass_models(model_name):
+    """These give one probability column per class"""
+    model, X, y = _fit(model_name, n_classes=3)
+    probs = model.predict_proba(X)
+    assert probs.shape == (len(X), 3)
+    assert np.allclose(probs.sum(axis=1), 1)
+    assert set(np.unique(model.predict(X))) <= set(np.unique(y))
+
+
+@pytest.mark.parametrize('model_name', BINARY_ONLY_MODELS)
+def test_binary_only_models_reject_multiclass(model_name):
+    """Binary-only models must raise, not silently treat y as binary"""
+    X, y = _data(model_name, n_classes=3)
+    model = getattr(imodels, model_name)(**MODEL_KWARGS.get(model_name, {}))
+    with pytest.raises(ValueError, match='binary|multiclass'):
+        with contextlib.redirect_stdout(io.StringIO()):
+            model.fit(X, y)
+
+
+@pytest.mark.parametrize('model_name', BINARY_ONLY_MODELS)
+def test_binary_only_models_still_fit_binary(model_name):
+    """The guard must not disturb the binary case"""
+    model, X, y = _fit(model_name, n_classes=2)
+    probs = model.predict_proba(X)
+    assert probs.shape == (len(X), 2)
+
+
+def test_every_classifier_is_accounted_for():
+    """A new classifier must be classified as multiclass or binary-only"""
+    registered = {m.__name__ for m in imodels.CLASSIFIERS} - set(EXCLUDED_MODELS)
+    covered = set(MULTICLASS_MODELS) | set(BINARY_ONLY_MODELS)
+    # AutoInterpretable wraps a grid search, so it follows whatever it selects
+    assert registered - covered <= {'AutoInterpretableClassifier'}


### PR DESCRIPTION
Fixes #93

## What I found

I fitted every registered classifier on a 3-class target and checked what came back:

| | models |
|---|---|
| **Support multiclass** (10) | `BoostedRules`, `SLIM`, `TaoTree`, `FIGS` (+CV), `HSTree` (+CV), `GreedyTree`, `DecisionTreeCCP`, `AutoInterpretable` |
| **Rejected clearly** (3) | `BayesianRuleList`, `RuleFit`, `FPLasso` |
| **Silently wrong** (7) | `GreedyRuleList`, `SkopeRules`, `C45Tree`, `OneR`, `FPSkope`, `TreeGAM`, `Slipper` |

That last row is the problem. Those six fit happily on 3-class data and returned a **two-column** `predict_proba` — silently collapsing the target — and `Slipper` failed deep inside boosting with `operands could not be broadcast together`. Nothing told the user their third class had been thrown away.

## Fix

A shared `check_binary_target` helper, applied to the seven. They now raise:

> `OneRClassifier only supports binary classification, but y has 3 classes. Models in imodels that do support multiclass include FIGSClassifier, GreedyTreeClassifier, HSTreeClassifier, TaoTreeClassifier and BoostedRulesClassifier.`

This deliberately does **not** implement multiclass for those models — that's a much larger piece of work per algorithm, since rule lists and rule sets are formulated around a positive class. It stops them producing quietly wrong output, and points at models that can do the job.

The readme now records which classifiers handle multiclass.

## Test plan
- [x] New `tests/multiclass_test.py`: the 9 multiclass models give one probability column per class summing to 1; the 10 binary-only models raise; **and all of them still fit binary data unchanged**, so the guard can't have broken the normal path
- [x] A coverage test so a newly registered classifier has to be categorized as one or the other
- [x] `pytest tests` — 699 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf