### PR TITLE
Round rule thresholds to significant digits, not decimal places

### DIFF
--- a/imodels/util/convert.py
+++ b/imodels/util/convert.py
@@ -4,6 +4,22 @@ from sklearn.tree import _tree
 from typing import Union, List, Tuple
 
 
+def _round_threshold(threshold, decimals: int = 5):
+    """Shorten a split threshold without moving it onto the data.
+
+    Rounding to a fixed number of decimal places collapses thresholds on
+    small-scale features to 0.0, which changes which rows a rule selects (and
+    can turn two distinct splits into the same one). Rounding to significant
+    digits instead keeps the threshold in the right place at any scale.
+    """
+    if threshold == 0 or not np.isfinite(threshold):
+        return threshold
+    magnitude = int(np.floor(np.log10(abs(threshold))))
+    # keep `decimals` digits after the point for values of order 1, and the
+    # equivalent precision for values that are much smaller or larger
+    return float(np.round(threshold, decimals=max(decimals, decimals - magnitude)))
+
+
 def tree_to_rules(tree: Union[DecisionTreeClassifier, DecisionTreeRegressor],
                   feature_names: List[str],
                   prediction_values: bool = False, round_thresholds=True) -> List[str]:
@@ -36,7 +52,7 @@ def tree_to_rules(tree: Union[DecisionTreeClassifier, DecisionTreeRegressor],
             symbol2 = '>'
             threshold = tree_.threshold[node]
             if round_thresholds:
-                threshold = np.round(threshold, decimals=5)
+                threshold = _round_threshold(threshold)
             text = base_name + ["{} {} {}".format(name, symbol, threshold)]
             recurse(tree_.children_left[node], text)
 

--- a/tests/convert_test.py
+++ b/tests/convert_test.py
@@ -1,0 +1,60 @@
+"""Tests for converting fitted trees into rule strings."""
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.tree import DecisionTreeClassifier
+
+from imodels.util.convert import tree_to_rules
+
+
+def _rows_selected(X, rule):
+    return int(X.eval(rule.replace(' and ', ' & ')).sum())
+
+
+@pytest.mark.parametrize('scale', [1e-6, 1e-3, 1.0, 1e3, 1e6],
+                         ids=['1e-6', '1e-3', '1', '1e3', '1e6'])
+def test_rounded_rules_select_the_same_rows(scale):
+    """Shortening a threshold must not move it onto the data
+
+    Thresholds were rounded to 5 decimal places, so on small-scale features
+    they collapsed to 0.0 and the rule selected entirely different rows -- 134
+    instead of 9 in one case.
+    """
+    rng = np.random.RandomState(0)
+    values = rng.randn(300, 2) * scale
+    y = (values[:, 0] > 0).astype(int)
+    tree = DecisionTreeClassifier(max_depth=2, random_state=0).fit(values, y)
+
+    X = pd.DataFrame(values, columns=['a', 'b'])
+    rounded = tree_to_rules(tree, ['a', 'b'], round_thresholds=True)
+    exact = tree_to_rules(tree, ['a', 'b'], round_thresholds=False)
+
+    assert len(rounded) == len(exact)
+    for short, full in zip(rounded, exact):
+        assert _rows_selected(X, short) == _rows_selected(X, full), (
+            f'{short!r} and {full!r} disagree')
+
+
+def test_thresholds_stay_short_at_ordinary_scales():
+    """The shortening should still shorten: no full float repr for normal data"""
+    rng = np.random.RandomState(0)
+    values = rng.randn(300, 2)
+    y = (values[:, 0] > 0).astype(int)
+    tree = DecisionTreeClassifier(max_depth=2, random_state=0).fit(values, y)
+
+    for rule in tree_to_rules(tree, ['a', 'b'], round_thresholds=True):
+        for token in rule.replace(' and ', ' ').split():
+            if token.replace('.', '').replace('-', '').isdigit() and '.' in token:
+                decimals = len(token.split('.')[1])
+                assert decimals <= 8, f'{token} in {rule!r} was not shortened'
+
+
+def test_tree_with_no_splits():
+    """A tree that never splits yields the catch-all rule, not a crash"""
+    rng = np.random.RandomState(0)
+    X = rng.randn(200, 3)
+    tree = DecisionTreeClassifier(max_depth=3).fit(X, np.zeros(200, dtype=int))
+
+    rules = tree_to_rules(tree, ['a', 'b', 'c'])
+    assert rules == ['a == a']


### PR DESCRIPTION
Found auditing `imodels/util/convert.py`, which every rule-based model uses to turn fitted trees into rule strings. No linked issue.

## Problem

Thresholds were shortened with a fixed number of decimal places:

```python
threshold = np.round(threshold, decimals=5)
```

On a feature measured at a small scale (proportions, rates, currency in millions) every threshold collapses to `0.0` or `-0.0`, and the rule stops describing the split it came from:

| rule (rounded) | rows selected | rows the tree splits on |
|---|---|---|
| `a <= -0.0` | 134 | 9 |
| `a > -0.0 and a <= 0.0` | 0 | 283 |

Two genuinely different splits can also round to the *same* threshold. The damage is visible end to end — `SkopeRulesClassifier` on a perfectly separable `1e-5`-scale feature learned **zero rules** and scored 0.522, and RuleFit emitted rules like `tiny <= 0.0` and `tiny <= -0.0`.

## Fix

Round to significant digits instead, so the threshold keeps its position at any scale:

```
tiny   scale: a <= 1.41556e-06
normal scale: a <= -0.000398149
huge   scale: a <= -4292.73572
```

0 of N rules select different rows at every scale tested (1e-6 through 1e6); previously 3 of 3 did at 1e-6.

## Impact on existing behaviour

Predictions on ordinary data are unchanged — verified byte-identical `predict_proba` for SkopeRules, RuleFit and BoostedRules. The only visible difference is that a rule string may carry an extra digit (`X0 <= 0.373625` rather than `X0 <= 0.37363`).

## Honest scope note

Fixing the rounding does **not** by itself make SkopeRules/RuleFit learn that `1e-5`-scale feature — their accuracy there is still 0.522, so something else in those models is also scale-sensitive (plain sklearn trees fit it perfectly). This PR fixes the rule-text bug I could isolate and verify; the remaining scale sensitivity is a separate investigation.

## Test plan
- [x] `test_rounded_rules_select_the_same_rows`, parametrized over five scales — the `1e-6` case fails on master
- [x] `test_thresholds_stay_short_at_ordinary_scales` — guards against "fixing" this by not rounding at all
- [x] `test_tree_with_no_splits` — the degenerate tree still yields its catch-all rule
- [x] 714 passed on sklearn 1.5.2, 706 on 1.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PWG8LboAM9TsyHCxRi2Bk