### PR TITLE
Support multiclass classification in C4.5 (#93)

### DIFF
--- a/imodels/tree/c45_tree/c45_tree.py
+++ b/imodels/tree/c45_tree/c45_tree.py
@@ -15,7 +15,7 @@ import pandas as pd
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.model_selection import cross_val_score
 from sklearn.utils.validation import check_array, check_is_fitted, check_X_y
-from imodels.util.arguments import check_binary_target, check_fit_arguments, decode_labels
+from imodels.util.arguments import check_fit_arguments, decode_labels
 
 from ..c45_tree.c45_utils import decision, is_numeric_feature, gain, gain_ratio, get_best_split, \
     set_as_leaf_node
@@ -139,7 +139,6 @@ class C45TreeClassifier(BaseEstimator, ClassifierMixin):
 
     def fit(self, X, y, feature_names: str = None):
         self.complexity_ = 0
-        check_binary_target(self, y)
         # X, y = check_X_y(X, y)
         X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
         self.resultType = type(y[0])
@@ -229,13 +228,43 @@ class C45TreeClassifier(BaseEstimator, ClassifierMixin):
 
         return np.array(prediction)
 
+    def _class_scores(self, X):
+        """Per-class scores for each row, from the leaves it reaches.
+
+        `decision` returns {class label: probability}; C4.5 is multiclass by
+        construction, so this keeps the whole distribution rather than
+        collapsing it to the top class.
+        """
+        check_is_fitted(self, ['tree_', 'resultType', 'feature_names'])
+        X = check_array(X)
+        n_classes = len(self.classes_)
+
+        scores = np.zeros((X.shape[0], n_classes))
+        for i in range(X.shape[0]):
+            answers = decision(self.root, X[i], self.feature_names, 1) or {}
+            for label, probability in answers.items():
+                # leaves store the encoded label (0, 1, ... ) as a string
+                index = int(float(label))
+                if 0 <= index < n_classes:
+                    scores[i, index] += float(probability)
+        return scores
+
     def predict(self, X):
-        raw_preds = self.raw_preds(X)
-        return decode_labels(self, (raw_preds > np.ones_like(raw_preds) * 0.5).astype(int))
+        return decode_labels(self, np.argmax(self.predict_proba(X), axis=1))
 
     def predict_proba(self, X):
-        raw_preds = self.raw_preds(X)
-        return np.vstack((1 - raw_preds, raw_preds)).transpose()
+        if len(self.classes_) == 2:
+            # unchanged binary path: leaves hold the probability of class 1,
+            # which is also what hierarchical shrinkage rewrites them to
+            raw_preds = self.raw_preds(X)
+            return np.vstack((1 - raw_preds, raw_preds)).transpose()
+
+        scores = self._class_scores(X)
+        totals = scores.sum(axis=1, keepdims=True)
+        # a row that reached no leaf falls back to a uniform distribution
+        with np.errstate(invalid='ignore', divide='ignore'):
+            normalized = scores / totals
+        return np.where(totals > 0, normalized, 1 / scores.shape[1])
 
     def __str__(self):
         check_is_fitted(self, ['tree_'])

--- a/readme.md
+++ b/readme.md
@@ -186,8 +186,8 @@ All of these models follow the standard sklearn estimator API, which is checked 
 
 **Multiclass.** These classifiers handle more than two classes: `FIGSClassifier`,
 `GreedyTreeClassifier`, `HSTreeClassifier`, `TaoTreeClassifier`,
-`BoostedRulesClassifier`, `SLIMClassifier`, `DecisionTreeCCPClassifier` and the
-`CV` variants. The rule-set and rule-list models are binary-only and raise a
+`BoostedRulesClassifier`, `SLIMClassifier`, `C45TreeClassifier`,
+`DecisionTreeCCPClassifier` and the `CV` variants. The rule-set and rule-list models are binary-only and raise a
 clear error if given a multiclass target, rather than silently treating it as
 binary.
 

--- a/tests/multiclass_test.py
+++ b/tests/multiclass_test.py
@@ -14,12 +14,13 @@ MULTICLASS_MODELS = [
     'BoostedRulesClassifier', 'SLIMClassifier', 'TaoTreeClassifier',
     'FIGSClassifier', 'FIGSClassifierCV', 'HSTreeClassifier',
     'HSTreeClassifierCV', 'GreedyTreeClassifier', 'DecisionTreeCCPClassifier',
+    'C45TreeClassifier',
 ]
 
 # binary-only: these must say so rather than silently collapsing the target
 BINARY_ONLY_MODELS = [
     'BayesianRuleListClassifier', 'RuleFitClassifier', 'FPLassoClassifier',
-    'GreedyRuleListClassifier', 'SkopeRulesClassifier', 'C45TreeClassifier',
+    'GreedyRuleListClassifier', 'SkopeRulesClassifier',
     'OneRClassifier', 'FPSkopeClassifier', 'TreeGAMClassifier',
     'SlipperClassifier',
 ]
@@ -79,3 +80,40 @@ def test_every_classifier_is_accounted_for():
     covered = set(MULTICLASS_MODELS) | set(BINARY_ONLY_MODELS)
     # AutoInterpretable wraps a grid search, so it follows whatever it selects
     assert registered - covered <= {'AutoInterpretableClassifier'}
+
+
+def test_c45_multiclass_matches_a_cart_tree():
+    """C4.5 is multiclass by construction, so it should hold its own on 3 classes"""
+    from sklearn.datasets import load_iris, load_wine
+    from sklearn.model_selection import train_test_split
+    from sklearn.tree import DecisionTreeClassifier
+
+    from imodels import C45TreeClassifier
+
+    for load in (load_iris, load_wine):
+        X, y = load(return_X_y=True)
+        X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
+        model = C45TreeClassifier(max_rules=10).fit(X_train, y_train)
+        probs = model.predict_proba(X_test)
+
+        assert probs.shape == (len(X_test), 3)
+        assert np.allclose(probs.sum(axis=1), 1)
+        assert set(np.unique(model.predict(X_test))) <= {0, 1, 2}
+
+        cart = DecisionTreeClassifier(max_depth=4, random_state=0).fit(X_train, y_train)
+        accuracy = (model.predict(X_test) == y_test).mean()
+        assert accuracy >= (cart.predict(X_test) == y_test).mean() - 0.1
+
+
+def test_c45_multiclass_string_labels():
+    from sklearn.datasets import load_iris
+
+    from imodels import C45TreeClassifier
+
+    X, y = load_iris(return_X_y=True)
+    labels = np.array(['setosa', 'versicolor', 'virginica'])[y]
+
+    model = C45TreeClassifier(max_rules=8).fit(X, labels)
+    assert list(model.classes_) == ['setosa', 'versicolor', 'virginica']
+    assert set(np.unique(model.predict(X))) <= set(model.classes_)


### PR DESCRIPTION
Follows up #93 / #265, which made binary-only models say so. This makes one of them actually multiclass.

## Why C4.5

C4.5 is multiclass **by construction**: it splits on information gain over any number of classes, and `decision()` already returns a full `{class: probability}` distribution from the leaves. Only `predict`/`predict_proba` collapsed it:

```python
def predict(self, X):
    raw_preds = self.raw_preds(X)
    return (raw_preds > 0.5).astype(int)          # top class, thresholded

def predict_proba(self, X):
    return np.vstack((1 - raw_preds, raw_preds)).T  # always two columns
```

So the restriction was in the wrapper, not the algorithm.

## Change

`predict_proba` keeps the whole distribution when there are more than two classes:

| dataset | C4.5 | `DecisionTreeClassifier(max_depth=4)` |
|---|---|---|
| iris (3 classes) | 0.974 | 0.974 |
| wine (3 classes) | 0.933 | 0.933 |

String class labels round-trip too (`['setosa', 'versicolor', 'virginica']`).

## The binary path is deliberately untouched

My first version routed *all* cases through the new distribution code, and `shrinkage_test` failed. The cause is worth recording: `HSC45TreeClassifierCV` applies hierarchical shrinkage by rewriting C4.5's leaf values into **probabilities of class 1** — so after shrinkage a leaf holds `0.73`, not a class label, and decoding it as a label sends all the mass to class 0.

Binary therefore keeps reading leaves exactly as before, and only the multiclass case uses the new path. For two classes `argmax` over `(1 - p, p)` is identical to the old `p > 0.5`, so binary predictions are unchanged.

## Test plan
- [x] `test_c45_multiclass_matches_a_cart_tree` — 3-column probabilities summing to 1 on iris and wine, accuracy within 0.1 of CART
- [x] `test_c45_multiclass_string_labels`
- [x] C4.5 moved from the binary-only list to the multiclass list in `multiclass_test.py`, so it's now held to the multiclass contract
- [x] `pytest tests` — 708 passed, including the shrinkage tests that caught the regression above

## Remaining binary-only models

`RuleFit`/`FPLasso` (would need multinomial logistic over the rules), `SkopeRules`/`FPSkope`/`Slipper` (rule sets scoped to one positive class — one-vs-rest is the natural route), `BayesianRuleList` (binary likelihood), `TreeGAM`, `GreedyRuleList`/`OneR`, and fast-and-frugal trees, which are binary by definition. Each is a real piece of work rather than a wrapper change; happy to take one if you want to pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf