### PR TITLE
Stop MDLPDiscretizer from using a removed pandas internal

### DIFF
--- a/imodels/discretization/mdlp.py
+++ b/imodels/discretization/mdlp.py
@@ -56,7 +56,10 @@ class MDLPDiscretizer(object):
             if missing:
                 print('WARNING: user-specified features %s not in input dataframe' % str(missing))
         else:  # then we need to recognize which features are numeric
-            numeric_cols = self._data_raw._data.get_numeric_data().items
+            # _data is a private pandas internal, deprecated in pandas 2 and
+            # removed in pandas 3; select_dtypes is the public equivalent
+            numeric_cols = self._data_raw.select_dtypes(
+                include=[np.number]).columns
             self._features = [f for f in numeric_cols if f != class_label]
         # other features that won't be discretized
         self._ignored_features = set(self._data_raw.columns) - set(self._features)

--- a/tests/mdlp_test.py
+++ b/tests/mdlp_test.py
@@ -1,0 +1,50 @@
+"""Tests for the MDLP discretizer."""
+
+import contextlib
+import io
+
+import numpy as np
+import pandas as pd
+
+from imodels.discretization.mdlp import MDLPDiscretizer
+
+
+def _frame(with_text_column=False):
+    rng = np.random.RandomState(0)
+    X = pd.DataFrame(rng.randn(200, 3), columns=list('abc'))
+    X['target'] = (X['a'] > 0).astype(int)
+    if with_text_column:
+        X['label'] = ['x', 'y'] * 100
+    return X
+
+
+def _build(frame):
+    with contextlib.redirect_stdout(io.StringIO()):  # it logs while discretizing
+        return MDLPDiscretizer(dataset=frame, class_label='target')
+
+
+def test_selects_numeric_features_without_private_pandas_apis():
+    """Numeric columns were found via DataFrame._data
+
+    That is a pandas internal: deprecated in pandas 2 and removed in pandas 3,
+    where constructing the discretizer failed outright with
+    AttributeError: 'DataFrame' object has no attribute '_data'.
+    """
+    discretizer = _build(_frame())
+    assert sorted(discretizer._features) == ['a', 'b', 'c']
+
+
+def test_non_numeric_columns_are_left_alone():
+    discretizer = _build(_frame(with_text_column=True))
+    assert sorted(discretizer._features) == ['a', 'b', 'c']
+    assert 'label' in discretizer._ignored_features
+    assert 'target' in discretizer._ignored_features
+
+
+def test_explicit_features_still_honored():
+    discretizer = _build(_frame())
+    explicit = MDLPDiscretizer.__new__(MDLPDiscretizer)
+    with contextlib.redirect_stdout(io.StringIO()):
+        explicit.__init__(dataset=_frame(), class_label='target', features=['a'])
+    assert list(explicit._features) == ['a']
+    assert 'b' in explicit._ignored_features


### PR DESCRIPTION
Found auditing `imodels/discretization/`. No linked issue.

## Problem

`MDLPDiscretizer` discovered its numeric columns through a **private pandas internal**:

```python
numeric_cols = self._data_raw._data.get_numeric_data().items
```

`DataFrame._data` is deprecated in pandas 2 (it emits `DeprecationWarning: DataFrame._data is deprecated`) and **removed in pandas 3**:

```
pandas 3.0.5: AttributeError: 'DataFrame' object has no attribute '_data'
```

So the discretizer cannot be constructed at all on pandas 3. Since CI resolves the latest dependencies (`uv sync --upgrade`), this affects a supported environment today, not a hypothetical future one.

## Fix

`select_dtypes(include=[np.number])` is the public equivalent. Verified identical behaviour on **pandas 2.3.2 and 3.0.5**, including that non-numeric columns are correctly left out:

```
pandas 2.3.2: features ['a','b','c'] | mixed dtypes -> ignored ['label','target']
pandas 3.0.5: features ['a','b','c'] | mixed dtypes -> ignored ['label','target']
```

## Test plan
- [x] New `tests/mdlp_test.py`: numeric-column selection, non-numeric columns ignored, explicit `features=` still honoured
- [x] On master these **pass under pandas 2 and fail under pandas 3** — the version-dependent signature of this bug. They pass under both here
- [x] 710 passed on sklearn 1.5.2 / pandas 2.3.2, 702 on sklearn 1.9.0 / pandas 3.0.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PWG8LboAM9TsyHCxRi2Bk