### PR TITLE
Evaluate FIGS candidate splits in parallel with n_jobs (#94)

### DIFF
--- a/imodels/tree/figs.py
+++ b/imodels/tree/figs.py
@@ -12,6 +12,7 @@ from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.model_selection import train_test_split, cross_val_score
 from sklearn.tree import plot_tree, DecisionTreeClassifier
 from sklearn.utils import check_X_y, check_array
+from joblib import Parallel, delayed
 from sklearn.utils.class_weight import compute_sample_weight
 from sklearn.utils.validation import _check_sample_weight, check_is_fitted
 
@@ -125,6 +126,7 @@ class FIGS(BaseEstimator):
         max_depth: int = None,
         class_weight=None,
         verbose: int = 0,
+        n_jobs: int = None,
     ):
         """
         Params
@@ -137,6 +139,11 @@ class FIGS(BaseEstimator):
             A node will be split if this split induces a decrease of the impurity greater than or equal to this value.
         max_features
             The number of features to consider when looking for the best split (see https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html)
+        n_jobs: int, default=None
+            Number of threads used to evaluate candidate splits, which are
+            independent of one another. None means 1; -1 uses all processors.
+            Only helps once there are several candidates to compare, i.e. on
+            larger datasets or deeper models.
         verbose: int, default=0
             Controls progress reporting while fitting. 0 is silent; 1 reports each
             rule as it is added, with the running total; 2 also prints the model
@@ -157,6 +164,7 @@ class FIGS(BaseEstimator):
         self.max_depth = max_depth
         self.class_weight = class_weight
         self.verbose = verbose
+        self.n_jobs = n_jobs
         self._init_decision_function()
         self.n_outputs = None
         self.need_to_reshape = False
@@ -171,6 +179,26 @@ class FIGS(BaseEstimator):
         """Return the leaf each sample reaches (see imodels.util.apply.apply_leaves)."""
         from imodels.util.apply import apply_leaves
         return apply_leaves(self, X)
+    def _fit_candidate_stumps(self, X, potential_splits, y_residuals_per_tree,
+                              sample_weight):
+        """Re-fit the stump for every candidate split, in parallel if asked."""
+        def fit_stump(potential_split):
+            return self._construct_node_with_stump(
+                X=X,
+                y=y_residuals_per_tree[potential_split.tree_num],
+                idxs=potential_split.idxs,
+                tree_num=potential_split.tree_num,
+                sample_weight=sample_weight,
+                max_features=self.max_features,
+                depth=potential_split.depth + 1,
+            )
+
+        n_jobs = 1 if self.n_jobs is None else self.n_jobs
+        if n_jobs == 1 or len(potential_splits) < 2:
+            return [fit_stump(split) for split in potential_splits]
+        return Parallel(n_jobs=n_jobs, backend="threading")(
+            delayed(fit_stump)(split) for split in potential_splits)
+
     def _apply_class_weight(self, y, sample_weight):
         """Fold class_weight into sample_weight, which the splits already honor."""
         if self.class_weight is None:
@@ -474,19 +502,12 @@ class FIGS(BaseEstimator):
 
             # recompute all impurities + update potential_split children
             potential_splits_new = []
-            for potential_split in potential_splits:
-                y_target = y_residuals_per_tree[potential_split.tree_num]
-
-                # re-calculate the best split
-                potential_split_updated = self._construct_node_with_stump(
-                    X=X,
-                    y=y_target,
-                    idxs=potential_split.idxs,
-                    tree_num=potential_split.tree_num,
-                    sample_weight=sample_weight,
-                    max_features=self.max_features,
-                    depth=potential_split.depth+1,
-                )
+            # each candidate's stump is fit independently of the others, and
+            # sklearn's tree builder releases the GIL, so this threads well
+            updated_splits = self._fit_candidate_stumps(
+                X, potential_splits, y_residuals_per_tree, sample_weight)
+            for potential_split, potential_split_updated in zip(
+                    potential_splits, updated_splits):
 
                 # need to preserve certain attributes from before (value at this split + is_root)
                 # value may change because residuals may have changed, but we want it to store the value from before

--- a/tests/figs_test.py
+++ b/tests/figs_test.py
@@ -263,3 +263,30 @@ def test_single_feature_input():
     # leaf membership and rules work too
     assert classifier.apply(X).shape[0] == 120
     assert len(classifier.get_rules()) > 0
+
+
+def test_n_jobs_gives_identical_models():
+    """Fitting candidate splits in parallel must not change the result
+
+    https://github.com/csinva/imodels/issues/94: FIGS used one core. Candidate
+    splits are independent, so they can be evaluated in threads.
+    """
+    from imodels import FIGSClassifier, FIGSRegressor
+
+    rng = np.random.RandomState(0)
+    X = rng.randn(2000, 10)
+    y = X[:, 0] + X[:, 1] + rng.randn(2000) * 0.3
+
+    serial = FIGSRegressor(max_rules=12).fit(X, y)
+    parallel = FIGSRegressor(max_rules=12, n_jobs=4).fit(X, y)
+    assert np.allclose(serial.predict(X), parallel.predict(X))
+    assert len(serial.trees_) == len(parallel.trees_)
+
+    y_binary = (y > 0).astype(int)
+    serial_clf = FIGSClassifier(max_rules=10).fit(X, y_binary)
+    parallel_clf = FIGSClassifier(max_rules=10, n_jobs=4).fit(X, y_binary)
+    assert np.allclose(serial_clf.predict_proba(X), parallel_clf.predict_proba(X))
+
+    # it round-trips as an ordinary parameter
+    assert FIGSRegressor(n_jobs=4).get_params()['n_jobs'] == 4
+    assert FIGSRegressor().get_params()['n_jobs'] is None


### PR DESCRIPTION
Fixes #94

## Problem

`FIGSRegressor.fit()` used one core. Profiling a 20000×20 fit shows where the time goes:

```
114 calls   0.836s   sklearn DecisionTreeRegressor._fit     <- 76%
1.4M calls  0.139s   _predict_tree_single_point
```

At each step FIGS re-fits a stump for **every** candidate split, sequentially. Those fits are independent of one another, and sklearn's tree builder is Cython that releases the GIL — I measured 8 independent stump fits on this data going from 0.210s to 0.050s (**4.2×**) with 8 threads.

## Fix

FIGS takes `n_jobs` (`None` means 1, as in sklearn), and evaluates candidate splits with a threading backend:

| | max_rules=15 | max_rules=30 | classifier, max_rules=20 |
|---|---|---|---|
| serial | 1.34s | 2.76s | 1.83s |
| `n_jobs=8` | 0.80s | 1.69s | 1.09s |
| | **1.67×** | **1.63×** | **1.67×** |

Predictions are **identical** to the serial fit in every case — asserted in the tests, not just observed.

The end-to-end gain is 1.65× rather than the 4.2× the stumps alone achieve, because the greedy loop around them is inherently sequential: only ~76% of the time is parallelizable, and the early steps have few candidates to spread. I'd rather report that honestly than quote the microbenchmark.

## Contrast with #125

I measured the same idea for hierarchical shrinkage and it doesn't work there — threads give 1.00× because that code is pure-Python recursion holding the GIL. The difference is that FIGS spends its time inside sklearn's Cython, which releases it. Details are on that issue.

## Test plan
- [x] `test_n_jobs_gives_identical_models` — serial and `n_jobs=4` produce the same predictions and tree count, for both regressor and classifier, and `n_jobs` round-trips through `get_params`
- [x] `pytest tests` — 676 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf