### PR TITLE
Keep C4.5 feature names distinct, and report the caller's names

### DIFF
--- a/imodels/tree/c45_tree/c45_tree.py
+++ b/imodels/tree/c45_tree/c45_tree.py
@@ -124,6 +124,22 @@ def shrink_node(node, reg_param, parent_val, parent_num, cum_sum, scheme, consta
     return node
 
 
+def _make_xml_safe_names(feature_names):
+    """Turn feature names into distinct, valid XML element names."""
+    safe_names = []
+    for name in feature_names:
+        safe = ''.join(c for c in str(name) if c.isalnum() or c == '_')
+        if not safe or safe[0].isdigit():
+            safe = 'X_' + safe
+        # keep names distinct after stripping the punctuation out of them
+        candidate, suffix = safe, 1
+        while candidate in safe_names:
+            candidate = f'{safe}_{suffix}'
+            suffix += 1
+        safe_names.append(candidate)
+    return safe_names
+
+
 class C45TreeClassifier(BaseEstimator, ClassifierMixin):
     """A C4.5 tree classifier.
 
@@ -146,16 +162,15 @@ class C45TreeClassifier(BaseEstimator, ClassifierMixin):
         if feature_names is None:
             self.feature_names = [f'X_{x}' for x in range(X.shape[1])]
         else:
-            # only include alphanumeric chars / replace spaces with underscores
-            self.feature_names = [''.join([i for i in x if i.isalnum()]).replace(' ', '_')
-                                  for x in feature_names]
-            self.feature_names = [
-                'X_' + x if x[0].isdigit()
-                else x
-                for x in self.feature_names
-            ]
+            # the tree is stored as XML, so names must be valid element names.
+            # They must also stay distinct: 'age (years)' and 'age-years' both
+            # reduce to 'ageyears', and the tree would then read the wrong column.
+            self.feature_names = _make_xml_safe_names(feature_names)
 
         assert len(self.feature_names) == X.shape[1]
+        # so that rules can be reported with the names the caller used
+        self.xml_name_to_feature_name_ = dict(
+            zip(self.feature_names, feature_names))
 
         data = [[] for i in range(len(self.feature_names))]
         categories = []

--- a/imodels/util/get_rules.py
+++ b/imodels/util/get_rules.py
@@ -212,6 +212,8 @@ def _rules_from_c45(model, feature_names):
 
     # flags mark how a child splits its parent: less-than, right (>=) or equal
     comparisons = {'l': '<', 'r': '>=', 'm': '=='}
+    # the tree stores XML-safe names; report the ones the caller used
+    original_names = getattr(model, 'xml_name_to_feature_name_', {})
     rows = []
 
     def walk(node, conditions):
@@ -227,8 +229,8 @@ def _rules_from_c45(model, feature_names):
             flag = child.getAttribute('flag')
             threshold = child.getAttribute('feature')
             comparison = comparisons.get(flag, flag)
-            walk(child, conditions +
-                 [f"{child.nodeName} {comparison} {threshold}"])
+            name = original_names.get(child.nodeName, child.nodeName)
+            walk(child, conditions + [f"{name} {comparison} {threshold}"])
 
     walk(dom.childNodes[0], [])
     return pd.DataFrame(rows)

--- a/tests/c45_test.py
+++ b/tests/c45_test.py
@@ -1,0 +1,51 @@
+"""Tests for the C4.5 tree, whose tree is stored as XML."""
+
+import numpy as np
+import pandas as pd
+
+from imodels import C45TreeClassifier
+
+
+def test_feature_names_that_reduce_to_the_same_string():
+    """Distinct columns must stay distinct internally
+
+    The tree is XML, so names are stripped to valid element names. Two
+    different columns could reduce to the same name, and the tree then read
+    whichever came first -- splitting on one column but testing another.
+    """
+    rng = np.random.RandomState(0)
+    X = pd.DataFrame(rng.randn(200, 4),
+                     columns=['age (years)', 'age-years', 'other', 'last'])
+    X['age (years)'] = rng.randn(200)
+    X['age-years'] = rng.randn(200) * 5 + 10
+    y = (X['age-years'] > 10).astype(int)
+
+    model = C45TreeClassifier(max_rules=4).fit(X, y)
+
+    assert len(set(model.feature_names)) == X.shape[1], 'names collided'
+    # with the columns confused this scored 0.445, below chance
+    assert np.mean(model.predict(X) == y) > 0.9
+
+
+def test_rules_report_the_original_feature_names():
+    """Reported rules should name the caller's columns, not internal ones"""
+    rng = np.random.RandomState(0)
+    X = pd.DataFrame(rng.randn(200, 3),
+                     columns=['age (years)', 'blood pressure', 'weight-kg'])
+    y = (X['age (years)'] > 0).astype(int)
+
+    rules = C45TreeClassifier(max_rules=3).fit(X, y).get_rules()
+    text = ' '.join(rules['rule'])
+    assert 'age (years)' in text
+    assert 'ageyears' not in text.replace('age (years)', '')
+
+
+def test_awkward_feature_names_are_accepted():
+    """Names starting with a digit, or with spaces, still work"""
+    rng = np.random.RandomState(0)
+    X = pd.DataFrame(rng.randn(150, 3), columns=['a b', '2bad', 'fine'])
+    y = (X['a b'] > 0).astype(int)
+
+    model = C45TreeClassifier(max_rules=3).fit(X, y)
+    assert model.predict(X).shape == (150,)
+    assert np.mean(model.predict(X) == y) > 0.9


### PR DESCRIPTION
Found by fitting every model on realistically messy column names. No linked issue.

## Problem

`C45TreeClassifier` stores its tree as XML, so it strips feature names down to valid element names:

```python
self.feature_names = [''.join([i for i in x if i.isalnum()]).replace(' ', '_') for x in feature_names]
```

Nothing kept the results **distinct**. `'age (years)'` and `'age-years'` both become `'ageyears'`, and the tree resolves a name with `self.feature_names.index(att_name)` — the *first* match. So splits learned on one column were evaluated against the other:

```
mangled names: ['ageyears', 'ageyears', 'other', 'last']
train accuracy: 0.445          # below chance, no error, no warning
```

Column names like `age (years)` and `age-years` are entirely ordinary in real data.

Separately, the stripped names leaked into output: `get_rules()` reported `ageyears < 10.08` for a column the caller knows as `age (years)`, so rules couldn't be matched back to the data.

## Fix

Sanitized names are made unique (`ageyears`, `ageyears_1`), and the mapping back to the caller's names is kept so `get_rules` reports the original.

```
internal names: ['ageyears', 'ageyears_1', 'other', 'last']
train accuracy: 1.0
rules: ['age-years < 10.08...', 'age-years >= 10.08...']
```

## Test plan
- [x] `test_feature_names_that_reduce_to_the_same_string` — names stay distinct and accuracy recovers
- [x] `test_rules_report_the_original_feature_names`
- [x] `test_awkward_feature_names_are_accepted` — names with spaces or a leading digit
- [x] First two fail on master; 710 passed on sklearn 1.5.2, 702 on 1.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PWG8LboAM9TsyHCxRi2Bk