### PR TITLE
Print the caller's feature names in CART and Bayesian rule lists

### DIFF
--- a/imodels/rule_list/bayesian_rule_list/bayesian_rule_list.py
+++ b/imodels/rule_list/bayesian_rule_list/bayesian_rule_list.py
@@ -140,6 +140,10 @@ class BayesianRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
         if not np.all((X == 1) | (X == 0)):
             raise ValueError("All numeric features must be discretized prior to fitting!")
 
+        # fall back to the DataFrame's columns when no names were passed, so the
+        # printed rule list names the caller's features rather than X_0, X_1, ...
+        if feature_names is None:
+            feature_names = getattr(self, 'feature_names_in_', None)
         self.feature_dict_ = get_feature_dict(X.shape[1], feature_names)
         self.feature_placeholders = np.array(list(self.feature_dict_.keys()))
         self.feature_names = np.array(list(self.feature_dict_.values()))

--- a/imodels/tree/cart_wrapper.py
+++ b/imodels/tree/cart_wrapper.py
@@ -39,6 +39,7 @@ class GreedyTreeClassifier(DecisionTreeClassifier):
             Fitted estimator.
         """
         X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
+        self.feature_names = list(feature_names)
         classes = self.classes_  # super().fit overwrites this with the encoded labels
         names_in = getattr(self, 'feature_names_in_', None)
         super().fit(X, y, sample_weight=sample_weight, check_input=check_input)

--- a/tests/printed_model_test.py
+++ b/tests/printed_model_test.py
@@ -1,0 +1,55 @@
+"""Printing a model should name the caller's features."""
+
+import numpy as np
+import pandas as pd
+
+import imodels
+
+FEATURE_NAMES = ['age', 'bmi', 'bp', 'chol']
+
+
+def _frame(binary=False):
+    rng = np.random.RandomState(0)
+    X = pd.DataFrame(rng.randn(200, 4), columns=FEATURE_NAMES)
+    if binary:
+        X = (X > 0).astype(int)
+    return X, (X['age'] > (0.5 if binary else 0)).astype(int)
+
+
+def test_greedy_tree_prints_feature_names():
+    """The classifier printed feature_0 despite knowing the column names
+
+    The regressor stored self.feature_names and passed it to export_text; the
+    classifier never did, so export_text generated its own placeholders.
+    """
+    X, y = _frame()
+    printed = str(imodels.GreedyTreeClassifier(max_leaf_nodes=3).fit(X, y))
+
+    assert 'age' in printed
+    assert 'feature_0' not in printed
+
+    # numpy input still prints something sensible
+    numpy_printed = str(imodels.GreedyTreeClassifier(
+        max_leaf_nodes=3).fit(X.to_numpy(), y))
+    assert 'X0' in numpy_printed or 'feature_0' in numpy_printed
+
+
+def test_bayesian_rule_list_prints_feature_names():
+    """BRL discarded DataFrame columns and printed X_0, X_1, ..."""
+    X, y = _frame(binary=True)
+    model = imodels.BayesianRuleListClassifier(
+        max_iter=2000, n_chains=1, random_state=0).fit(X, y)
+
+    printed = str(model)
+    assert 'age' in printed
+    assert 'X_0' not in printed
+    assert any('age' in str(rule) for rule in model.rules_)
+
+
+def test_explicit_feature_names_still_win():
+    """Names passed to fit take precedence over the frame's columns"""
+    X, y = _frame(binary=True)
+    names = ['a1', 'a2', 'a3', 'a4']
+    model = imodels.BayesianRuleListClassifier(
+        max_iter=2000, n_chains=1, random_state=0).fit(X, y, feature_names=names)
+    assert 'a1' in str(model)


### PR DESCRIPTION
Found by printing every model fitted on a named DataFrame. No linked issue.

## Problem

Two models printed positional placeholders instead of the columns they were fitted on. For a package whose purpose is interpretable models, an unreadable printout is a real defect.

**`GreedyTreeClassifier`**

```
|--- feature_0 <= -0.00
|   |--- weights: [115.00, 0.00] class: 0
```

`__str__` passes `self.feature_names` to `export_text`, but only the *regressor* ever set that attribute — the classifier left it unset, so `export_text` generated its own names. (`feature_names_in_` was correctly populated the whole time.)

**`BayesianRuleListClassifier`**

```
IF X_0 > 0.5 THEN probability of class 1: 98.9% (95.8%-100.0%)
```

It used feature names only when passed explicitly to `fit`, ignoring the DataFrame's columns. The placeholders also ended up in `rules_`, so `get_rules()` couldn't be matched back to the data.

## After

```
|--- age <= -0.00
|   |--- weights: [115.00, 0.00] class: 0

IF age > 0.5 THEN probability of class 1: 98.9% (95.8%-100.0%)
```

Numpy input still falls back to positional names, and names passed to `fit` still take precedence over the frame's columns.

## Test plan
- [x] New `tests/printed_model_test.py` — both name tests fail on master, pass here
- [x] Covers the numpy fallback and the explicit-`feature_names` precedence, so neither regresses
- [x] 710 passed on sklearn 1.5.2, 702 on 1.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PWG8LboAM9TsyHCxRi2Bk