### PR TITLE
Let SkopeRules learn rules on data with few features

### DIFF
--- a/imodels/util/score.py
+++ b/imodels/util/score.py
@@ -45,8 +45,10 @@ def score_precision_recall(X,
             columns=np.array(feature_names)[curr_features_to_use]
         )
 
-        if X_oob.shape[1] <= 1:  # otherwise pandas bug (cf. issue #16363)
-            return []
+        # a guard for pandas issue #16363 used to skip estimators that use a
+        # single feature, and did so with `return []`, discarding every rule
+        # scored so far. That pandas bug is long fixed, and on data with few
+        # features every estimator uses one feature, so no rules survived.
 
         y_oob = y[mask]
         y_oob = np.array((y_oob != 0))

--- a/tests/skope_rules_test.py
+++ b/tests/skope_rules_test.py
@@ -161,3 +161,47 @@ def test_performances():
     assert y_pred.shape == (n_samples,)
     # training set performance
     assert accuracy_score(y, y_pred) > 0.83
+
+
+def test_learns_rules_with_few_features():
+    """SkopeRules found no rules at all on data with only a couple of features
+
+    Rule scoring skipped any estimator that used a single feature, as a
+    workaround for a long-fixed pandas bug, and did so with `return []` --
+    discarding every rule scored so far. With few features every estimator uses
+    one feature, so nothing survived.
+    """
+    import numpy as np
+    import pandas as pd
+
+    from imodels import SkopeRulesClassifier
+
+    rng = np.random.RandomState(0)
+    for n_features in (1, 2, 3):
+        X = pd.DataFrame(rng.randn(400, n_features),
+                         columns=[f'f{i}' for i in range(n_features)])
+        y = (X['f0'] > 0).astype(int)
+
+        model = SkopeRulesClassifier(
+            max_depth=2, random_state=0, precision_min=0.3,
+            max_depth_duplication=1).fit(X, y)
+
+        assert len(model.rules_) > 0, f'no rules with {n_features} feature(s)'
+        assert np.mean(model.predict(X) == y) > 0.9
+
+
+def test_fpskope_learns_rules_with_few_features():
+    """FPSkope shares the same rule scorer"""
+    import numpy as np
+    import pandas as pd
+
+    from imodels import FPSkopeClassifier
+
+    rng = np.random.RandomState(0)
+    X = (pd.DataFrame(rng.randn(400, 3), columns=list('abc')) > 0).astype(int)
+    y = (X['a'] > 0).astype(int)
+
+    model = FPSkopeClassifier(random_state=0, recall_min=0.3, precision_min=0.3,
+                              max_depth_duplication=1).fit(X, y)
+    assert len(model.rules_) > 0
+    assert np.mean(model.predict(X) == y) > 0.9


### PR DESCRIPTION
Found auditing `imodels/util/score.py`. No linked issue.

## Problem

`SkopeRulesClassifier` learned **zero rules** on perfectly separable two-feature data, scoring 0.560:

```
1 feature : 0 rules, acc 0.560
2 features: 0 rules, acc 0.560
3 features: 0 rules, acc 0.560
```

In `score_precision_recall`:

```python
if X_oob.shape[1] <= 1:  # otherwise pandas bug (cf. issue #16363)
    return []
```

Two problems in one line:

1. **`return []` exits the whole function**, discarding every rule already scored from previous estimators and abandoning the ones not yet visited. Even one degenerate estimator among many wipes out the entire model.
2. The guard fires far more often than intended. Each estimator is fitted on a subset of features, so with few features in total **every** estimator uses one feature — I confirmed all 10 estimator rule-groups were skipped, leaving 0 scored rules.

`FPSkopeClassifier` shares this scorer and had the same problem.

## Fix

The pandas bug being guarded against was fixed years ago — `df.query()` on a single-column frame works fine on pandas 2.x — so the guard is removed rather than repaired.

```
1 feature : 1 rule,  acc 1.000
2 features: 3 rules, acc 0.975
3 features: 3 rules, acc 0.925
6 features: 2 rules, acc 1.000
```

## No change on wider data

Rules and `predict_proba` are byte-identical before and after on 8-feature data — the guard simply never fired there.

## Note on the fix I first tried

My first change was `continue` instead of `return []`, which fixes the "discards everything" half. It didn't help here, because with few features *every* estimator is skipped. Checking the actual pandas behaviour showed the guard itself was obsolete.

## Test plan
- [x] `test_learns_rules_with_few_features` (1, 2 and 3 features) — fails on master
- [x] `test_fpskope_learns_rules_with_few_features`
- [x] 709 passed on sklearn 1.5.2, 701 on 1.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PWG8LboAM9TsyHCxRi2Bk