### PR TITLE
Remember FIGS categorical features for predict (#77)

### DIFF
--- a/imodels/tree/figs.py
+++ b/imodels/tree/figs.py
@@ -328,6 +328,8 @@ class FIGS(BaseEstimator):
         # fit(verbose=...) still wins, so existing callers are unaffected
         verbose = int(self.verbose if verbose is None else verbose)
 
+        # remembered so that predict/predict_proba don't need them passed again
+        self.categorical_features_ = categorical_features
         if categorical_features is not None:
             X, self._encoder = encode_categories(X, categorical_features)
 
@@ -655,6 +657,7 @@ class FIGS(BaseEstimator):
         return s
 
     def predict(self, X, categorical_features=None, by_tree=False):
+        categorical_features = self._categorical_features(categorical_features)
         if hasattr(self, "_encoder"):
             X = self._encode_categories(
                 X, categorical_features=categorical_features, encoder_name="_encoder")
@@ -683,11 +686,18 @@ class FIGS(BaseEstimator):
 #             class_preds = (preds > 0.5).astype(int)
 #             return np.array([self.classes_[i] for i in class_preds])
 
+    def _categorical_features(self, categorical_features):
+        """Fall back on the categorical features the model was fitted with."""
+        if categorical_features is None:
+            return getattr(self, 'categorical_features_', None)
+        return categorical_features
+
     def predict_proba(self, X, categorical_features=None, use_clipped_prediction=False):
         """Predict probability for classifiers:
         Default behavior is to constrain the outputs to the range of probabilities, i.e. 0 to 1, with a sigmoid function.
         Set use_clipped_prediction=True to use prior behavior of clipping between 0 and 1 instead.
         """
+        categorical_features = self._categorical_features(categorical_features)
         if hasattr(self, "_encoder"):
             X = self._encode_categories(
                 X, categorical_features=categorical_features, encoder_name="_encoder")

--- a/readme.md
+++ b/readme.md
@@ -184,6 +184,20 @@ All of these models follow the standard sklearn estimator API, which is checked 
 | AutoML model | [AutoInterpretableClassifier️](https://csinva.io/imodels/util/automl.html)  | [AutoInterpretableRegressor️](https://csinva.io/imodels/util/automl.html) | |
 
 
+**Categorical features.** `FIGS` takes them directly — pass the column names and
+it one-hot encodes them internally, remembering them for `predict`:
+
+```python
+model = FIGSClassifier().fit(X, y, categorical_features=['pet', 'city'])
+model.predict(X)
+```
+
+Other models expect numeric input, so encode categorical columns first (e.g. with
+`sklearn.preprocessing.OneHotEncoder`, or one of the
+[discretizers](https://csinva.io/imodels/discretization/index.html) for numeric
+columns that a rule model needs binarized).
+
+
 ### Inspecting the rules a model learned
 
 Every rule-based model exposes its rules the same way, as a `pandas` DataFrame with

--- a/tests/figs_test.py
+++ b/tests/figs_test.py
@@ -234,3 +234,45 @@ def test_verbose_progress_reporting():
 
     # and it round-trips as a normal parameter
     assert FIGSRegressor(verbose=1).get_params()['verbose'] == 1
+
+
+def test_categorical_features_remembered_from_fit():
+    """predict shouldn't require re-passing categorical_features
+
+    https://github.com/csinva/imodels/issues/77: fitting with
+    categorical_features worked, but predict(X) then failed with
+    "TypeError: 'NoneType' object is not iterable" unless they were passed again.
+    """
+    import pandas as pd
+
+    from imodels import FIGSClassifier, FIGSRegressor
+
+    rng = np.random.RandomState(0)
+    X = pd.DataFrame({
+        'age': rng.randn(300),
+        'pet': rng.choice(['cat', 'dog', 'bird'], 300),
+        'city': rng.choice(['NY', 'LA'], 300),
+    })
+    y = ((X['age'] > 0) | (X['pet'] == 'dog')).astype(int)
+    categorical = ['pet', 'city']
+
+    model = FIGSClassifier(max_rules=5).fit(X, y, categorical_features=categorical)
+
+    preds = model.predict(X)                       # used to raise
+    assert preds.shape == (300,)
+    assert model.categorical_features_ == categorical
+    assert model.predict_proba(X).shape == (300, 2)
+
+    # passing them explicitly gives the same answer
+    assert np.array_equal(preds, model.predict(X, categorical_features=categorical))
+
+    # regressors too
+    regressor = FIGSRegressor(max_rules=4).fit(
+        X, X['age'], categorical_features=categorical)
+    assert regressor.predict(X).shape == (300,)
+
+    # and a purely numeric model is unaffected
+    X_num = pd.DataFrame(rng.randn(200, 3), columns=list('abc'))
+    numeric = FIGSClassifier(max_rules=4).fit(X_num, (X_num['a'] > 0).astype(int))
+    assert numeric.categorical_features_ is None
+    assert numeric.predict(X_num).shape == (200,)


### PR DESCRIPTION
Fixes #77

## Context

The answer in the thread was "you'll have to first one-hot encode them" — but FIGS has since grown direct support via `categorical_features`. It only half-worked:

```python
model = FIGSClassifier().fit(X, y, categorical_features=['pet', 'city'])
model.predict(X)
TypeError: 'NoneType' object is not iterable
```

Fitting encodes the named columns and stores the encoder, but `predict` re-encoded using whatever `categorical_features` you passed *it* — defaulting to `None`, which then failed inside the encoder with a message that gives no hint about the cause. You had to know to repeat the list on every call.

## Fix

`fit` stores the list on the model, and `predict`/`predict_proba` fall back to it. Passing it explicitly still works and gives an identical answer; a purely numeric model is unaffected (`categorical_features_` is `None`).

```python
model = FIGSClassifier().fit(X, y, categorical_features=['pet', 'city'])
model.predict(X)          # now works
model.predict_proba(X)    # and this
```

## Docs

The readme now says how categorical features are handled: FIGS takes them directly, and other models need them encoded first (`OneHotEncoder`, or the discretizers for numeric columns a rule model needs binarized). That was only recorded in this issue thread.

## Scope

This doesn't add native categorical handling to the other models — that's a per-algorithm change, and one-hot encoding remains the answer there. It makes the support FIGS already has actually usable.

## Test plan
- [x] `test_categorical_features_remembered_from_fit` — `predict`/`predict_proba` work without re-passing, explicit passing gives the same result, regressors covered, and a numeric-only model is unchanged
- [x] Test fails on master with the reported `TypeError`, passes here
- [x] `pytest tests` — 670 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf