### PR TITLE
Fix CorrelationScreenTransformer refitting and output type

### DIFF
--- a/imodels/util/transforms.py
+++ b/imodels/util/transforms.py
@@ -75,9 +75,12 @@ class CorrelationScreenTransformer(BaseEstimator, TransformerMixin):
     def __init__(self, threshold=1.0):
         # Initialize with a correlation threshold
         self.threshold = threshold
-        self.correlated_feature_sets = []
 
     def fit(self, X, y=None):
+        # started fresh each time: appending to sets kept from a previous fit
+        # would screen out features that are not correlated in this data
+        self.correlated_feature_sets = []
+
         # Check if X is a pandas DataFrame; if not, convert it to DataFrame
         if not isinstance(X, pd.DataFrame):
             X = pd.DataFrame(X)
@@ -120,7 +123,7 @@ class CorrelationScreenTransformer(BaseEstimator, TransformerMixin):
             X_transformed.iloc[:, to_remove] = 0
 
         if input_type == np.ndarray:
-            X_transformed == X_transformed.values
+            X_transformed = X_transformed.values
 
         return X_transformed
 

--- a/tests/transforms_test.py
+++ b/tests/transforms_test.py
@@ -1,0 +1,78 @@
+"""Tests for the shared transforms."""
+
+import numpy as np
+import pandas as pd
+
+from imodels.util.transforms import CorrelationScreenTransformer, FriedScale, Winsorizer
+
+
+def _correlated(seed, pair):
+    rng = np.random.RandomState(seed)
+    X = rng.randn(30, 4)
+    X[:, pair[1]] = X[:, pair[0]]
+    return X
+
+
+def test_refit_forgets_the_previous_fit():
+    """Refitting must screen the new data only
+
+    The sets of correlated features were built in __init__ and appended to by
+    fit, so refitting kept the previous data's correlations and zeroed columns
+    that are not correlated in the new data.
+    """
+    first, second = _correlated(0, (0, 1)), _correlated(1, (2, 3))
+
+    refit = CorrelationScreenTransformer()
+    refit.fit(first)
+    refit.fit(second)
+    fresh = CorrelationScreenTransformer().fit(second)
+
+    assert refit.correlated_feature_sets == fresh.correlated_feature_sets
+
+    zeroed = lambda out: [j for j in range(4) if np.all(np.asarray(out)[:, j] == 0)]
+    assert zeroed(refit.transform(second)) == zeroed(fresh.transform(second))
+
+
+def test_output_type_follows_input_type():
+    """A numpy array in gives a numpy array out
+
+    The conversion back used `==` rather than `=`, so it silently did nothing.
+    """
+    X = _correlated(0, (0, 1))
+    transformer = CorrelationScreenTransformer().fit(X)
+
+    assert isinstance(transformer.transform(X), np.ndarray)
+    assert isinstance(transformer.transform(pd.DataFrame(X)), pd.DataFrame)
+
+
+def test_correlated_columns_are_screened():
+    """The transformer still does its job: keep the first, zero the rest"""
+    X = _correlated(0, (0, 1))
+    out = np.asarray(CorrelationScreenTransformer().fit_transform(X))
+
+    assert np.all(out[:, 1] == 0)
+    assert np.allclose(out[:, 0], X[:, 0])
+    assert np.allclose(out[:, 2], X[:, 2])
+
+
+def test_winsorizer_and_friedscale_round_trip():
+    """Winsorizing clips to the requested quantiles; scaling standardises"""
+    rng = np.random.RandomState(0)
+    X = rng.randn(500, 3)
+    X[0, 0] = 100.0  # an outlier to clip
+
+    winsorizer = Winsorizer(trim_quantile=0.05)
+    winsorizer.train(X)
+    trimmed = winsorizer.trim(X)
+    assert trimmed[:, 0].max() < 100.0
+    assert trimmed.min() >= np.percentile(X, 5, axis=0).min() - 1e-9
+
+    scaler = FriedScale(winsorizer)
+    scaler.train(X)
+    scaled = scaler.scale(X)
+    assert scaled.shape == X.shape
+    # binary columns are left alone, continuous ones are rescaled
+    binary = np.c_[X[:, :2], (X[:, 2] > 0).astype(float)]
+    scaler_binary = FriedScale(None)
+    scaler_binary.train(binary)
+    assert scaler_binary.scale_multipliers[2] == 1


### PR DESCRIPTION
Found auditing `imodels/util/`. No linked issue. This transformer is used by the multitask GAM (`gam_multitask.py`).

## Two bugs

**1. Refitting kept the previous fit's correlations.** The sets were built in `__init__` and *appended to* by `fit`:

```python
def __init__(self, threshold=1.0):
    self.correlated_feature_sets = []      # created once

def fit(self, X, y=None):
    ...
    self.correlated_feature_sets.append(set([i, j]))   # appended, never reset
```

So refitting screened the union of every dataset seen. Concretely — fit on data where columns 0,1 are correlated, then refit on data where only 2,3 are:

| | correlated sets | columns zeroed |
|---|---|---|
| after refit | `[{0,1}, {2,3}]` | `[1, 3]` |
| fresh fit | `[{2,3}]` | `[3]` |

Column 1 is discarded despite being uncorrelated in the data actually fitted.

**2. The output type conversion was a no-op.**

```python
if input_type == np.ndarray:
    X_transformed == X_transformed.values     # == not =
```

The comparison result was computed and thrown away, so a numpy array in always gave a DataFrame out.

## Fix

`fit` resets the sets, and the conversion assigns. Screening behaviour is otherwise unchanged — the first of each correlated group is kept and the rest zeroed.

## Test plan
- [x] New `tests/transforms_test.py`: refit forgetting the previous fit, output type following input type, correlated columns still screened, plus coverage for `Winsorizer`/`FriedScale`, which had none
- [x] The first two fail on master, all pass here
- [x] 674 passed on sklearn 1.5.2, 667 on 1.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PWG8LboAM9TsyHCxRi2Bk