### PR TITLE
Make BayesianRuleList.predict agree with predict_proba

### DIFF
--- a/imodels/rule_list/bayesian_rule_list/bayesian_rule_list.py
+++ b/imodels/rule_list/bayesian_rule_list/bayesian_rule_list.py
@@ -287,12 +287,17 @@ class BayesianRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
         P = preds_d_t(X2, np.zeros((N, 1), dtype=int), self.d_star, self.theta)
         return np.vstack((1 - P, P)).T
 
-    def predict(self, X, threshold=0.1):
+    def predict(self, X, threshold=0.5):
         """Perform classification on samples in X.
 
         Parameters
         ----------
         X : array-like, shape = [n_samples, n_features]
+
+        threshold : float, default=0.5
+            Probability at or above which the positive class is predicted. The
+            default makes predict agree with predict_proba, as for any other
+            classifier; lower it to trade precision for recall.
 
         Returns
         -------

--- a/tests/brl_test.py
+++ b/tests/brl_test.py
@@ -58,3 +58,40 @@ class TestBRL(unittest.TestCase):
     #     model.fit(X_train_disc.values, y_train, feature_names=X_train_disc.columns)
     #     preds = model.predict(X_test_disc.values, threshold=0.1)
     #     print("RuleListClassifier Accuracy:", np.mean(y_test == preds), "Learned interpretable model:\n", model)
+
+
+def test_predict_agrees_with_predict_proba():
+    """predict should return the class predict_proba scores highest
+
+    The default threshold was 0.1, so on data the model cannot separate,
+    predict returned every sample as positive while predict_proba said the
+    opposite -- worse than predicting the majority class.
+    """
+    rng = np.random.RandomState(3)
+    X = (rng.randn(400, 5) > 0).astype(int)
+    y = ((X[:, 0] + 1.5 * rng.randn(400)) > 1.4).astype(int)  # weak signal
+
+    model = BayesianRuleListClassifier(
+        max_iter=2000, n_chains=1, random_state=0).fit(X, y)
+
+    probs = model.predict_proba(X)
+    expected = np.asarray(model.classes_)[np.argmax(probs, axis=1)]
+    assert np.array_equal(model.predict(X), expected)
+
+    # never worse than always guessing the majority class
+    accuracy = np.mean(model.predict(X) == y)
+    assert accuracy >= max(y.mean(), 1 - y.mean()) - 1e-9
+
+    # the threshold is still adjustable for a different operating point
+    assert np.mean(model.predict(X, threshold=0.1)) >= np.mean(model.predict(X))
+
+
+def test_learnable_task_is_unaffected():
+    """Data the model can separate predicts the same as before"""
+    rng = np.random.RandomState(3)
+    X = (rng.randn(400, 5) > 0).astype(int)
+    y = ((X[:, 0] + X[:, 1]) >= 2).astype(int)
+
+    model = BayesianRuleListClassifier(
+        max_iter=2000, n_chains=1, random_state=0).fit(X, y)
+    assert np.mean(model.predict(X) == y) > 0.9


### PR DESCRIPTION
Found by checking the classifier contract across every model on imbalanced, noisy data. No linked issue.

## Problem

`BayesianRuleListClassifier.predict` thresholded the positive-class probability at **0.1**:

```python
def predict(self, X, threshold=0.1):
    return decode_labels(self, 1 * (self.predict_proba(X)[:, 1] >= threshold))
```

Every other classifier in the package predicts the class `predict_proba` scores highest, and sklearn's contract expects the same.

This isn't a rounding difference. On data the model can't separate (~29% positives, weak signal), the two disagreed on **all 400 samples**:

| | predicted-positive rate | accuracy |
|---|---|---|
| `predict()` (threshold 0.1) | 1.000 | **0.292** |
| `argmax(predict_proba)` | 0.000 | 0.708 |
| majority-class baseline | — | 0.708 |

So `predict` returned every sample as positive and scored well below the majority baseline, while the model's own probabilities said the opposite.

## Fix

Default to 0.5, so `predict` agrees with `predict_proba`. The threshold stays a parameter for callers who want a different operating point.

After: accuracy on that data goes 0.292 → 0.708, `predict == argmax(predict_proba)`, and a learnable task still scores 1.0.

## Evidence the old default was a known nuisance

`tests/brl_test.py` already passed `threshold=0.5` explicitly to get sensible predictions:

```python
assert (np.array([M.predict(np.array([row]), threshold=0.5) for row in X]).flatten() == y).all()
```

The library's own test had to work around the default.

## Behaviour change

This changes predictions for anyone relying on the 0.1 default. That default made `predict` contradict `predict_proba`, so I think the change is right, but it is a behaviour change and worth a release note.

## Test plan
- [x] `test_predict_agrees_with_predict_proba` — agreement with `predict_proba`, never worse than the majority baseline, and the threshold still adjustable
- [x] `test_learnable_task_is_unaffected` — separable data still scores > 0.9
- [x] The first fails on master, both pass here
- [x] 671 passed on sklearn 1.5.2, 664 on 1.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PWG8LboAM9TsyHCxRi2Bk