### PR TITLE
Give each explain_classification_errors call its own classifier

### DIFF
--- a/imodels/util/explain_errors.py
+++ b/imodels/util/explain_errors.py
@@ -9,7 +9,7 @@ import imodels
 def explain_classification_errors(X, predictions, y,
                                   feature_names: list = None,
                                   target_name: str = None,
-                                  classifier: BaseEstimator = imodels.GreedyTreeClassifier(),
+                                  classifier: BaseEstimator = None,
                                   target_one_hot_encode: bool = False,
                                   print_rules: bool = True):
     """Explains the classification errors of a model by fitting an interpretable model to them.
@@ -25,11 +25,19 @@ def explain_classification_errors(X, predictions, y,
         (n, 1) targets with integer values representing class
     feature_names
         n_features
+    classifier
+        Interpretable model fitted to the errors. A new GreedyTreeClassifier is
+        used if none is given.
 
     Returns
     -------
     model: BaseEstimator
     """
+    # built per call: a default constructed in the signature is created once at
+    # import, so every call would share and refit the same classifier
+    if classifier is None:
+        classifier = imodels.GreedyTreeClassifier()
+
     # deal with names
     if feature_names is None:
         if isinstance(X, pd.DataFrame):

--- a/tests/explain_errors_test.py
+++ b/tests/explain_errors_test.py
@@ -1,0 +1,54 @@
+"""Tests for explain_classification_errors."""
+
+import contextlib
+import io
+
+import numpy as np
+
+from imodels import GreedyTreeClassifier, explain_classification_errors
+
+
+def _case(seed, signal_column):
+    rng = np.random.RandomState(seed)
+    X = rng.randn(200, 3)
+    y = (X[:, signal_column] > 0).astype(int)
+    predictions = (X[:, signal_column] + 0.5 * rng.randn(200) > 0).astype(int)
+    return X, predictions, y
+
+
+def _explain(X, predictions, y, **kwargs):
+    with contextlib.redirect_stdout(io.StringIO()):
+        return explain_classification_errors(X, predictions, y, **kwargs)
+
+
+def test_each_call_gets_its_own_classifier():
+    """Two explanations must not share one model
+
+    The default classifier was constructed in the function signature, so it was
+    created once at import and every call refitted the same object: the first
+    explanation silently changed when the second one was made.
+    """
+    X1, p1, y1 = _case(0, 0)
+    X2, p2, y2 = _case(1, 1)
+
+    first, _ = _explain(X1, p1, y1)
+    before = first.predict(np.c_[X1, y1]).copy()
+
+    second, _ = _explain(X2, p2, y2)
+    after = first.predict(np.c_[X1, y1])
+
+    assert first is not second
+    assert np.array_equal(before, after), 'the first explanation was overwritten'
+
+
+def test_explicit_classifier_is_used():
+    X, predictions, y = _case(0, 0)
+    mine = GreedyTreeClassifier(max_depth=2)
+    returned, _ = _explain(X, predictions, y, classifier=mine)
+    assert returned is mine
+
+
+def test_returns_feature_and_target_names():
+    X, predictions, y = _case(0, 0)
+    _, columns = _explain(X, predictions, y)
+    assert list(columns) == ['X1', 'X2', 'X3', 'target']


### PR DESCRIPTION
Found auditing `imodels/util/`. No linked issue. Same bug class as the HSTree default estimator (#253) and TAO's `model_args` (#256), in a user-facing helper.

## Problem

```python
def explain_classification_errors(X, predictions, y, ...,
                                  classifier: BaseEstimator = imodels.GreedyTreeClassifier(), ...):
```

Python evaluates that default **once, at import**, so every call fits the same object:

```python
first, _  = explain_classification_errors(X1, preds1, y1)
before    = first.predict(...)
second, _ = explain_classification_errors(X2, preds2, y2)   # a different dataset
first.predict(...) == before      # False -- the first explanation changed
first is second                   # True
```

Explaining errors for two models, or two datasets, silently gives you one explanation twice — and the earlier result is destroyed even if you kept a reference to it.

## Fix

Default to `None` and construct per call. Passing your own classifier is unchanged.

## Test plan
- [x] New `tests/explain_errors_test.py`: distinct objects per call and the earlier explanation surviving (fails on master), an explicit classifier still used, and the returned column names
- [x] 710 passed on sklearn 1.5.2, 702 on 1.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PWG8LboAM9TsyHCxRi2Bk