### PR TITLE
Remove the Colab demo link from the readme (#197)

### DIFF
--- a/docs/algebraic/marginal_shrinkage_linear_model.html
+++ b/docs/algebraic/marginal_shrinkage_linear_model.html
@@ -139,7 +139,9 @@ class MarginalShrinkageLinearModel(BaseEstimator):
                 est_marginal.fit(X[:, i].reshape(-1, 1), y,
                                  sample_weight=sample_weight)
                 coef_marginal_.append(deepcopy(est_marginal.coef_))
-            coef_marginal_ = np.vstack(coef_marginal_).squeeze()
+            # squeeze() alone collapses a single feature&#39;s coefficient to a
+            # scalar, which then cannot be multiplied with X
+            coef_marginal_ = np.vstack(coef_marginal_).squeeze(axis=1)
 
         # evenly divide effects among features
         if self.marginal_divide_by_d:
@@ -1010,7 +1012,9 @@ Random seed</p></div>
                 est_marginal.fit(X[:, i].reshape(-1, 1), y,
                                  sample_weight=sample_weight)
                 coef_marginal_.append(deepcopy(est_marginal.coef_))
-            coef_marginal_ = np.vstack(coef_marginal_).squeeze()
+            # squeeze() alone collapses a single feature&#39;s coefficient to a
+            # scalar, which then cannot be multiplied with X
+            coef_marginal_ = np.vstack(coef_marginal_).squeeze(axis=1)
 
         # evenly divide effects among features
         if self.marginal_divide_by_d:

--- a/docs/algebraic/tree_gam.html
+++ b/docs/algebraic/tree_gam.html
@@ -40,7 +40,8 @@ from tqdm import tqdm
 import imodels
 
 from sklearn.base import RegressorMixin, ClassifierMixin
-from imodels.util.arguments import decode_labels, set_feature_names_in
+from imodels.util.arguments import (check_binary_target, decode_labels,
+                                    set_feature_names_in)
 
 
 class TreeGAM(BaseEstimator):
@@ -128,6 +129,7 @@ class TreeGAM(BaseEstimator):
         self.n_features_in_ = X.shape[1]
         if isinstance(self, ClassifierMixin):
             check_classification_targets(y)
+            check_binary_target(self, y)
             self.classes_, y = np.unique(y, return_inverse=True)
 
         sample_weight = _check_sample_weight(sample_weight, X, dtype=None)
@@ -579,6 +581,7 @@ Random seed.</p></div>
         self.n_features_in_ = X.shape[1]
         if isinstance(self, ClassifierMixin):
             check_classification_targets(y)
+            check_binary_target(self, y)
             self.classes_, y = np.unique(y, return_inverse=True)
 
         sample_weight = _check_sample_weight(sample_weight, X, dtype=None)
@@ -883,6 +886,7 @@ Random seed.</p></div>
     self.n_features_in_ = X.shape[1]
     if isinstance(self, ClassifierMixin):
         check_classification_targets(y)
+        check_binary_target(self, y)
         self.classes_, y = np.unique(y, return_inverse=True)
 
     sample_weight = _check_sample_weight(sample_weight, X, dtype=None)

--- a/docs/discretization/discretizer.html
+++ b/docs/discretization/discretizer.html
@@ -104,6 +104,9 @@ class AbstractDiscretizer(TransformerMixin, BaseEstimator):
     def _validate_n_bins(self):
         &#34;&#34;&#34;
         Check if n_bins argument is valid.
+
+        Stores the per-feature bin counts in n_bins_, leaving the n_bins
+        constructor parameter as the caller set it.
         &#34;&#34;&#34;
         orig_bins = self.n_bins
         n_features = len(self.dcols_)
@@ -122,7 +125,7 @@ class AbstractDiscretizer(TransformerMixin, BaseEstimator):
                         AbstractDiscretizer.__name__, orig_bins
                     )
                 )
-            self.n_bins = np.full(n_features, orig_bins, dtype=int)
+            self.n_bins_ = np.full(n_features, orig_bins, dtype=int)
         else:
             n_bins = check_array(orig_bins, dtype=int,
                                  copy=True, ensure_2d=False)
@@ -143,7 +146,7 @@ class AbstractDiscretizer(TransformerMixin, BaseEstimator):
                         AbstractDiscretizer.__name__, indices
                     )
                 )
-            self.n_bins = n_bins
+            self.n_bins_ = n_bins
 
     def _validate_dcols(self, X):
         &#34;&#34;&#34;
@@ -540,7 +543,7 @@ class BasicDiscretizer(AbstractDiscretizer):
         self._fit_preprocessing(X)
 
         # apply KBinsDiscretizer to the selected columns
-        discretizer = KBinsDiscretizer(n_bins=self.n_bins,
+        discretizer = KBinsDiscretizer(n_bins=self.n_bins_,
                                        encode=&#39;ordinal&#39;,
                                        strategy=self.strategy)
 
@@ -556,12 +559,12 @@ class BasicDiscretizer(AbstractDiscretizer):
 
         # fix KBinsDiscretizer errors if any when strategy = &#34;quantile&#34;
         if self.strategy == &#34;quantile&#34;:
-            err_idx = np.where(discretized_df.nunique() != self.n_bins)[0]
+            err_idx = np.where(discretized_df.nunique() != self.n_bins_)[0]
             self.manual_discretizer_ = dict()
             for idx in err_idx:
                 col = self.dcols_[idx]
                 if X[col].nunique() &gt; 1:
-                    q_values = np.linspace(0, 1, self.n_bins[idx] + 1)
+                    q_values = np.linspace(0, 1, self.n_bins_[idx] + 1)
                     bin_edges = np.quantile(X[col], q_values)
                     discretized_df[col] = self._discretize_to_bins(X[col], bin_edges,
                                                                    keep_pointwise_bins=True)
@@ -825,7 +828,7 @@ class RFDiscretizer(AbstractDiscretizer):
         self._fit_rf(X=X, y=y)
 
         # get total number of bins to reallocate
-        total_bins = self.n_bins.sum()
+        total_bins = np.asarray(self.n_bins_).sum()
 
         # reweight n_bins
         if by == &#34;nsplits&#34;:
@@ -869,7 +872,7 @@ class RFDiscretizer(AbstractDiscretizer):
         if len(self.missing_rf_cols_) &gt; 0:
             print(&#34;{} did not appear in random forest so were discretized via {} discretization&#34;
                   .format(self.missing_rf_cols_, self.strategy))
-            missing_n_bins = np.array([self.n_bins[np.array(self.dcols_) == col][0]
+            missing_n_bins = np.array([self.n_bins_[np.array(self.dcols_) == col][0]
                                        for col in self.missing_rf_cols_])
 
             backup_discretizer = BasicDiscretizer(n_bins=missing_n_bins,
@@ -893,7 +896,7 @@ class RFDiscretizer(AbstractDiscretizer):
         for col in self.dcols_:
             if col in self.rf_splits.keys():
                 # .item(): numpy no longer converts a size-1 array to a scalar
-                b = self.n_bins[np.array(self.dcols_) == col].item()
+                b = self.n_bins_[np.array(self.dcols_) == col].item()
                 if self.strategy == &#34;quantile&#34;:
                     q_values = np.linspace(0, 1, int(b) + 1)
                     bin_edges = np.quantile(self.rf_splits[col], q_values)
@@ -1070,6 +1073,9 @@ per feature when encode = "onehot".</p>
     def _validate_n_bins(self):
         &#34;&#34;&#34;
         Check if n_bins argument is valid.
+
+        Stores the per-feature bin counts in n_bins_, leaving the n_bins
+        constructor parameter as the caller set it.
         &#34;&#34;&#34;
         orig_bins = self.n_bins
         n_features = len(self.dcols_)
@@ -1088,7 +1094,7 @@ per feature when encode = "onehot".</p>
                         AbstractDiscretizer.__name__, orig_bins
                     )
                 )
-            self.n_bins = np.full(n_features, orig_bins, dtype=int)
+            self.n_bins_ = np.full(n_features, orig_bins, dtype=int)
         else:
             n_bins = check_array(orig_bins, dtype=int,
                                  copy=True, ensure_2d=False)
@@ -1109,7 +1115,7 @@ per feature when encode = "onehot".</p>
                         AbstractDiscretizer.__name__, indices
                     )
                 )
-            self.n_bins = n_bins
+            self.n_bins_ = n_bins
 
     def _validate_dcols(self, X):
         &#34;&#34;&#34;
@@ -1438,7 +1444,7 @@ or no errors in KBinsDiscretizer().</dd>
         self._fit_preprocessing(X)
 
         # apply KBinsDiscretizer to the selected columns
-        discretizer = KBinsDiscretizer(n_bins=self.n_bins,
+        discretizer = KBinsDiscretizer(n_bins=self.n_bins_,
                                        encode=&#39;ordinal&#39;,
                                        strategy=self.strategy)
 
@@ -1454,12 +1460,12 @@ or no errors in KBinsDiscretizer().</dd>
 
         # fix KBinsDiscretizer errors if any when strategy = &#34;quantile&#34;
         if self.strategy == &#34;quantile&#34;:
-            err_idx = np.where(discretized_df.nunique() != self.n_bins)[0]
+            err_idx = np.where(discretized_df.nunique() != self.n_bins_)[0]
             self.manual_discretizer_ = dict()
             for idx in err_idx:
                 col = self.dcols_[idx]
                 if X[col].nunique() &gt; 1:
-                    q_values = np.linspace(0, 1, self.n_bins[idx] + 1)
+                    q_values = np.linspace(0, 1, self.n_bins_[idx] + 1)
                     bin_edges = np.quantile(X[col], q_values)
                     discretized_df[col] = self._discretize_to_bins(X[col], bin_edges,
                                                                    keep_pointwise_bins=True)
@@ -1565,7 +1571,7 @@ or no errors in KBinsDiscretizer().</dd>
     self._fit_preprocessing(X)
 
     # apply KBinsDiscretizer to the selected columns
-    discretizer = KBinsDiscretizer(n_bins=self.n_bins,
+    discretizer = KBinsDiscretizer(n_bins=self.n_bins_,
                                    encode=&#39;ordinal&#39;,
                                    strategy=self.strategy)
 
@@ -1581,12 +1587,12 @@ or no errors in KBinsDiscretizer().</dd>
 
     # fix KBinsDiscretizer errors if any when strategy = &#34;quantile&#34;
     if self.strategy == &#34;quantile&#34;:
-        err_idx = np.where(discretized_df.nunique() != self.n_bins)[0]
+        err_idx = np.where(discretized_df.nunique() != self.n_bins_)[0]
         self.manual_discretizer_ = dict()
         for idx in err_idx:
             col = self.dcols_[idx]
             if X[col].nunique() &gt; 1:
-                q_values = np.linspace(0, 1, self.n_bins[idx] + 1)
+                q_values = np.linspace(0, 1, self.n_bins_[idx] + 1)
                 bin_edges = np.quantile(X[col], q_values)
                 discretized_df[col] = self._discretize_to_bins(X[col], bin_edges,
                                                                keep_pointwise_bins=True)
@@ -2274,7 +2280,7 @@ in missing_rf_cols_</dd>
         self._fit_rf(X=X, y=y)
 
         # get total number of bins to reallocate
-        total_bins = self.n_bins.sum()
+        total_bins = np.asarray(self.n_bins_).sum()
 
         # reweight n_bins
         if by == &#34;nsplits&#34;:
@@ -2318,7 +2324,7 @@ in missing_rf_cols_</dd>
         if len(self.missing_rf_cols_) &gt; 0:
             print(&#34;{} did not appear in random forest so were discretized via {} discretization&#34;
                   .format(self.missing_rf_cols_, self.strategy))
-            missing_n_bins = np.array([self.n_bins[np.array(self.dcols_) == col][0]
+            missing_n_bins = np.array([self.n_bins_[np.array(self.dcols_) == col][0]
                                        for col in self.missing_rf_cols_])
 
             backup_discretizer = BasicDiscretizer(n_bins=missing_n_bins,
@@ -2342,7 +2348,7 @@ in missing_rf_cols_</dd>
         for col in self.dcols_:
             if col in self.rf_splits.keys():
                 # .item(): numpy no longer converts a size-1 array to a scalar
-                b = self.n_bins[np.array(self.dcols_) == col].item()
+                b = self.n_bins_[np.array(self.dcols_) == col].item()
                 if self.strategy == &#34;quantile&#34;:
                     q_values = np.linspace(0, 1, int(b) + 1)
                     bin_edges = np.quantile(self.rf_splits[col], q_values)
@@ -2466,7 +2472,7 @@ rf_model = None or rf_model has not yet been fitted</dd>
     if len(self.missing_rf_cols_) &gt; 0:
         print(&#34;{} did not appear in random forest so were discretized via {} discretization&#34;
               .format(self.missing_rf_cols_, self.strategy))
-        missing_n_bins = np.array([self.n_bins[np.array(self.dcols_) == col][0]
+        missing_n_bins = np.array([self.n_bins_[np.array(self.dcols_) == col][0]
                                    for col in self.missing_rf_cols_])
 
         backup_discretizer = BasicDiscretizer(n_bins=missing_n_bins,
@@ -2490,7 +2496,7 @@ rf_model = None or rf_model has not yet been fitted</dd>
     for col in self.dcols_:
         if col in self.rf_splits.keys():
             # .item(): numpy no longer converts a size-1 array to a scalar
-            b = self.n_bins[np.array(self.dcols_) == col].item()
+            b = self.n_bins_[np.array(self.dcols_) == col].item()
             if self.strategy == &#34;quantile&#34;:
                 q_values = np.linspace(0, 1, int(b) + 1)
                 bin_edges = np.quantile(self.rf_splits[col], q_values)
@@ -2580,7 +2586,7 @@ number of RF splits using that feature</p>
     self._fit_rf(X=X, y=y)
 
     # get total number of bins to reallocate
-    total_bins = self.n_bins.sum()
+    total_bins = np.asarray(self.n_bins_).sum()
 
     # reweight n_bins
     if by == &#34;nsplits&#34;:

--- a/docs/discretization/mdlp.html
+++ b/docs/discretization/mdlp.html
@@ -83,7 +83,10 @@ class MDLPDiscretizer(object):
             if missing:
                 print(&#39;WARNING: user-specified features %s not in input dataframe&#39; % str(missing))
         else:  # then we need to recognize which features are numeric
-            numeric_cols = self._data_raw._data.get_numeric_data().items
+            # _data is a private pandas internal, deprecated in pandas 2 and
+            # removed in pandas 3; select_dtypes is the public equivalent
+            numeric_cols = self._data_raw.select_dtypes(
+                include=[np.number]).columns
             self._features = [f for f in numeric_cols if f != class_label]
         # other features that won&#39;t be discretized
         self._ignored_features = set(self._data_raw.columns) - set(self._features)
@@ -784,7 +787,10 @@ if !None, features that the user wants to discretize specifically</p></div>
             if missing:
                 print(&#39;WARNING: user-specified features %s not in input dataframe&#39; % str(missing))
         else:  # then we need to recognize which features are numeric
-            numeric_cols = self._data_raw._data.get_numeric_data().items
+            # _data is a private pandas internal, deprecated in pandas 2 and
+            # removed in pandas 3; select_dtypes is the public equivalent
+            numeric_cols = self._data_raw.select_dtypes(
+                include=[np.number]).columns
             self._features = [f for f in numeric_cols if f != class_label]
         # other features that won&#39;t be discretized
         self._ignored_features = set(self._data_raw.columns) - set(self._features)

--- a/docs/index.html
+++ b/docs/index.html
@@ -123,6 +123,11 @@ Prediction is made by looking at the value in the appropriate leaf of the tree
 <td>Uses CART to fit a list (only a single path), rather than a tree</td>
 </tr>
 <tr>
+<td style="text-align: left;">Fast-and-frugal tree</td>
+<td><a href="https://csinva.io/imodels/rule_list/fast_frugal_tree.html">FastFrugalTreeClassifier</a></td>
+<td></td>
+</tr>
+<tr>
 <td style="text-align: left;">OneR rule list</td>
 <td><a href="https://csinva.io/imodels/rule_list/one_r.html">🗂️</a>, <a href="https://link.springer.com/article/10.1023/A:1022631118932">📄</a></td>
 <td>Fits rule list restricted to only one feature</td>
@@ -185,7 +190,7 @@ Prediction is made by looking at the value in the appropriate leaf of the tree
 </tbody>
 </table>
 <h2 id="demo-notebooks">Demo notebooks</h2>
-<p>Demos are contained in the <a href="notebooks">notebooks</a> folder.</p>
+<p>Demos are contained in the <a href="notebooks">notebooks</a> folder. (The standalone Colab notebook has been retired; please refer to the demos below, which are kept up to date with the package.)</p>
 <details>
 <summary><a href="https://github.com/csinva/imodels/blob/master/notebooks/imodels_demo.ipynb">Quickstart demo</a></summary>
 Shows how to fit, predict, and visualize with different interpretable models
@@ -193,10 +198,6 @@ Shows how to fit, predict, and visualize with different interpretable models
 <details>
 <summary><a href="https://auto.gluon.ai/dev/tutorials/tabular_prediction/tabular-interpretability.html">Autogluon demo</a></summary>
 Fit/select an interpretable model automatically using Autogluon AutoML
-</details>
-<details>
-<summary><a href="https://colab.research.google.com/drive/1WfqvSjegygT7p0gyqiWpRpiwz2ePtiao#scrollTo=bLnLknIuoWtQ">Quickstart colab demo</a> <a href="https://colab.research.google.com/drive/1WfqvSjegygT7p0gyqiWpRpiwz2ePtiao#scrollTo=bLnLknIuoWtQ"> <img src="https://colab.research.google.com/assets/colab-badge.svg"></a></summary>
-Shows how to fit, predict, and visualize with different interpretable models
 </details>
 <details>
 <summary><a href="https://github.com/csinva/iai-clinical-decision-rule/blob/master/notebooks/05_fit_interpretable_models.ipynb">Clinical decision rule notebook</a></summary>
@@ -287,6 +288,12 @@ FPSkope and SkopeRules differ only in the way they generate candidate rules: FPS
 <td style="text-align: center;"><a href="https://csinva.io/imodels/rule_set/fpskope.html#imodels.rule_set.fpskope.FPSkopeClassifier">FPSkopeClassifier</a></td>
 <td style="text-align: center;"></td>
 <td>Like Skope, but generates candidate rules with FPGrowth; requires discretized features</td>
+</tr>
+<tr>
+<td style="text-align: left;">Rulefit rule set (XGBoost)</td>
+<td style="text-align: center;">pass <code>tree_generator=XGBClassifier(...)</code> to <code>RuleFitClassifier</code></td>
+<td style="text-align: center;">pass <code>tree_generator=XGBRegressor(...)</code> to <code>RuleFitRegressor</code></td>
+<td>Requires <a href="https://pypi.org/project/xgboost/">xgboost</a></td>
 </tr>
 <tr>
 <td style="text-align: left;">FPLasso rule set</td>
@@ -404,6 +411,34 @@ FPSkope and SkopeRules differ only in the way they generate candidate rules: FPS
 </tr>
 </tbody>
 </table>
+<p><strong>Multiclass.</strong> These classifiers handle more than two classes: <code>FIGSClassifier</code>,
+<code>GreedyTreeClassifier</code>, <code>HSTreeClassifier</code>, <code>TaoTreeClassifier</code>,
+<code>BoostedRulesClassifier</code>, <code>SLIMClassifier</code>, <code>C45TreeClassifier</code>,
+<code>DecisionTreeCCPClassifier</code> and the <code>CV</code> variants. The rule-set and rule-list models are binary-only and raise a
+clear error if given a multiclass target, rather than silently treating it as
+binary.</p>
+<p><strong>Categorical features.</strong> <code>FIGS</code> takes them directly — pass the column names and
+it one-hot encodes them internally, remembering them for <code>predict</code>:</p>
+<pre><code class="language-python">model = FIGSClassifier().fit(X, y, categorical_features=['pet', 'city'])
+model.predict(X)
+</code></pre>
+<p>Other models expect numeric input, so encode categorical columns first (e.g. with
+<code>sklearn.preprocessing.OneHotEncoder</code>, or one of the
+<a href="https://csinva.io/imodels/discretization/index.html">discretizers</a> for numeric
+columns that a rule model needs binarized).</p>
+<h3 id="plotting-trees-with-dtreeviz">Plotting trees with dtreeviz</h3>
+<p>Tree-based models can be drawn with <a href="https://github.com/parrt/dtreeviz">dtreeviz</a>.
+<code>shadow_tree</code> builds the <code>ShadowDecTree</code> it needs from any imodels tree model:</p>
+<pre><code class="language-python">import dtreeviz
+from imodels import FIGSClassifier, shadow_tree
+
+model = FIGSClassifier(max_rules=6).fit(X, y)
+viz = dtreeviz.trees.DTreeVizAPI(shadow_tree(model, X, y))
+viz.view()
+</code></pre>
+<p>For a model made of several trees (FIGS, boosted rules), pass <code>tree_num</code> to pick
+one. Feature and class names default to those the model was fitted with.
+dtreeviz is not a dependency and is imported only when this is called.</p>
 <h3 id="inspecting-the-rules-a-model-learned">Inspecting the rules a model learned</h3>
 <p>Every rule-based model exposes its rules the same way, as a <code>pandas</code> DataFrame with
 one row per rule, via <code>get_rules()</code>:</p>
@@ -422,15 +457,32 @@ model.get_rules()
 6                                   PainNeck2 &gt; 0.5       0.058     2
 </code></pre>
 <p>Two columns are always present: <code>rule</code>, the condition as a string, and <code>prediction</code>,
-what the model predicts when that rule applies. Models add their own columns on top —
-<code>coef</code>, <code>support</code> and <code><a title="imodels.importance" href="importance/index.html">imodels.importance</a></code> for RuleFit, <code><a title="imodels.tree" href="tree/index.html">imodels.tree</a></code> for models made of several trees.
-Where a model is additive, as FIGS is, <code>prediction</code> is that tree's contribution, so the
-contributions of the matching rules sum to the model's output.</p>
+what that rule predicts. Models add their own columns on top — <code>coef</code>, <code>support</code> and
+<code><a title="imodels.importance" href="importance/index.html">imodels.importance</a></code> for RuleFit, <code><a title="imodels.tree" href="tree/index.html">imodels.tree</a></code> for models made of several trees, and <code>weight</code> for
+boosted ensembles, which combine their trees by weighted vote. Where a model is
+additive, as FIGS is, <code>prediction</code> is that tree's contribution, so the contributions
+of the matching rules sum to the model's output.</p>
 <p>This works across rule sets, rule lists and tree-based models (RuleFit, SkopeRules,
 SLIPPER, greedy and Bayesian rule lists, FIGS, CART, C4.5, TAO, boosted rules, and
 hierarchical shrinkage, including the <code>CV</code> variants). It is also available as a
 function, <code>imodels.get_rules(model)</code>, and takes an optional <code>feature_names</code> argument
 to rename the features. Models that aren't rule-based raise a clear error.</p>
+<h3 id="shap-values-for-shrunk-trees">SHAP values for shrunk trees</h3>
+<p><code>shap.TreeExplainer</code> dispatches on the model class, so it doesn't recognize the
+imodels wrapper. Pass the shrunk estimator it wraps:</p>
+<pre><code class="language-python">import shap
+from imodels import HSTreeClassifier
+
+model = HSTreeClassifier(DecisionTreeClassifier(max_leaf_nodes=8), reg_param=50).fit(X, y)
+explainer = shap.TreeExplainer(model.estimator_)   # not model itself
+shap_values = explainer.shap_values(X)
+</code></pre>
+<p>Hierarchical shrinkage rewrites the node values of that tree in place, so the
+explainer sees the shrunk model: the SHAP values differ from the unshrunk tree's
+and sum, with the expected value, to <code>model.predict_proba(X)</code>. This reproduces
+the SHAP summary plots in the <a href="https://arxiv.org/abs/2202.00858">paper</a>.</p>
+<p>Tree-based models expose <code>feature_importances_</code> (mean decrease in impurity), the
+same measure sklearn's tree models report, so they can be compared directly.</p>
 <p>Tree-based models also expose <code>apply(X)</code>, which reports which leaf each sample
 falls into, using the same node numbering as scikit-learn. A single tree returns
 one index per sample; a model made of several trees (FIGS, boosted rules) returns
@@ -574,6 +626,7 @@ from .discretization.discretizer import RFDiscretizer, BasicDiscretizer
 from .discretization.mdlp import MDLPDiscretizer, BRLDiscretizer
 from .experimental.bartpy import BART
 from .rule_list.bayesian_rule_list.bayesian_rule_list import BayesianRuleListClassifier
+from .rule_list.fast_frugal_tree import FastFrugalTreeClassifier
 from .rule_list.greedy_rule_list import GreedyRuleListClassifier
 from .rule_list.one_r import OneRClassifier
 from .rule_set import boosted_rules
@@ -605,6 +658,7 @@ from .tree.tao import TaoTreeClassifier, TaoTreeRegressor
 from .util.automl import AutoInterpretableClassifier, AutoInterpretableRegressor
 from .util.data_util import get_clean_dataset
 from .util.get_rules import get_rules
+from .util.tree_viz import shadow_tree
 from .util.distillation import DistilledRegressor
 from .util.explain_errors import explain_classification_errors
 from .clustering.stableclustering import StableClustering
@@ -612,6 +666,7 @@ from .clustering.stableclustering import StableClustering
 CLASSIFIERS = [
     BayesianRuleListClassifier,
     GreedyRuleListClassifier,
+    FastFrugalTreeClassifier,
     SkopeRulesClassifier,
     BoostedRulesClassifier,
     SLIMClassifier,
@@ -711,7 +766,9 @@ DISCRETIZERS = [RFDiscretizer, BasicDiscretizer,
 <li><a href="#demo-notebooks">Demo notebooks</a></li>
 <li><a href="#whats-the-difference-between-the-models">What's the difference between the models?</a></li>
 <li><a href="#support-for-different-tasks">Support for different tasks</a><ul>
+<li><a href="#plotting-trees-with-dtreeviz">Plotting trees with dtreeviz</a></li>
 <li><a href="#inspecting-the-rules-a-model-learned">Inspecting the rules a model learned</a></li>
+<li><a href="#shap-values-for-shrunk-trees">SHAP values for shrunk trees</a></li>
 <li><a href="#extras">Extras</a></li>
 </ul>
 </li>

--- a/docs/rule_list/bayesian_rule_list/bayesian_rule_list.html
+++ b/docs/rule_list/bayesian_rule_list/bayesian_rule_list.html
@@ -163,6 +163,10 @@ class BayesianRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
         if not np.all((X == 1) | (X == 0)):
             raise ValueError(&#34;All numeric features must be discretized prior to fitting!&#34;)
 
+        # fall back to the DataFrame&#39;s columns when no names were passed, so the
+        # printed rule list names the caller&#39;s features rather than X_0, X_1, ...
+        if feature_names is None:
+            feature_names = getattr(self, &#39;feature_names_in_&#39;, None)
         self.feature_dict_ = get_feature_dict(X.shape[1], feature_names)
         self.feature_placeholders = np.array(list(self.feature_dict_.keys()))
         self.feature_names = np.array(list(self.feature_dict_.values()))
@@ -310,12 +314,17 @@ class BayesianRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
         P = preds_d_t(X2, np.zeros((N, 1), dtype=int), self.d_star, self.theta)
         return np.vstack((1 - P, P)).T
 
-    def predict(self, X, threshold=0.1):
+    def predict(self, X, threshold=0.5):
         &#34;&#34;&#34;Perform classification on samples in X.
 
         Parameters
         ----------
         X : array-like, shape = [n_samples, n_features]
+
+        threshold : float, default=0.5
+            Probability at or above which the positive class is predicted. The
+            default makes predict agree with predict_proba, as for any other
+            classifier; lower it to trade precision for recall.
 
         Returns
         -------
@@ -497,6 +506,10 @@ rule lists, trying to optimize for compactness and predictive performance.</p>
         if not np.all((X == 1) | (X == 0)):
             raise ValueError(&#34;All numeric features must be discretized prior to fitting!&#34;)
 
+        # fall back to the DataFrame&#39;s columns when no names were passed, so the
+        # printed rule list names the caller&#39;s features rather than X_0, X_1, ...
+        if feature_names is None:
+            feature_names = getattr(self, &#39;feature_names_in_&#39;, None)
         self.feature_dict_ = get_feature_dict(X.shape[1], feature_names)
         self.feature_placeholders = np.array(list(self.feature_dict_.keys()))
         self.feature_names = np.array(list(self.feature_dict_.values()))
@@ -644,12 +657,17 @@ rule lists, trying to optimize for compactness and predictive performance.</p>
         P = preds_d_t(X2, np.zeros((N, 1), dtype=int), self.d_star, self.theta)
         return np.vstack((1 - P, P)).T
 
-    def predict(self, X, threshold=0.1):
+    def predict(self, X, threshold=0.5):
         &#34;&#34;&#34;Perform classification on samples in X.
 
         Parameters
         ----------
         X : array-like, shape = [n_samples, n_features]
+
+        threshold : float, default=0.5
+            Probability at or above which the positive class is predicted. The
+            default makes predict agree with predict_proba, as for any other
+            classifier; lower it to trade precision for recall.
 
         Returns
         -------
@@ -741,6 +759,10 @@ If empty and X is not a DataFrame, then features are simply enumerated</dd>
     if not np.all((X == 1) | (X == 0)):
         raise ValueError(&#34;All numeric features must be discretized prior to fitting!&#34;)
 
+    # fall back to the DataFrame&#39;s columns when no names were passed, so the
+    # printed rule list names the caller&#39;s features rather than X_0, X_1, ...
+    if feature_names is None:
+        feature_names = getattr(self, &#39;feature_names_in_&#39;, None)
     self.feature_dict_ = get_feature_dict(X.shape[1], feature_names)
     self.feature_placeholders = np.array(list(self.feature_dict_.keys()))
     self.feature_names = np.array(list(self.feature_dict_.values()))
@@ -808,7 +830,7 @@ If empty and X is not a DataFrame, then features are simply enumerated</dd>
 </details>
 </dd>
 <dt id="imodels.rule_list.bayesian_rule_list.bayesian_rule_list.BayesianRuleListClassifier.predict"><code class="name flex">
-<span>def <span class="ident">predict</span></span>(<span>self, X, threshold=0.1)</span>
+<span>def <span class="ident">predict</span></span>(<span>self, X, threshold=0.5)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Perform classification on samples in X.</p>
@@ -816,6 +838,10 @@ If empty and X is not a DataFrame, then features are simply enumerated</dd>
 <dl>
 <dt><strong><code>X</code></strong> :&ensp;<code>array-like, shape = [n_samples, n_features]</code></dt>
 <dd>&nbsp;</dd>
+<dt><strong><code>threshold</code></strong> :&ensp;<code>float</code>, default=<code>0.5</code></dt>
+<dd>Probability at or above which the positive class is predicted. The
+default makes predict agree with predict_proba, as for any other
+classifier; lower it to trade precision for recall.</dd>
 </dl>
 <h2 id="returns">Returns</h2>
 <dl>
@@ -826,12 +852,17 @@ If empty and X is not a DataFrame, then features are simply enumerated</dd>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def predict(self, X, threshold=0.1):
+<pre><code class="python">def predict(self, X, threshold=0.5):
     &#34;&#34;&#34;Perform classification on samples in X.
 
     Parameters
     ----------
     X : array-like, shape = [n_samples, n_features]
+
+    threshold : float, default=0.5
+        Probability at or above which the positive class is predicted. The
+        default makes predict agree with predict_proba, as for any other
+        classifier; lower it to trade precision for recall.
 
     Returns
     -------

--- a/docs/rule_list/fast_frugal_tree.html
+++ b/docs/rule_list/fast_frugal_tree.html
@@ -1,0 +1,712 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.11.6" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/default.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:1.5em;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:2em 0 .50em 0}h3{font-size:1.4em;margin:1.6em 0 .7em 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .2s ease-in-out}a:visited{color:#503}a:hover{color:#b62}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900;font-weight:bold}pre code{font-size:.8em;line-height:1.4em;padding:1em;display:block}code{background:#f3f3f3;font-family:"DejaVu Sans Mono",monospace;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source > summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible;min-width:max-content}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em 1em;margin:1em 0}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul ul{padding-left:1em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<section id="section-intro">
+<p>Fast-and-frugal trees (Phillips, Neth, Woike &amp; Gaissmaier 2017).</p>
+<p>A fast-and-frugal tree asks one question per level and, at every level, is able
+to stop and decide: each cue has an <em>exit</em> to one class, and whatever it doesn't
+catch falls through to the next cue. The last cue exits both ways, so the tree
+always decides within <code>max_depth</code> questions.</p>
+<p>That single descending path is why this lives with the rule lists rather than
+the trees, and it is what makes these models usable from memory &ndash; they are
+widely used for triage decisions in medicine.</p>
+<h2 id="references">References</h2>
+<p>Phillips, Neth, Woike &amp; Gaissmaier (2017), "FFTrees: A toolbox to create,
+visualize, and evaluate fast-and-frugal decision trees",
+Judgment and Decision Making 12(4). <a href="http://journal.sjdm.org/17/17217/jdm17217.html">http://journal.sjdm.org/17/17217/jdm17217.html</a></p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">&#34;&#34;&#34;Fast-and-frugal trees (Phillips, Neth, Woike &amp; Gaissmaier 2017).
+
+A fast-and-frugal tree asks one question per level and, at every level, is able
+to stop and decide: each cue has an *exit* to one class, and whatever it doesn&#39;t
+catch falls through to the next cue. The last cue exits both ways, so the tree
+always decides within `max_depth` questions.
+
+That single descending path is why this lives with the rule lists rather than
+the trees, and it is what makes these models usable from memory -- they are
+widely used for triage decisions in medicine.
+
+References
+----------
+Phillips, Neth, Woike &amp; Gaissmaier (2017), &#34;FFTrees: A toolbox to create,
+visualize, and evaluate fast-and-frugal decision trees&#34;,
+Judgment and Decision Making 12(4). http://journal.sjdm.org/17/17217/jdm17217.html
+&#34;&#34;&#34;
+
+import numpy as np
+from sklearn.base import BaseEstimator, ClassifierMixin
+from sklearn.utils.validation import check_array, check_is_fitted
+
+from imodels.rule_list.rule_list import RuleList
+from imodels.util.arguments import (check_binary_target, check_fit_arguments,
+                                    decode_labels)
+
+
+class FastFrugalTreeClassifier(BaseEstimator, RuleList, ClassifierMixin):
+    &#34;&#34;&#34;A fast-and-frugal tree: one cue per level, each with an exit.
+
+    Parameters
+    ----------
+    max_depth : int, default=4
+        Number of cues the tree may ask. Fast-and-frugal trees are deliberately
+        shallow; the literature typically uses 4 or fewer.
+    max_thresholds : int, default=64
+        Candidate thresholds considered per feature. Thresholds are taken from
+        quantiles of the feature, so this bounds the search on large datasets.
+    min_samples_exit : int, default=1
+        A cue must send at least this many samples to its exit to be used.
+
+    Attributes
+    ----------
+    rules_ : list of dict
+        One entry per cue, in the order they are asked, plus a final catch-all.
+        Uses the same representation as the other rule lists, so `get_rules()`
+        works on it.
+    classes_ : ndarray
+    &#34;&#34;&#34;
+
+    def __init__(self, max_depth: int = 4, max_thresholds: int = 64,
+                 min_samples_exit: int = 1):
+        self.max_depth = max_depth
+        self.max_thresholds = max_thresholds
+        self.min_samples_exit = min_samples_exit
+
+    def fit(self, X, y, feature_names=None):
+        check_binary_target(self, y)
+        X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
+
+        remaining = np.ones(X.shape[0], dtype=bool)
+        self.rules_ = []
+
+        for depth in range(self.max_depth):
+            # the last cue has to decide both ways, so stop asking questions
+            if depth == self.max_depth - 1 or remaining.sum() == 0:
+                break
+            cue = self._best_cue(X, y, remaining, feature_names)
+            if cue is None:  # no cue earns its place
+                break
+            cue[&#39;depth&#39;] = depth
+            self.rules_.append(cue)
+            remaining = remaining &amp; ~cue.pop(&#39;_exits&#39;)
+
+        self.rules_.append(self._final_exit(y, remaining))
+        self.complexity_ = len(self.rules_)
+        return self
+
+    def _candidate_thresholds(self, column):
+        values = np.unique(column)
+        if len(values) &lt;= self.max_thresholds:
+            # midpoints between observed values
+            return (values[:-1] + values[1:]) / 2 if len(values) &gt; 1 else values
+        quantiles = np.linspace(0, 1, self.max_thresholds + 2)[1:-1]
+        return np.unique(np.quantile(column, quantiles))
+
+    def _best_cue(self, X, y, remaining, feature_names):
+        &#34;&#34;&#34;The cue whose exit gets the most samples right, net of its mistakes.&#34;&#34;&#34;
+        y_remaining = y[remaining]
+        best, best_score = None, 0
+
+        for feature in range(X.shape[1]):
+            column = X[remaining, feature]
+            for threshold in self._candidate_thresholds(column):
+                above = column &gt; threshold
+                for exit_above in (True, False):
+                    exits = above if exit_above else ~above
+                    n_exits = int(exits.sum())
+                    if n_exits &lt; self.min_samples_exit:
+                        continue
+                    exited_y = y_remaining[exits]
+                    for exit_class in (0, 1):
+                        correct = int((exited_y == exit_class).sum())
+                        # reward correct exits, penalize wrong ones
+                        score = 2 * correct - n_exits
+                        if score &gt; best_score:
+                            full = np.zeros(len(y), dtype=bool)
+                            full[np.flatnonzero(remaining)[exits]] = True
+                            best_score = score
+                            best = {
+                                &#39;col&#39;: str(feature_names[feature]),
+                                &#39;index_col&#39;: feature,
+                                &#39;cutoff&#39;: threshold,
+                                # &#39;flip&#39; marks the exit as the &lt;= side, matching
+                                # how the other rule lists record their direction
+                                &#39;flip&#39;: not exit_above,
+                                &#39;val_right&#39;: float(exit_class),
+                                &#39;num_pts&#39;: int(remaining.sum()),
+                                &#39;num_pts_right&#39;: n_exits,
+                                &#39;_exits&#39;: full,
+                            }
+        return best
+
+    def _final_exit(self, y, remaining):
+        &#34;&#34;&#34;Everything still undecided takes the majority class of what&#39;s left.&#34;&#34;&#34;
+        if remaining.sum() == 0:
+            value = float(np.round(y.mean())) if len(y) else 0.0
+            return {&#39;val&#39;: value, &#39;num_pts&#39;: 0}
+        return {&#39;val&#39;: float(np.round(y[remaining].mean())),
+                &#39;num_pts&#39;: int(remaining.sum())}
+
+    def predict_proba(self, X):
+        check_is_fitted(self)
+        X = check_array(X)
+
+        probs = np.zeros(X.shape[0])
+        undecided = np.ones(X.shape[0], dtype=bool)
+        for rule in self.rules_:
+            if &#39;col&#39; not in rule:  # the final catch-all
+                probs[undecided] = rule[&#39;val&#39;]
+                break
+            above = X[:, rule[&#39;index_col&#39;]] &gt; rule[&#39;cutoff&#39;]
+            exits = (~above if rule[&#39;flip&#39;] else above) &amp; undecided
+            probs[exits] = rule[&#39;val_right&#39;]
+            undecided = undecided &amp; ~exits
+
+        return np.vstack((1 - probs, probs)).transpose()
+
+    def predict(self, X):
+        return decode_labels(self, np.argmax(self.predict_proba(X), axis=1))
+
+    def __str__(self):
+        if not hasattr(self, &#39;rules_&#39;):
+            return f&#39;{type(self).__name__}(max_depth={self.max_depth})&#39;
+        s = &#39;&gt; ------------------------------\n&#39;
+        s += &#39;&gt; Fast-and-frugal tree\n&#39;
+        s += &#39;&gt; \tEach cue either decides, or passes the case to the next cue\n&#39;
+        s += &#39;&gt; ------------------------------\n&#39;
+        for rule in self.rules_:
+            if &#39;col&#39; not in rule:
+                s += (f&#34;&gt; else | predict {int(rule[&#39;val&#39;])} &#34;
+                      f&#34;({rule[&#39;num_pts&#39;]} obs)\n&#34;)
+                continue
+            comparison = &#39;&lt;=&#39; if rule[&#39;flip&#39;] else &#39;&gt;&#39;
+            s += (f&#34;&gt; if {rule[&#39;col&#39;]} {comparison} {rule[&#39;cutoff&#39;]:.3g} | &#34;
+                  f&#34;predict {int(rule[&#39;val_right&#39;])} &#34;
+                  f&#34;({rule[&#39;num_pts_right&#39;]} obs)\n&#34;)
+        s += &#39;&gt; ------------------------------\n&#39;
+        return s</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier"><code class="flex name class">
+<span>class <span class="ident">FastFrugalTreeClassifier</span></span>
+<span>(</span><span>max_depth: int = 4, max_thresholds: int = 64, min_samples_exit: int = 1)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>A fast-and-frugal tree: one cue per level, each with an exit.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>max_depth</code></strong> :&ensp;<code>int</code>, default=<code>4</code></dt>
+<dd>Number of cues the tree may ask. Fast-and-frugal trees are deliberately
+shallow; the literature typically uses 4 or fewer.</dd>
+<dt><strong><code>max_thresholds</code></strong> :&ensp;<code>int</code>, default=<code>64</code></dt>
+<dd>Candidate thresholds considered per feature. Thresholds are taken from
+quantiles of the feature, so this bounds the search on large datasets.</dd>
+<dt><strong><code>min_samples_exit</code></strong> :&ensp;<code>int</code>, default=<code>1</code></dt>
+<dd>A cue must send at least this many samples to its exit to be used.</dd>
+</dl>
+<h2 id="attributes">Attributes</h2>
+<dl>
+<dt><strong><code>rules_</code></strong> :&ensp;<code>list</code> of <code>dict</code></dt>
+<dd>One entry per cue, in the order they are asked, plus a final catch-all.
+Uses the same representation as the other rule lists, so <code>get_rules()</code>
+works on it.</dd>
+<dt><strong><code>classes_</code></strong> :&ensp;<code>ndarray</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class FastFrugalTreeClassifier(BaseEstimator, RuleList, ClassifierMixin):
+    &#34;&#34;&#34;A fast-and-frugal tree: one cue per level, each with an exit.
+
+    Parameters
+    ----------
+    max_depth : int, default=4
+        Number of cues the tree may ask. Fast-and-frugal trees are deliberately
+        shallow; the literature typically uses 4 or fewer.
+    max_thresholds : int, default=64
+        Candidate thresholds considered per feature. Thresholds are taken from
+        quantiles of the feature, so this bounds the search on large datasets.
+    min_samples_exit : int, default=1
+        A cue must send at least this many samples to its exit to be used.
+
+    Attributes
+    ----------
+    rules_ : list of dict
+        One entry per cue, in the order they are asked, plus a final catch-all.
+        Uses the same representation as the other rule lists, so `get_rules()`
+        works on it.
+    classes_ : ndarray
+    &#34;&#34;&#34;
+
+    def __init__(self, max_depth: int = 4, max_thresholds: int = 64,
+                 min_samples_exit: int = 1):
+        self.max_depth = max_depth
+        self.max_thresholds = max_thresholds
+        self.min_samples_exit = min_samples_exit
+
+    def fit(self, X, y, feature_names=None):
+        check_binary_target(self, y)
+        X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
+
+        remaining = np.ones(X.shape[0], dtype=bool)
+        self.rules_ = []
+
+        for depth in range(self.max_depth):
+            # the last cue has to decide both ways, so stop asking questions
+            if depth == self.max_depth - 1 or remaining.sum() == 0:
+                break
+            cue = self._best_cue(X, y, remaining, feature_names)
+            if cue is None:  # no cue earns its place
+                break
+            cue[&#39;depth&#39;] = depth
+            self.rules_.append(cue)
+            remaining = remaining &amp; ~cue.pop(&#39;_exits&#39;)
+
+        self.rules_.append(self._final_exit(y, remaining))
+        self.complexity_ = len(self.rules_)
+        return self
+
+    def _candidate_thresholds(self, column):
+        values = np.unique(column)
+        if len(values) &lt;= self.max_thresholds:
+            # midpoints between observed values
+            return (values[:-1] + values[1:]) / 2 if len(values) &gt; 1 else values
+        quantiles = np.linspace(0, 1, self.max_thresholds + 2)[1:-1]
+        return np.unique(np.quantile(column, quantiles))
+
+    def _best_cue(self, X, y, remaining, feature_names):
+        &#34;&#34;&#34;The cue whose exit gets the most samples right, net of its mistakes.&#34;&#34;&#34;
+        y_remaining = y[remaining]
+        best, best_score = None, 0
+
+        for feature in range(X.shape[1]):
+            column = X[remaining, feature]
+            for threshold in self._candidate_thresholds(column):
+                above = column &gt; threshold
+                for exit_above in (True, False):
+                    exits = above if exit_above else ~above
+                    n_exits = int(exits.sum())
+                    if n_exits &lt; self.min_samples_exit:
+                        continue
+                    exited_y = y_remaining[exits]
+                    for exit_class in (0, 1):
+                        correct = int((exited_y == exit_class).sum())
+                        # reward correct exits, penalize wrong ones
+                        score = 2 * correct - n_exits
+                        if score &gt; best_score:
+                            full = np.zeros(len(y), dtype=bool)
+                            full[np.flatnonzero(remaining)[exits]] = True
+                            best_score = score
+                            best = {
+                                &#39;col&#39;: str(feature_names[feature]),
+                                &#39;index_col&#39;: feature,
+                                &#39;cutoff&#39;: threshold,
+                                # &#39;flip&#39; marks the exit as the &lt;= side, matching
+                                # how the other rule lists record their direction
+                                &#39;flip&#39;: not exit_above,
+                                &#39;val_right&#39;: float(exit_class),
+                                &#39;num_pts&#39;: int(remaining.sum()),
+                                &#39;num_pts_right&#39;: n_exits,
+                                &#39;_exits&#39;: full,
+                            }
+        return best
+
+    def _final_exit(self, y, remaining):
+        &#34;&#34;&#34;Everything still undecided takes the majority class of what&#39;s left.&#34;&#34;&#34;
+        if remaining.sum() == 0:
+            value = float(np.round(y.mean())) if len(y) else 0.0
+            return {&#39;val&#39;: value, &#39;num_pts&#39;: 0}
+        return {&#39;val&#39;: float(np.round(y[remaining].mean())),
+                &#39;num_pts&#39;: int(remaining.sum())}
+
+    def predict_proba(self, X):
+        check_is_fitted(self)
+        X = check_array(X)
+
+        probs = np.zeros(X.shape[0])
+        undecided = np.ones(X.shape[0], dtype=bool)
+        for rule in self.rules_:
+            if &#39;col&#39; not in rule:  # the final catch-all
+                probs[undecided] = rule[&#39;val&#39;]
+                break
+            above = X[:, rule[&#39;index_col&#39;]] &gt; rule[&#39;cutoff&#39;]
+            exits = (~above if rule[&#39;flip&#39;] else above) &amp; undecided
+            probs[exits] = rule[&#39;val_right&#39;]
+            undecided = undecided &amp; ~exits
+
+        return np.vstack((1 - probs, probs)).transpose()
+
+    def predict(self, X):
+        return decode_labels(self, np.argmax(self.predict_proba(X), axis=1))
+
+    def __str__(self):
+        if not hasattr(self, &#39;rules_&#39;):
+            return f&#39;{type(self).__name__}(max_depth={self.max_depth})&#39;
+        s = &#39;&gt; ------------------------------\n&#39;
+        s += &#39;&gt; Fast-and-frugal tree\n&#39;
+        s += &#39;&gt; \tEach cue either decides, or passes the case to the next cue\n&#39;
+        s += &#39;&gt; ------------------------------\n&#39;
+        for rule in self.rules_:
+            if &#39;col&#39; not in rule:
+                s += (f&#34;&gt; else | predict {int(rule[&#39;val&#39;])} &#34;
+                      f&#34;({rule[&#39;num_pts&#39;]} obs)\n&#34;)
+                continue
+            comparison = &#39;&lt;=&#39; if rule[&#39;flip&#39;] else &#39;&gt;&#39;
+            s += (f&#34;&gt; if {rule[&#39;col&#39;]} {comparison} {rule[&#39;cutoff&#39;]:.3g} | &#34;
+                  f&#34;predict {int(rule[&#39;val_right&#39;])} &#34;
+                  f&#34;({rule[&#39;num_pts_right&#39;]} obs)\n&#34;)
+        s += &#39;&gt; ------------------------------\n&#39;
+        return s</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>sklearn.base.BaseEstimator</li>
+<li>sklearn.utils._repr_html.base.ReprHTMLMixin</li>
+<li>sklearn.utils._repr_html.base._HTMLDocumentationLinkMixin</li>
+<li>sklearn.utils._metadata_requests._MetadataRequester</li>
+<li><a title="imodels.rule_list.rule_list.RuleList" href="rule_list.html#imodels.rule_list.rule_list.RuleList">RuleList</a></li>
+<li>sklearn.base.ClassifierMixin</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier.fit"><code class="name flex">
+<span>def <span class="ident">fit</span></span>(<span>self, X, y, feature_names=None)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def fit(self, X, y, feature_names=None):
+    check_binary_target(self, y)
+    X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
+
+    remaining = np.ones(X.shape[0], dtype=bool)
+    self.rules_ = []
+
+    for depth in range(self.max_depth):
+        # the last cue has to decide both ways, so stop asking questions
+        if depth == self.max_depth - 1 or remaining.sum() == 0:
+            break
+        cue = self._best_cue(X, y, remaining, feature_names)
+        if cue is None:  # no cue earns its place
+            break
+        cue[&#39;depth&#39;] = depth
+        self.rules_.append(cue)
+        remaining = remaining &amp; ~cue.pop(&#39;_exits&#39;)
+
+    self.rules_.append(self._final_exit(y, remaining))
+    self.complexity_ = len(self.rules_)
+    return self</code></pre>
+</details>
+</dd>
+<dt id="imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier.predict"><code class="name flex">
+<span>def <span class="ident">predict</span></span>(<span>self, X)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def predict(self, X):
+    return decode_labels(self, np.argmax(self.predict_proba(X), axis=1))</code></pre>
+</details>
+</dd>
+<dt id="imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier.predict_proba"><code class="name flex">
+<span>def <span class="ident">predict_proba</span></span>(<span>self, X)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def predict_proba(self, X):
+    check_is_fitted(self)
+    X = check_array(X)
+
+    probs = np.zeros(X.shape[0])
+    undecided = np.ones(X.shape[0], dtype=bool)
+    for rule in self.rules_:
+        if &#39;col&#39; not in rule:  # the final catch-all
+            probs[undecided] = rule[&#39;val&#39;]
+            break
+        above = X[:, rule[&#39;index_col&#39;]] &gt; rule[&#39;cutoff&#39;]
+        exits = (~above if rule[&#39;flip&#39;] else above) &amp; undecided
+        probs[exits] = rule[&#39;val_right&#39;]
+        undecided = undecided &amp; ~exits
+
+    return np.vstack((1 - probs, probs)).transpose()</code></pre>
+</details>
+</dd>
+<dt id="imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier.set_fit_request"><code class="name flex">
+<span>def <span class="ident">set_fit_request</span></span>(<span>self: <a title="imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier" href="#imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier">FastFrugalTreeClassifier</a>, *, feature_names: bool | str | None = '$UNCHANGED$') ‑> <a title="imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier" href="#imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier">FastFrugalTreeClassifier</a></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Configure whether metadata should be requested to be passed to the <code>fit</code> method.</p>
+<p>Note that this method is only relevant when this estimator is used as a
+sub-estimator within a :term:<code>meta-estimator</code> and metadata routing is enabled
+with <code>enable_metadata_routing=True</code> (see :func:<code>sklearn.set_config</code>).
+Please check the :ref:<code>User Guide &lt;metadata_routing&gt;</code> on how the routing
+mechanism works.</p>
+<p>The options for each parameter are:</p>
+<ul>
+<li>
+<p><code>True</code>: metadata is requested, and passed to <code>fit</code> if provided. The request is ignored if metadata is not provided.</p>
+</li>
+<li>
+<p><code>False</code>: metadata is not requested and the meta-estimator will not pass it to <code>fit</code>.</p>
+</li>
+<li>
+<p><code>None</code>: metadata is not requested, and the meta-estimator will raise an error if the user provides it.</p>
+</li>
+<li>
+<p><code>str</code>: metadata should be passed to the meta-estimator with this given alias instead of the original name.</p>
+</li>
+</ul>
+<p>The default (<code>sklearn.utils.metadata_routing.UNCHANGED</code>) retains the
+existing request. This allows you to change the request for some
+parameters and not others.</p>
+<div class="admonition versionadded">
+<p class="admonition-title">Added in version:&ensp;1.3</p>
+</div>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>feature_names</code></strong> :&ensp;<code>str, True, False,</code> or <code>None</code>,
+default=<code>sklearn.utils.metadata_routing.UNCHANGED</code></dt>
+<dd>Metadata routing for <code>feature_names</code> parameter in <code>fit</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><strong><code>self</code></strong> :&ensp;<code>object</code></dt>
+<dd>The updated object.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def func(*args, **kw):
+    &#34;&#34;&#34;Updates the `_metadata_request` attribute of the consumer (`instance`)
+    for the parameters provided as `**kw`.
+
+    This docstring is overwritten below.
+    See REQUESTER_DOC for expected functionality.
+    &#34;&#34;&#34;
+    if not _routing_enabled():
+        raise RuntimeError(
+            &#34;This method is only available when metadata routing is enabled.&#34;
+            &#34; You can enable it using&#34;
+            &#34; sklearn.set_config(enable_metadata_routing=True).&#34;
+        )
+
+    if self.validate_keys and (set(kw) - set(self.keys)):
+        raise TypeError(
+            f&#34;Unexpected args: {set(kw) - set(self.keys)} in {self.name}. &#34;
+            f&#34;Accepted arguments are: {set(self.keys)}&#34;
+        )
+
+    # This makes it possible to use the decorated method as an unbound method,
+    # for instance when monkeypatching.
+    # https://github.com/scikit-learn/scikit-learn/issues/28632
+    if instance is None:
+        _instance = args[0]
+        args = args[1:]
+    else:
+        _instance = instance
+
+    # Replicating python&#39;s behavior when positional args are given other than
+    # `self`, and `self` is only allowed if this method is unbound.
+    if args:
+        raise TypeError(
+            f&#34;set_{self.name}_request() takes 0 positional argument but&#34;
+            f&#34; {len(args)} were given&#34;
+        )
+
+    requests = _instance._get_metadata_request()
+    method_metadata_request = getattr(requests, self.name)
+
+    for prop, alias in kw.items():
+        if alias is not UNCHANGED:
+            method_metadata_request.add_request(param=prop, alias=alias)
+    _instance._metadata_request = requests
+
+    return _instance</code></pre>
+</details>
+</dd>
+<dt id="imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier.set_score_request"><code class="name flex">
+<span>def <span class="ident">set_score_request</span></span>(<span>self: <a title="imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier" href="#imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier">FastFrugalTreeClassifier</a>, *, sample_weight: bool | str | None = '$UNCHANGED$') ‑> <a title="imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier" href="#imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier">FastFrugalTreeClassifier</a></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Configure whether metadata should be requested to be passed to the <code>score</code> method.</p>
+<p>Note that this method is only relevant when this estimator is used as a
+sub-estimator within a :term:<code>meta-estimator</code> and metadata routing is enabled
+with <code>enable_metadata_routing=True</code> (see :func:<code>sklearn.set_config</code>).
+Please check the :ref:<code>User Guide &lt;metadata_routing&gt;</code> on how the routing
+mechanism works.</p>
+<p>The options for each parameter are:</p>
+<ul>
+<li>
+<p><code>True</code>: metadata is requested, and passed to <code>score</code> if provided. The request is ignored if metadata is not provided.</p>
+</li>
+<li>
+<p><code>False</code>: metadata is not requested and the meta-estimator will not pass it to <code>score</code>.</p>
+</li>
+<li>
+<p><code>None</code>: metadata is not requested, and the meta-estimator will raise an error if the user provides it.</p>
+</li>
+<li>
+<p><code>str</code>: metadata should be passed to the meta-estimator with this given alias instead of the original name.</p>
+</li>
+</ul>
+<p>The default (<code>sklearn.utils.metadata_routing.UNCHANGED</code>) retains the
+existing request. This allows you to change the request for some
+parameters and not others.</p>
+<div class="admonition versionadded">
+<p class="admonition-title">Added in version:&ensp;1.3</p>
+</div>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>sample_weight</code></strong> :&ensp;<code>str, True, False,</code> or <code>None</code>,
+default=<code>sklearn.utils.metadata_routing.UNCHANGED</code></dt>
+<dd>Metadata routing for <code>sample_weight</code> parameter in <code>score</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><strong><code>self</code></strong> :&ensp;<code>object</code></dt>
+<dd>The updated object.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def func(*args, **kw):
+    &#34;&#34;&#34;Updates the `_metadata_request` attribute of the consumer (`instance`)
+    for the parameters provided as `**kw`.
+
+    This docstring is overwritten below.
+    See REQUESTER_DOC for expected functionality.
+    &#34;&#34;&#34;
+    if not _routing_enabled():
+        raise RuntimeError(
+            &#34;This method is only available when metadata routing is enabled.&#34;
+            &#34; You can enable it using&#34;
+            &#34; sklearn.set_config(enable_metadata_routing=True).&#34;
+        )
+
+    if self.validate_keys and (set(kw) - set(self.keys)):
+        raise TypeError(
+            f&#34;Unexpected args: {set(kw) - set(self.keys)} in {self.name}. &#34;
+            f&#34;Accepted arguments are: {set(self.keys)}&#34;
+        )
+
+    # This makes it possible to use the decorated method as an unbound method,
+    # for instance when monkeypatching.
+    # https://github.com/scikit-learn/scikit-learn/issues/28632
+    if instance is None:
+        _instance = args[0]
+        args = args[1:]
+    else:
+        _instance = instance
+
+    # Replicating python&#39;s behavior when positional args are given other than
+    # `self`, and `self` is only allowed if this method is unbound.
+    if args:
+        raise TypeError(
+            f&#34;set_{self.name}_request() takes 0 positional argument but&#34;
+            f&#34; {len(args)} were given&#34;
+        )
+
+    requests = _instance._get_metadata_request()
+    method_metadata_request = getattr(requests, self.name)
+
+    for prop, alias in kw.items():
+        if alias is not UNCHANGED:
+            method_metadata_request.add_request(param=prop, alias=alias)
+    _instance._metadata_request = requests
+
+    return _instance</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="imodels.rule_list.rule_list.RuleList" href="rule_list.html#imodels.rule_list.rule_list.RuleList">RuleList</a></b></code>:
+<ul class="hlist">
+<li><code><a title="imodels.rule_list.rule_list.RuleList.get_rules" href="rule_list.html#imodels.rule_list.rule_list.RuleList.get_rules">get_rules</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index 🔍</h1>
+<div class="toc">
+<ul>
+<li><a href="#references">References</a></li>
+</ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="imodels.rule_list" href="index.html">imodels.rule_list</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier" href="#imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier">FastFrugalTreeClassifier</a></code></h4>
+<ul class="">
+<li><code><a title="imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier.fit" href="#imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier.fit">fit</a></code></li>
+<li><code><a title="imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier.predict" href="#imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier.predict">predict</a></code></li>
+<li><code><a title="imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier.predict_proba" href="#imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier.predict_proba">predict_proba</a></code></li>
+<li><code><a title="imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier.set_fit_request" href="#imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier.set_fit_request">set_fit_request</a></code></li>
+<li><code><a title="imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier.set_score_request" href="#imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier.set_score_request">set_score_request</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+<p><img align="center" width=100% src="https://csinva.io/imodels/img/anim.gif"> </img></p>
+<!-- add wave animation -->
+</nav>
+</main>
+<footer id="footer">
+</footer>
+</body>
+</html>
+<!-- add github corner -->
+<a href="https://github.com/csinva/imodels" class="github-corner" aria-label="View source on GitHub"><svg width="120" height="120" viewBox="0 0 250 250" style="fill:#70B7FD; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="m128.3,109.0 c113.8,99.7 119.0,89.6 119.0,89.6 c122.0,82.7 120.5,78.6 120.5,78.6 c119.2,72.0 123.4,76.3 123.4,76.3 c127.3,80.9 125.5,87.3 125.5,87.3 c122.9,97.6 130.6,101.9 134.4,103.2" fill="currentcolor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
+<!-- add wave animation stylesheet -->
+<link rel="stylesheet" href="github.css">

--- a/docs/rule_list/greedy_rule_list.html
+++ b/docs/rule_list/greedy_rule_list.html
@@ -39,7 +39,7 @@ from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.utils.validation import check_array, check_is_fitted
 from sklearn.tree import DecisionTreeClassifier
 from imodels.rule_list.rule_list import RuleList
-from imodels.util.arguments import check_fit_arguments, decode_labels
+from imodels.util.arguments import check_binary_target, check_fit_arguments, decode_labels
 
 
 class GreedyRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
@@ -71,6 +71,7 @@ class GreedyRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
         depth
             the depth of the current layer (used to recurse)
         &#34;&#34;&#34;
+        check_binary_target(self, y)
         X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
         self.depth = 0  # reset so that refitting doesn&#39;t accumulate depth
         self.rules_ = self.fit_node_recursive(X, y, depth=0, verbose=verbose)
@@ -438,6 +439,7 @@ Criterion used to split
         depth
             the depth of the current layer (used to recurse)
         &#34;&#34;&#34;
+        check_binary_target(self, y)
         X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
         self.depth = 0  # reset so that refitting doesn&#39;t accumulate depth
         self.rules_ = self.fit_node_recursive(X, y, depth=0, verbose=verbose)
@@ -756,6 +758,7 @@ the depth of the current layer (used to recurse)</p></div>
     depth
         the depth of the current layer (used to recurse)
     &#34;&#34;&#34;
+    check_binary_target(self, y)
     X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
     self.depth = 0  # reset so that refitting doesn&#39;t accumulate depth
     self.rules_ = self.fit_node_recursive(X, y, depth=0, verbose=verbose)

--- a/docs/rule_list/index.html
+++ b/docs/rule_list/index.html
@@ -33,6 +33,10 @@
 <dd>
 <div class="desc"><p><a href="https://arxiv.org/abs/1602.08610">bayesian rule list</a> (based on <a href="https://github.com/tmadl/sklearn-expertsys">this implementation</a>) - learn a compact …</p></div>
 </dd>
+<dt><code class="name"><a title="imodels.rule_list.fast_frugal_tree" href="fast_frugal_tree.html">imodels.rule_list.fast_frugal_tree</a></code></dt>
+<dd>
+<div class="desc"><p>Fast-and-frugal trees (Phillips, Neth, Woike &amp; Gaissmaier 2017) …</p></div>
+</dd>
 <dt><code class="name"><a title="imodels.rule_list.greedy_rule_list" href="greedy_rule_list.html">imodels.rule_list.greedy_rule_list</a></code></dt>
 <dd>
 <div class="desc"><p>Greedy rule list.
@@ -79,6 +83,7 @@ It works by building a greedy rule list using only one …</p></div>
 <li><h3><a href="#header-submodules">Sub-modules</a></h3>
 <ul>
 <li><code><a title="imodels.rule_list.bayesian_rule_list" href="bayesian_rule_list/index.html">imodels.rule_list.bayesian_rule_list</a></code></li>
+<li><code><a title="imodels.rule_list.fast_frugal_tree" href="fast_frugal_tree.html">imodels.rule_list.fast_frugal_tree</a></code></li>
 <li><code><a title="imodels.rule_list.greedy_rule_list" href="greedy_rule_list.html">imodels.rule_list.greedy_rule_list</a></code></li>
 <li><code><a title="imodels.rule_list.one_r" href="one_r.html">imodels.rule_list.one_r</a></code></li>
 <li><code><a title="imodels.rule_list.rule_list" href="rule_list.html">imodels.rule_list.rule_list</a></code></li>

--- a/docs/rule_list/one_r.html
+++ b/docs/rule_list/one_r.html
@@ -39,7 +39,7 @@ from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
 
 from imodels import GreedyRuleListClassifier
 from imodels.rule_list.rule_list import RuleList
-from imodels.util.arguments import check_fit_arguments
+from imodels.util.arguments import check_binary_target, check_fit_arguments
 
 
 class OneRClassifier(GreedyRuleListClassifier):
@@ -53,6 +53,7 @@ class OneRClassifier(GreedyRuleListClassifier):
     def fit(self, X, y, feature_names=None):
         &#34;&#34;&#34;Fit oneR
         &#34;&#34;&#34;
+        check_binary_target(self, y)
         X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
 
         ms = []
@@ -149,6 +150,7 @@ Criterion used to split
     def fit(self, X, y, feature_names=None):
         &#34;&#34;&#34;Fit oneR
         &#34;&#34;&#34;
+        check_binary_target(self, y)
         X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
 
         ms = []
@@ -197,6 +199,7 @@ Criterion used to split
 <pre><code class="python">def fit(self, X, y, feature_names=None):
     &#34;&#34;&#34;Fit oneR
     &#34;&#34;&#34;
+    check_binary_target(self, y)
     X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
 
     ms = []

--- a/docs/rule_list/rule_list.html
+++ b/docs/rule_list/rule_list.html
@@ -68,6 +68,7 @@ class RuleList:
 <h3>Subclasses</h3>
 <ul class="hlist">
 <li><a title="imodels.rule_list.bayesian_rule_list.bayesian_rule_list.BayesianRuleListClassifier" href="bayesian_rule_list/bayesian_rule_list.html#imodels.rule_list.bayesian_rule_list.bayesian_rule_list.BayesianRuleListClassifier">BayesianRuleListClassifier</a></li>
+<li><a title="imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier" href="fast_frugal_tree.html#imodels.rule_list.fast_frugal_tree.FastFrugalTreeClassifier">FastFrugalTreeClassifier</a></li>
 <li><a title="imodels.rule_list.greedy_rule_list.GreedyRuleListClassifier" href="greedy_rule_list.html#imodels.rule_list.greedy_rule_list.GreedyRuleListClassifier">GreedyRuleListClassifier</a></li>
 </ul>
 <h3>Methods</h3>

--- a/docs/rule_set/skope_rules.html
+++ b/docs/rule_set/skope_rules.html
@@ -161,7 +161,7 @@ from sklearn.utils.multiclass import check_classification_targets, unique_labels
 from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
 
 from imodels.rule_set.rule_set import RuleSet
-from imodels.util.arguments import check_fit_arguments, decode_labels
+from imodels.util.arguments import check_binary_target, check_fit_arguments, decode_labels
 from imodels.util.rule import replace_feature_name, get_feature_dict, Rule
 from imodels.util.extract import extract_skope
 from imodels.util.score import score_precision_recall
@@ -344,6 +344,7 @@ class SkopeRulesClassifier(BaseEstimator, RuleSet, ClassifierMixin):
         self : object
             Returns self.
         &#34;&#34;&#34;
+        check_binary_target(self, y)
         X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
         check_classification_targets(y)
         self.n_features_ = X.shape[1]
@@ -865,6 +866,7 @@ estimator.</dd>
         self : object
             Returns self.
         &#34;&#34;&#34;
+        check_binary_target(self, y)
         X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
         check_classification_targets(y)
         self.n_features_ = X.shape[1]
@@ -1161,6 +1163,7 @@ If not provided, then each sample is given unit weight.</dd>
     self : object
         Returns self.
     &#34;&#34;&#34;
+    check_binary_target(self, y)
     X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
     check_classification_targets(y)
     self.n_features_ = X.shape[1]

--- a/docs/rule_set/slipper.html
+++ b/docs/rule_set/slipper.html
@@ -23,6 +23,7 @@
 </summary>
 <pre><code class="python">from imodels.rule_set.boosted_rules import BoostedRulesClassifier
 from imodels.rule_set.slipper_util import SlipperBaseEstimator
+from imodels.util.arguments import check_binary_target
 
 
 class SlipperClassifier(BoostedRulesClassifier):
@@ -35,7 +36,13 @@ class SlipperClassifier(BoostedRulesClassifier):
         n_estimators
         &#39;&#39;&#39;
         super().__init__(estimator=SlipperBaseEstimator(), n_estimators=n_estimators, **kwargs)
-        # super().__init__(n_estimators, SlipperBaseEstimator)</code></pre>
+        # super().__init__(n_estimators, SlipperBaseEstimator)
+
+    def fit(self, X, y, feature_names=None, **kwargs):
+        # its base estimator learns a single binary rule, so a multiclass target
+        # otherwise fails deep inside boosting with a shape mismatch
+        check_binary_target(self, y)
+        return super().fit(X, y, feature_names=feature_names, **kwargs)</code></pre>
 </details>
 </section>
 <section>
@@ -79,7 +86,13 @@ Parameters</p>
         n_estimators
         &#39;&#39;&#39;
         super().__init__(estimator=SlipperBaseEstimator(), n_estimators=n_estimators, **kwargs)
-        # super().__init__(n_estimators, SlipperBaseEstimator)</code></pre>
+        # super().__init__(n_estimators, SlipperBaseEstimator)
+
+    def fit(self, X, y, feature_names=None, **kwargs):
+        # its base estimator learns a single binary rule, so a multiclass target
+        # otherwise fails deep inside boosting with a shape mismatch
+        check_binary_target(self, y)
+        return super().fit(X, y, feature_names=feature_names, **kwargs)</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">

--- a/docs/rule_set/slipper_util.html
+++ b/docs/rule_set/slipper_util.html
@@ -21,10 +21,9 @@
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">import random
-
-import numpy as np
+<pre><code class="python">import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
+from sklearn.utils import check_random_state
 from sklearn.model_selection import train_test_split
 
 from imodels.util.arguments import check_fit_arguments
@@ -36,7 +35,10 @@ class SlipperBaseEstimator(BaseEstimator, ClassifierMixin):
     as part of the SlipperRulesClassifier.
     &#34;&#34;&#34;
 
-    def __init__(self):
+    def __init__(self, random_state=None):
+        # exposed so that the boosting ensemble seeds each clone of this
+        # estimator, which is how sklearn makes sub-estimators reproducible
+        self.random_state = random_state
         self.Z = None
         self.rule = None
         self.D = None
@@ -200,10 +202,10 @@ class SlipperBaseEstimator(BaseEstimator, ClassifierMixin):
         predict negative
         &#34;&#34;&#34;
         default_rule = []
-        features = random.choices(
-            range(X.shape[1]),
-            k=random.randint(2, 8)
-        )
+        # drawn through random_state rather than the `random` module, which
+        # neither random_state nor np.random.seed can control
+        rng = check_random_state(self.random_state)
+        features = list(rng.choice(X.shape[1], size=rng.randint(2, 9)))
 
         default_rule.append({
             &#39;feature&#39;: str(features[0]),
@@ -270,14 +272,11 @@ class SlipperBaseEstimator(BaseEstimator, ClassifierMixin):
         }
 
     def predict_proba(self, X):
-
-        proba = self.predict(X)
-        proba = proba.reshape(-1, 1)
-        proba = np.hstack([
-            np.zeros(proba.shape), proba
-        ])
-
-        return proba
+        # a rule either fires or it doesn&#39;t, so the two columns are the
+        # complementary probabilities; returning [0, prediction] instead left
+        # rows that don&#39;t sum to 1, which corrupts the boosting weights
+        proba = np.asarray(self.predict(X), dtype=float).reshape(-1, 1)
+        return np.hstack([1 - proba, proba])
 
     def predict(self, X):
         &#34;&#34;&#34;
@@ -290,12 +289,16 @@ class SlipperBaseEstimator(BaseEstimator, ClassifierMixin):
         &#34;&#34;&#34;
         Main loop for training
         &#34;&#34;&#34;
-        X, y, feature_names = check_fit_arguments(self, X, y, feature_names) 
+        X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
         if sample_weight is not None:
             self.D = sample_weight
+        elif self.D is None:
+            # uniform weights, so the estimator also works outside the ensemble
+            self.D = np.full(len(y), 1 / len(y))
 
+        rng = check_random_state(self.random_state)
         X_grow, X_prune, y_grow, y_prune = \
-            train_test_split(X, y, test_size=0.33)
+            train_test_split(X, y, test_size=0.33, random_state=rng)
 
         self._make_feature_dict(X.shape[1], feature_names)
 
@@ -317,6 +320,7 @@ class SlipperBaseEstimator(BaseEstimator, ClassifierMixin):
 <dl>
 <dt id="imodels.rule_set.slipper_util.SlipperBaseEstimator"><code class="flex name class">
 <span>class <span class="ident">SlipperBaseEstimator</span></span>
+<span>(</span><span>random_state=None)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>An estimator that supports building rules as described in
@@ -332,7 +336,10 @@ as part of the SlipperRulesClassifier.</p></div>
     as part of the SlipperRulesClassifier.
     &#34;&#34;&#34;
 
-    def __init__(self):
+    def __init__(self, random_state=None):
+        # exposed so that the boosting ensemble seeds each clone of this
+        # estimator, which is how sklearn makes sub-estimators reproducible
+        self.random_state = random_state
         self.Z = None
         self.rule = None
         self.D = None
@@ -496,10 +503,10 @@ as part of the SlipperRulesClassifier.</p></div>
         predict negative
         &#34;&#34;&#34;
         default_rule = []
-        features = random.choices(
-            range(X.shape[1]),
-            k=random.randint(2, 8)
-        )
+        # drawn through random_state rather than the `random` module, which
+        # neither random_state nor np.random.seed can control
+        rng = check_random_state(self.random_state)
+        features = list(rng.choice(X.shape[1], size=rng.randint(2, 9)))
 
         default_rule.append({
             &#39;feature&#39;: str(features[0]),
@@ -566,14 +573,11 @@ as part of the SlipperRulesClassifier.</p></div>
         }
 
     def predict_proba(self, X):
-
-        proba = self.predict(X)
-        proba = proba.reshape(-1, 1)
-        proba = np.hstack([
-            np.zeros(proba.shape), proba
-        ])
-
-        return proba
+        # a rule either fires or it doesn&#39;t, so the two columns are the
+        # complementary probabilities; returning [0, prediction] instead left
+        # rows that don&#39;t sum to 1, which corrupts the boosting weights
+        proba = np.asarray(self.predict(X), dtype=float).reshape(-1, 1)
+        return np.hstack([1 - proba, proba])
 
     def predict(self, X):
         &#34;&#34;&#34;
@@ -586,12 +590,16 @@ as part of the SlipperRulesClassifier.</p></div>
         &#34;&#34;&#34;
         Main loop for training
         &#34;&#34;&#34;
-        X, y, feature_names = check_fit_arguments(self, X, y, feature_names) 
+        X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
         if sample_weight is not None:
             self.D = sample_weight
+        elif self.D is None:
+            # uniform weights, so the estimator also works outside the ensemble
+            self.D = np.full(len(y), 1 / len(y))
 
+        rng = check_random_state(self.random_state)
         X_grow, X_prune, y_grow, y_prune = \
-            train_test_split(X, y, test_size=0.33)
+            train_test_split(X, y, test_size=0.33, random_state=rng)
 
         self._make_feature_dict(X.shape[1], feature_names)
 
@@ -624,12 +632,16 @@ as part of the SlipperRulesClassifier.</p></div>
     &#34;&#34;&#34;
     Main loop for training
     &#34;&#34;&#34;
-    X, y, feature_names = check_fit_arguments(self, X, y, feature_names) 
+    X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
     if sample_weight is not None:
         self.D = sample_weight
+    elif self.D is None:
+        # uniform weights, so the estimator also works outside the ensemble
+        self.D = np.full(len(y), 1 / len(y))
 
+    rng = check_random_state(self.random_state)
     X_grow, X_prune, y_grow, y_prune = \
-        train_test_split(X, y, test_size=0.33)
+        train_test_split(X, y, test_size=0.33, random_state=rng)
 
     self._make_feature_dict(X.shape[1], feature_names)
 
@@ -668,14 +680,11 @@ using estimators rule</p></div>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def predict_proba(self, X):
-
-    proba = self.predict(X)
-    proba = proba.reshape(-1, 1)
-    proba = np.hstack([
-        np.zeros(proba.shape), proba
-    ])
-
-    return proba</code></pre>
+    # a rule either fires or it doesn&#39;t, so the two columns are the
+    # complementary probabilities; returning [0, prediction] instead left
+    # rows that don&#39;t sum to 1, which corrupts the boosting weights
+    proba = np.asarray(self.predict(X), dtype=float).reshape(-1, 1)
+    return np.hstack([1 - proba, proba])</code></pre>
 </details>
 </dd>
 <dt id="imodels.rule_set.slipper_util.SlipperBaseEstimator.set_fit_request"><code class="name flex">

--- a/docs/tree/c45_tree/c45_tree.html
+++ b/docs/tree/c45_tree/c45_tree.html
@@ -152,6 +152,22 @@ def shrink_node(node, reg_param, parent_val, parent_num, cum_sum, scheme, consta
     return node
 
 
+def _make_xml_safe_names(feature_names):
+    &#34;&#34;&#34;Turn feature names into distinct, valid XML element names.&#34;&#34;&#34;
+    safe_names = []
+    for name in feature_names:
+        safe = &#39;&#39;.join(c for c in str(name) if c.isalnum() or c == &#39;_&#39;)
+        if not safe or safe[0].isdigit():
+            safe = &#39;X_&#39; + safe
+        # keep names distinct after stripping the punctuation out of them
+        candidate, suffix = safe, 1
+        while candidate in safe_names:
+            candidate = f&#39;{safe}_{suffix}&#39;
+            suffix += 1
+        safe_names.append(candidate)
+    return safe_names
+
+
 class C45TreeClassifier(BaseEstimator, ClassifierMixin):
     &#34;&#34;&#34;A C4.5 tree classifier.
 
@@ -173,16 +189,15 @@ class C45TreeClassifier(BaseEstimator, ClassifierMixin):
         if feature_names is None:
             self.feature_names = [f&#39;X_{x}&#39; for x in range(X.shape[1])]
         else:
-            # only include alphanumeric chars / replace spaces with underscores
-            self.feature_names = [&#39;&#39;.join([i for i in x if i.isalnum()]).replace(&#39; &#39;, &#39;_&#39;)
-                                  for x in feature_names]
-            self.feature_names = [
-                &#39;X_&#39; + x if x[0].isdigit()
-                else x
-                for x in self.feature_names
-            ]
+            # the tree is stored as XML, so names must be valid element names.
+            # They must also stay distinct: &#39;age (years)&#39; and &#39;age-years&#39; both
+            # reduce to &#39;ageyears&#39;, and the tree would then read the wrong column.
+            self.feature_names = _make_xml_safe_names(feature_names)
 
         assert len(self.feature_names) == X.shape[1]
+        # so that rules can be reported with the names the caller used
+        self.xml_name_to_feature_name_ = dict(
+            zip(self.feature_names, feature_names))
 
         data = [[] for i in range(len(self.feature_names))]
         categories = []
@@ -256,13 +271,43 @@ class C45TreeClassifier(BaseEstimator, ClassifierMixin):
 
         return np.array(prediction)
 
+    def _class_scores(self, X):
+        &#34;&#34;&#34;Per-class scores for each row, from the leaves it reaches.
+
+        `decision` returns {class label: probability}; C4.5 is multiclass by
+        construction, so this keeps the whole distribution rather than
+        collapsing it to the top class.
+        &#34;&#34;&#34;
+        check_is_fitted(self, [&#39;tree_&#39;, &#39;resultType&#39;, &#39;feature_names&#39;])
+        X = check_array(X)
+        n_classes = len(self.classes_)
+
+        scores = np.zeros((X.shape[0], n_classes))
+        for i in range(X.shape[0]):
+            answers = decision(self.root, X[i], self.feature_names, 1) or {}
+            for label, probability in answers.items():
+                # leaves store the encoded label (0, 1, ... ) as a string
+                index = int(float(label))
+                if 0 &lt;= index &lt; n_classes:
+                    scores[i, index] += float(probability)
+        return scores
+
     def predict(self, X):
-        raw_preds = self.raw_preds(X)
-        return decode_labels(self, (raw_preds &gt; np.ones_like(raw_preds) * 0.5).astype(int))
+        return decode_labels(self, np.argmax(self.predict_proba(X), axis=1))
 
     def predict_proba(self, X):
-        raw_preds = self.raw_preds(X)
-        return np.vstack((1 - raw_preds, raw_preds)).transpose()
+        if len(self.classes_) == 2:
+            # unchanged binary path: leaves hold the probability of class 1,
+            # which is also what hierarchical shrinkage rewrites them to
+            raw_preds = self.raw_preds(X)
+            return np.vstack((1 - raw_preds, raw_preds)).transpose()
+
+        scores = self._class_scores(X)
+        totals = scores.sum(axis=1, keepdims=True)
+        # a row that reached no leaf falls back to a uniform distribution
+        with np.errstate(invalid=&#39;ignore&#39;, divide=&#39;ignore&#39;):
+            normalized = scores / totals
+        return np.where(totals &gt; 0, normalized, 1 / scores.shape[1])
 
     def __str__(self):
         check_is_fitted(self, [&#39;tree_&#39;])
@@ -550,16 +595,15 @@ if __name__ == &#39;__main__&#39;:
         if feature_names is None:
             self.feature_names = [f&#39;X_{x}&#39; for x in range(X.shape[1])]
         else:
-            # only include alphanumeric chars / replace spaces with underscores
-            self.feature_names = [&#39;&#39;.join([i for i in x if i.isalnum()]).replace(&#39; &#39;, &#39;_&#39;)
-                                  for x in feature_names]
-            self.feature_names = [
-                &#39;X_&#39; + x if x[0].isdigit()
-                else x
-                for x in self.feature_names
-            ]
+            # the tree is stored as XML, so names must be valid element names.
+            # They must also stay distinct: &#39;age (years)&#39; and &#39;age-years&#39; both
+            # reduce to &#39;ageyears&#39;, and the tree would then read the wrong column.
+            self.feature_names = _make_xml_safe_names(feature_names)
 
         assert len(self.feature_names) == X.shape[1]
+        # so that rules can be reported with the names the caller used
+        self.xml_name_to_feature_name_ = dict(
+            zip(self.feature_names, feature_names))
 
         data = [[] for i in range(len(self.feature_names))]
         categories = []
@@ -633,13 +677,43 @@ if __name__ == &#39;__main__&#39;:
 
         return np.array(prediction)
 
+    def _class_scores(self, X):
+        &#34;&#34;&#34;Per-class scores for each row, from the leaves it reaches.
+
+        `decision` returns {class label: probability}; C4.5 is multiclass by
+        construction, so this keeps the whole distribution rather than
+        collapsing it to the top class.
+        &#34;&#34;&#34;
+        check_is_fitted(self, [&#39;tree_&#39;, &#39;resultType&#39;, &#39;feature_names&#39;])
+        X = check_array(X)
+        n_classes = len(self.classes_)
+
+        scores = np.zeros((X.shape[0], n_classes))
+        for i in range(X.shape[0]):
+            answers = decision(self.root, X[i], self.feature_names, 1) or {}
+            for label, probability in answers.items():
+                # leaves store the encoded label (0, 1, ... ) as a string
+                index = int(float(label))
+                if 0 &lt;= index &lt; n_classes:
+                    scores[i, index] += float(probability)
+        return scores
+
     def predict(self, X):
-        raw_preds = self.raw_preds(X)
-        return decode_labels(self, (raw_preds &gt; np.ones_like(raw_preds) * 0.5).astype(int))
+        return decode_labels(self, np.argmax(self.predict_proba(X), axis=1))
 
     def predict_proba(self, X):
-        raw_preds = self.raw_preds(X)
-        return np.vstack((1 - raw_preds, raw_preds)).transpose()
+        if len(self.classes_) == 2:
+            # unchanged binary path: leaves hold the probability of class 1,
+            # which is also what hierarchical shrinkage rewrites them to
+            raw_preds = self.raw_preds(X)
+            return np.vstack((1 - raw_preds, raw_preds)).transpose()
+
+        scores = self._class_scores(X)
+        totals = scores.sum(axis=1, keepdims=True)
+        # a row that reached no leaf falls back to a uniform distribution
+        with np.errstate(invalid=&#39;ignore&#39;, divide=&#39;ignore&#39;):
+            normalized = scores / totals
+        return np.where(totals &gt; 0, normalized, 1 / scores.shape[1])
 
     def __str__(self):
         check_is_fitted(self, [&#39;tree_&#39;])
@@ -792,16 +866,15 @@ def root(self):
     if feature_names is None:
         self.feature_names = [f&#39;X_{x}&#39; for x in range(X.shape[1])]
     else:
-        # only include alphanumeric chars / replace spaces with underscores
-        self.feature_names = [&#39;&#39;.join([i for i in x if i.isalnum()]).replace(&#39; &#39;, &#39;_&#39;)
-                              for x in feature_names]
-        self.feature_names = [
-            &#39;X_&#39; + x if x[0].isdigit()
-            else x
-            for x in self.feature_names
-        ]
+        # the tree is stored as XML, so names must be valid element names.
+        # They must also stay distinct: &#39;age (years)&#39; and &#39;age-years&#39; both
+        # reduce to &#39;ageyears&#39;, and the tree would then read the wrong column.
+        self.feature_names = _make_xml_safe_names(feature_names)
 
     assert len(self.feature_names) == X.shape[1]
+    # so that rules can be reported with the names the caller used
+    self.xml_name_to_feature_name_ = dict(
+        zip(self.feature_names, feature_names))
 
     data = [[] for i in range(len(self.feature_names))]
     categories = []
@@ -1007,8 +1080,7 @@ def root(self):
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def predict(self, X):
-    raw_preds = self.raw_preds(X)
-    return decode_labels(self, (raw_preds &gt; np.ones_like(raw_preds) * 0.5).astype(int))</code></pre>
+    return decode_labels(self, np.argmax(self.predict_proba(X), axis=1))</code></pre>
 </details>
 </dd>
 <dt id="imodels.tree.c45_tree.c45_tree.C45TreeClassifier.predict_proba"><code class="name flex">
@@ -1021,8 +1093,18 @@ def root(self):
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def predict_proba(self, X):
-    raw_preds = self.raw_preds(X)
-    return np.vstack((1 - raw_preds, raw_preds)).transpose()</code></pre>
+    if len(self.classes_) == 2:
+        # unchanged binary path: leaves hold the probability of class 1,
+        # which is also what hierarchical shrinkage rewrites them to
+        raw_preds = self.raw_preds(X)
+        return np.vstack((1 - raw_preds, raw_preds)).transpose()
+
+    scores = self._class_scores(X)
+    totals = scores.sum(axis=1, keepdims=True)
+    # a row that reached no leaf falls back to a uniform distribution
+    with np.errstate(invalid=&#39;ignore&#39;, divide=&#39;ignore&#39;):
+        normalized = scores / totals
+    return np.where(totals &gt; 0, normalized, 1 / scores.shape[1])</code></pre>
 </details>
 </dd>
 <dt id="imodels.tree.c45_tree.c45_tree.C45TreeClassifier.raw_preds"><code class="name flex">

--- a/docs/tree/cart_ccp.html
+++ b/docs/tree/cart_ccp.html
@@ -106,6 +106,15 @@ class DecisionTreeCCPClassifier(ClassifierMixin, BaseEstimator):
         from imodels.util.get_rules import get_rules
         return get_rules(self, feature_names=feature_names)
 
+    @property
+    def feature_importances_(self):
+        &#34;&#34;&#34;Mean decrease in impurity of the pruned tree, as in sklearn.&#34;&#34;&#34;
+        return self.estimator_.feature_importances_
+    def apply(self, X):
+        &#34;&#34;&#34;Return the leaf each sample reaches (see imodels.util.apply.apply_leaves).&#34;&#34;&#34;
+        from imodels.util.apply import apply_leaves
+        return apply_leaves(self, X)
+
     def _get_complexity(self, BaseEstimator, complexity_measure):
         return compute_tree_complexity(BaseEstimator.tree_, complexity_measure)
 
@@ -196,6 +205,20 @@ class DecisionTreeCCPRegressor(BaseEstimator):
         self.estimator_.fit(X, y, sample_weight=sample_weight)
         self._copy_fitted_attributes()
         return self
+
+    @property
+    def feature_importances_(self):
+        &#34;&#34;&#34;Mean decrease in impurity of the pruned tree, as in sklearn.&#34;&#34;&#34;
+        return self.estimator_.feature_importances_
+    def get_rules(self, feature_names=None):
+        &#34;&#34;&#34;Return this model&#39;s rules as a DataFrame (see imodels.get_rules).&#34;&#34;&#34;
+        from imodels.util.get_rules import get_rules
+        return get_rules(self, feature_names=feature_names)
+
+    def apply(self, X):
+        &#34;&#34;&#34;Return the leaf each sample reaches (see imodels.util.apply.apply_leaves).&#34;&#34;&#34;
+        from imodels.util.apply import apply_leaves
+        return apply_leaves(self, X)
 
     def _get_complexity(self, BaseEstimator, complexity_measure):
         return compute_tree_complexity(BaseEstimator.tree_, self.complexity_measure)
@@ -388,6 +411,15 @@ array([1, 1, 1])
         from imodels.util.get_rules import get_rules
         return get_rules(self, feature_names=feature_names)
 
+    @property
+    def feature_importances_(self):
+        &#34;&#34;&#34;Mean decrease in impurity of the pruned tree, as in sklearn.&#34;&#34;&#34;
+        return self.estimator_.feature_importances_
+    def apply(self, X):
+        &#34;&#34;&#34;Return the leaf each sample reaches (see imodels.util.apply.apply_leaves).&#34;&#34;&#34;
+        from imodels.util.apply import apply_leaves
+        return apply_leaves(self, X)
+
     def _get_complexity(self, BaseEstimator, complexity_measure):
         return compute_tree_complexity(BaseEstimator.tree_, complexity_measure)
 
@@ -414,8 +446,39 @@ array([1, 1, 1])
 <li>sklearn.utils._repr_html.base._HTMLDocumentationLinkMixin</li>
 <li>sklearn.utils._metadata_requests._MetadataRequester</li>
 </ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="imodels.tree.cart_ccp.DecisionTreeCCPClassifier.feature_importances_"><code class="name">var <span class="ident">feature_importances_</span></code></dt>
+<dd>
+<div class="desc"><p>Mean decrease in impurity of the pruned tree, as in sklearn.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def feature_importances_(self):
+    &#34;&#34;&#34;Mean decrease in impurity of the pruned tree, as in sklearn.&#34;&#34;&#34;
+    return self.estimator_.feature_importances_</code></pre>
+</details>
+</dd>
+</dl>
 <h3>Methods</h3>
 <dl>
+<dt id="imodels.tree.cart_ccp.DecisionTreeCCPClassifier.apply"><code class="name flex">
+<span>def <span class="ident">apply</span></span>(<span>self, X)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Return the leaf each sample reaches (see imodels.util.apply.apply_leaves).</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def apply(self, X):
+    &#34;&#34;&#34;Return the leaf each sample reaches (see imodels.util.apply.apply_leaves).&#34;&#34;&#34;
+    from imodels.util.apply import apply_leaves
+    return apply_leaves(self, X)</code></pre>
+</details>
+</dd>
 <dt id="imodels.tree.cart_ccp.DecisionTreeCCPClassifier.fit"><code class="name flex">
 <span>def <span class="ident">fit</span></span>(<span>self, X, y, sample_weight=None, *args, **kwargs)</span>
 </code></dt>
@@ -784,6 +847,20 @@ array([3, 3, 3])
         self._copy_fitted_attributes()
         return self
 
+    @property
+    def feature_importances_(self):
+        &#34;&#34;&#34;Mean decrease in impurity of the pruned tree, as in sklearn.&#34;&#34;&#34;
+        return self.estimator_.feature_importances_
+    def get_rules(self, feature_names=None):
+        &#34;&#34;&#34;Return this model&#39;s rules as a DataFrame (see imodels.get_rules).&#34;&#34;&#34;
+        from imodels.util.get_rules import get_rules
+        return get_rules(self, feature_names=feature_names)
+
+    def apply(self, X):
+        &#34;&#34;&#34;Return the leaf each sample reaches (see imodels.util.apply.apply_leaves).&#34;&#34;&#34;
+        from imodels.util.apply import apply_leaves
+        return apply_leaves(self, X)
+
     def _get_complexity(self, BaseEstimator, complexity_measure):
         return compute_tree_complexity(BaseEstimator.tree_, self.complexity_measure)
 
@@ -803,8 +880,39 @@ array([3, 3, 3])
 <li>sklearn.utils._repr_html.base._HTMLDocumentationLinkMixin</li>
 <li>sklearn.utils._metadata_requests._MetadataRequester</li>
 </ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="imodels.tree.cart_ccp.DecisionTreeCCPRegressor.feature_importances_"><code class="name">var <span class="ident">feature_importances_</span></code></dt>
+<dd>
+<div class="desc"><p>Mean decrease in impurity of the pruned tree, as in sklearn.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def feature_importances_(self):
+    &#34;&#34;&#34;Mean decrease in impurity of the pruned tree, as in sklearn.&#34;&#34;&#34;
+    return self.estimator_.feature_importances_</code></pre>
+</details>
+</dd>
+</dl>
 <h3>Methods</h3>
 <dl>
+<dt id="imodels.tree.cart_ccp.DecisionTreeCCPRegressor.apply"><code class="name flex">
+<span>def <span class="ident">apply</span></span>(<span>self, X)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Return the leaf each sample reaches (see imodels.util.apply.apply_leaves).</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def apply(self, X):
+    &#34;&#34;&#34;Return the leaf each sample reaches (see imodels.util.apply.apply_leaves).&#34;&#34;&#34;
+    from imodels.util.apply import apply_leaves
+    return apply_leaves(self, X)</code></pre>
+</details>
+</dd>
 <dt id="imodels.tree.cart_ccp.DecisionTreeCCPRegressor.fit"><code class="name flex">
 <span>def <span class="ident">fit</span></span>(<span>self, X, y, sample_weight=None)</span>
 </code></dt>
@@ -852,6 +960,21 @@ contained subobjects that are estimators.</dd>
         &#34;desired_complexity&#34;: self.desired_complexity,
         &#34;complexity_measure&#34;: self.complexity_measure,
     }</code></pre>
+</details>
+</dd>
+<dt id="imodels.tree.cart_ccp.DecisionTreeCCPRegressor.get_rules"><code class="name flex">
+<span>def <span class="ident">get_rules</span></span>(<span>self, feature_names=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Return this model's rules as a DataFrame (see imodels.get_rules).</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_rules(self, feature_names=None):
+    &#34;&#34;&#34;Return this model&#39;s rules as a DataFrame (see imodels.get_rules).&#34;&#34;&#34;
+    from imodels.util.get_rules import get_rules
+    return get_rules(self, feature_names=feature_names)</code></pre>
 </details>
 </dd>
 <dt id="imodels.tree.cart_ccp.DecisionTreeCCPRegressor.predict"><code class="name flex">
@@ -1105,6 +1228,7 @@ array([1, 1, 1])
 <li><code><b><a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifier" href="hierarchical_shrinkage.html#imodels.tree.hierarchical_shrinkage.HSTreeClassifier">HSTreeClassifier</a></b></code>:
 <ul class="hlist">
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifier.apply" href="hierarchical_shrinkage.html#imodels.tree.hierarchical_shrinkage.HSTree.apply">apply</a></code></li>
+<li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifier.feature_importances_" href="hierarchical_shrinkage.html#imodels.tree.hierarchical_shrinkage.HSTree.feature_importances_">feature_importances_</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifier.get_params" href="hierarchical_shrinkage.html#imodels.tree.hierarchical_shrinkage.HSTree.get_params">get_params</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifier.get_rules" href="hierarchical_shrinkage.html#imodels.tree.hierarchical_shrinkage.HSTree.get_rules">get_rules</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifier.set_fit_request" href="hierarchical_shrinkage.html#imodels.tree.hierarchical_shrinkage.HSTree.set_fit_request">set_fit_request</a></code></li>
@@ -1210,6 +1334,7 @@ array([0, 0, 0])
 <li><code><b><a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressor" href="hierarchical_shrinkage.html#imodels.tree.hierarchical_shrinkage.HSTreeRegressor">HSTreeRegressor</a></b></code>:
 <ul class="hlist">
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressor.apply" href="hierarchical_shrinkage.html#imodels.tree.hierarchical_shrinkage.HSTree.apply">apply</a></code></li>
+<li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressor.feature_importances_" href="hierarchical_shrinkage.html#imodels.tree.hierarchical_shrinkage.HSTree.feature_importances_">feature_importances_</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressor.get_params" href="hierarchical_shrinkage.html#imodels.tree.hierarchical_shrinkage.HSTree.get_params">get_params</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressor.get_rules" href="hierarchical_shrinkage.html#imodels.tree.hierarchical_shrinkage.HSTree.get_rules">get_rules</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressor.set_fit_request" href="hierarchical_shrinkage.html#imodels.tree.hierarchical_shrinkage.HSTree.set_fit_request">set_fit_request</a></code></li>
@@ -1236,7 +1361,9 @@ array([0, 0, 0])
 <ul>
 <li>
 <h4><code><a title="imodels.tree.cart_ccp.DecisionTreeCCPClassifier" href="#imodels.tree.cart_ccp.DecisionTreeCCPClassifier">DecisionTreeCCPClassifier</a></code></h4>
-<ul class="two-column">
+<ul class="">
+<li><code><a title="imodels.tree.cart_ccp.DecisionTreeCCPClassifier.apply" href="#imodels.tree.cart_ccp.DecisionTreeCCPClassifier.apply">apply</a></code></li>
+<li><code><a title="imodels.tree.cart_ccp.DecisionTreeCCPClassifier.feature_importances_" href="#imodels.tree.cart_ccp.DecisionTreeCCPClassifier.feature_importances_">feature_importances_</a></code></li>
 <li><code><a title="imodels.tree.cart_ccp.DecisionTreeCCPClassifier.fit" href="#imodels.tree.cart_ccp.DecisionTreeCCPClassifier.fit">fit</a></code></li>
 <li><code><a title="imodels.tree.cart_ccp.DecisionTreeCCPClassifier.get_params" href="#imodels.tree.cart_ccp.DecisionTreeCCPClassifier.get_params">get_params</a></code></li>
 <li><code><a title="imodels.tree.cart_ccp.DecisionTreeCCPClassifier.get_rules" href="#imodels.tree.cart_ccp.DecisionTreeCCPClassifier.get_rules">get_rules</a></code></li>
@@ -1249,9 +1376,12 @@ array([0, 0, 0])
 </li>
 <li>
 <h4><code><a title="imodels.tree.cart_ccp.DecisionTreeCCPRegressor" href="#imodels.tree.cart_ccp.DecisionTreeCCPRegressor">DecisionTreeCCPRegressor</a></code></h4>
-<ul class="two-column">
+<ul class="">
+<li><code><a title="imodels.tree.cart_ccp.DecisionTreeCCPRegressor.apply" href="#imodels.tree.cart_ccp.DecisionTreeCCPRegressor.apply">apply</a></code></li>
+<li><code><a title="imodels.tree.cart_ccp.DecisionTreeCCPRegressor.feature_importances_" href="#imodels.tree.cart_ccp.DecisionTreeCCPRegressor.feature_importances_">feature_importances_</a></code></li>
 <li><code><a title="imodels.tree.cart_ccp.DecisionTreeCCPRegressor.fit" href="#imodels.tree.cart_ccp.DecisionTreeCCPRegressor.fit">fit</a></code></li>
 <li><code><a title="imodels.tree.cart_ccp.DecisionTreeCCPRegressor.get_params" href="#imodels.tree.cart_ccp.DecisionTreeCCPRegressor.get_params">get_params</a></code></li>
+<li><code><a title="imodels.tree.cart_ccp.DecisionTreeCCPRegressor.get_rules" href="#imodels.tree.cart_ccp.DecisionTreeCCPRegressor.get_rules">get_rules</a></code></li>
 <li><code><a title="imodels.tree.cart_ccp.DecisionTreeCCPRegressor.predict" href="#imodels.tree.cart_ccp.DecisionTreeCCPRegressor.predict">predict</a></code></li>
 <li><code><a title="imodels.tree.cart_ccp.DecisionTreeCCPRegressor.score" href="#imodels.tree.cart_ccp.DecisionTreeCCPRegressor.score">score</a></code></li>
 <li><code><a title="imodels.tree.cart_ccp.DecisionTreeCCPRegressor.set_fit_request" href="#imodels.tree.cart_ccp.DecisionTreeCCPRegressor.set_fit_request">set_fit_request</a></code></li>

--- a/docs/tree/cart_wrapper.html
+++ b/docs/tree/cart_wrapper.html
@@ -62,6 +62,7 @@ class GreedyTreeClassifier(DecisionTreeClassifier):
             Fitted estimator.
         &#34;&#34;&#34;
         X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
+        self.feature_names = list(feature_names)
         classes = self.classes_  # super().fit overwrites this with the encoded labels
         names_in = getattr(self, &#39;feature_names_in_&#39;, None)
         super().fit(X, y, sample_weight=sample_weight, check_input=check_input)
@@ -198,6 +199,7 @@ class GreedyTreeRegressor(DecisionTreeRegressor):
             Fitted estimator.
         &#34;&#34;&#34;
         X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
+        self.feature_names = list(feature_names)
         classes = self.classes_  # super().fit overwrites this with the encoded labels
         names_in = getattr(self, &#39;feature_names_in_&#39;, None)
         super().fit(X, y, sample_weight=sample_weight, check_input=check_input)
@@ -304,6 +306,7 @@ Don't use this parameter unless you know what you do.</dd>
         Fitted estimator.
     &#34;&#34;&#34;
     X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
+    self.feature_names = list(feature_names)
     classes = self.classes_  # super().fit overwrites this with the encoded labels
     names_in = getattr(self, &#39;feature_names_in_&#39;, None)
     super().fit(X, y, sample_weight=sample_weight, check_input=check_input)

--- a/docs/tree/figs.html
+++ b/docs/tree/figs.html
@@ -35,6 +35,7 @@ from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.model_selection import train_test_split, cross_val_score
 from sklearn.tree import plot_tree, DecisionTreeClassifier
 from sklearn.utils import check_X_y, check_array
+from joblib import Parallel, delayed
 from sklearn.utils.class_weight import compute_sample_weight
 from sklearn.utils.validation import _check_sample_weight, check_is_fitted
 
@@ -147,6 +148,8 @@ class FIGS(BaseEstimator):
         max_features: str = None,
         max_depth: int = None,
         class_weight=None,
+        verbose: int = 0,
+        n_jobs: int = None,
     ):
         &#34;&#34;&#34;
         Params
@@ -159,6 +162,15 @@ class FIGS(BaseEstimator):
             A node will be split if this split induces a decrease of the impurity greater than or equal to this value.
         max_features
             The number of features to consider when looking for the best split (see https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html)
+        n_jobs: int, default=None
+            Number of threads used to evaluate candidate splits, which are
+            independent of one another. None means 1; -1 uses all processors.
+            Only helps once there are several candidates to compare, i.e. on
+            larger datasets or deeper models.
+        verbose: int, default=0
+            Controls progress reporting while fitting. 0 is silent; 1 reports each
+            rule as it is added, with the running total; 2 also prints the model
+            after every rule. Can be overridden per call via fit(verbose=...).
         class_weight: dict, list of dict or &#34;balanced&#34;, default=None
             Classification only. Weights associated with classes, in the form
             {class_label: weight}. &#34;balanced&#34; weights each class by
@@ -174,6 +186,8 @@ class FIGS(BaseEstimator):
         self.max_features = max_features
         self.max_depth = max_depth
         self.class_weight = class_weight
+        self.verbose = verbose
+        self.n_jobs = n_jobs
         self._init_decision_function()
         self.n_outputs = None
         self.need_to_reshape = False
@@ -188,6 +202,26 @@ class FIGS(BaseEstimator):
         &#34;&#34;&#34;Return the leaf each sample reaches (see imodels.util.apply.apply_leaves).&#34;&#34;&#34;
         from imodels.util.apply import apply_leaves
         return apply_leaves(self, X)
+    def _fit_candidate_stumps(self, X, potential_splits, y_residuals_per_tree,
+                              sample_weight):
+        &#34;&#34;&#34;Re-fit the stump for every candidate split, in parallel if asked.&#34;&#34;&#34;
+        def fit_stump(potential_split):
+            return self._construct_node_with_stump(
+                X=X,
+                y=y_residuals_per_tree[potential_split.tree_num],
+                idxs=potential_split.idxs,
+                tree_num=potential_split.tree_num,
+                sample_weight=sample_weight,
+                max_features=self.max_features,
+                depth=potential_split.depth + 1,
+            )
+
+        n_jobs = 1 if self.n_jobs is None else self.n_jobs
+        if n_jobs == 1 or len(potential_splits) &lt; 2:
+            return [fit_stump(split) for split in potential_splits]
+        return Parallel(n_jobs=n_jobs, backend=&#34;threading&#34;)(
+            delayed(fit_stump)(split) for split in potential_splits)
+
     def _apply_class_weight(self, y, sample_weight):
         &#34;&#34;&#34;Fold class_weight into sample_weight, which the splits already honor.&#34;&#34;&#34;
         if self.class_weight is None:
@@ -330,7 +364,7 @@ class FIGS(BaseEstimator):
         X,
         y=None,
         feature_names=None,
-        verbose=False,
+        verbose=None,
         sample_weight=None,
         categorical_features=None,
     ):
@@ -342,6 +376,11 @@ class FIGS(BaseEstimator):
             Splits that would create child nodes with net zero or negative weight
             are ignored while searching for a split in each node.
         &#34;&#34;&#34;
+        # fit(verbose=...) still wins, so existing callers are unaffected
+        verbose = int(self.verbose if verbose is None else verbose)
+
+        # remembered so that predict/predict_proba don&#39;t need them passed again
+        self.categorical_features_ = categorical_features
         if categorical_features is not None:
             X, self._encoder = encode_categories(X, categorical_features)
 
@@ -428,8 +467,6 @@ class FIGS(BaseEstimator):
                 continue
 
             # split on node
-            if verbose:
-                print(&#34;\nadding &#34; + str(split_node))
             self.complexity_ += 1
 
             # if added a tree root
@@ -458,6 +495,14 @@ class FIGS(BaseEstimator):
             potential_splits.append(split_node.left)
             potential_splits.append(split_node.right)
 
+            if verbose &gt;= 1:
+                # reported after the bookkeeping above, so the counts are final
+                budget = &#39;&#39; if self.max_rules is None else f&#39;/{self.max_rules}&#39;
+                condition = (f&#34;X_{split_node.feature} &lt;= {split_node.threshold:0.3f}&#34;
+                             if split_node.feature is not None else str(split_node))
+                print(f&#34;rule {self.complexity_}{budget} &#34;
+                      f&#34;({len(self.trees_)} tree(s)): {condition}&#34;)
+
             # update predictions for altered tree
             for tree_num_ in range(len(self.trees_)):
                 y_predictions_per_tree[tree_num_] = self._predict_tree(
@@ -482,19 +527,12 @@ class FIGS(BaseEstimator):
 
             # recompute all impurities + update potential_split children
             potential_splits_new = []
-            for potential_split in potential_splits:
-                y_target = y_residuals_per_tree[potential_split.tree_num]
-
-                # re-calculate the best split
-                potential_split_updated = self._construct_node_with_stump(
-                    X=X,
-                    y=y_target,
-                    idxs=potential_split.idxs,
-                    tree_num=potential_split.tree_num,
-                    sample_weight=sample_weight,
-                    max_features=self.max_features,
-                    depth=potential_split.depth+1,
-                )
+            # each candidate&#39;s stump is fit independently of the others, and
+            # sklearn&#39;s tree builder releases the GIL, so this threads well
+            updated_splits = self._fit_candidate_stumps(
+                X, potential_splits, y_residuals_per_tree, sample_weight)
+            for potential_split, potential_split_updated in zip(
+                    potential_splits, updated_splits):
 
                 # need to preserve certain attributes from before (value at this split + is_root)
                 # value may change because residuals may have changed, but we want it to store the value from before
@@ -515,7 +553,7 @@ class FIGS(BaseEstimator):
             potential_splits = sorted(
                 potential_splits_new, key=lambda x: x.impurity_reduction
             )
-            if verbose:
+            if verbose &gt;= 2:
                 print(self)
             if self.max_rules is not None and self.complexity_ &gt;= self.max_rules:
                 finished = True
@@ -548,6 +586,11 @@ class FIGS(BaseEstimator):
                 node.setattrs(node_id=next(node_counter),
                               value_sklearn=value_sklearn,
                               n_samples_=X.shape[0])
+
+                if node.left is None and node.right is None:
+                    # a leaf splits on nothing: its feature is the -2 placeholder,
+                    # which indexes the wrong column (or raises, with one feature)
+                    return
 
                 idxs_left = X[:, node.feature] &lt;= node.threshold
                 _annotate_node(node.left, X[idxs_left], y[idxs_left],
@@ -663,6 +706,7 @@ class FIGS(BaseEstimator):
         return s
 
     def predict(self, X, categorical_features=None, by_tree=False):
+        categorical_features = self._categorical_features(categorical_features)
         if hasattr(self, &#34;_encoder&#34;):
             X = self._encode_categories(
                 X, categorical_features=categorical_features, encoder_name=&#34;_encoder&#34;)
@@ -691,11 +735,18 @@ class FIGS(BaseEstimator):
 #             class_preds = (preds &gt; 0.5).astype(int)
 #             return np.array([self.classes_[i] for i in class_preds])
 
+    def _categorical_features(self, categorical_features):
+        &#34;&#34;&#34;Fall back on the categorical features the model was fitted with.&#34;&#34;&#34;
+        if categorical_features is None:
+            return getattr(self, &#39;categorical_features_&#39;, None)
+        return categorical_features
+
     def predict_proba(self, X, categorical_features=None, use_clipped_prediction=False):
         &#34;&#34;&#34;Predict probability for classifiers:
         Default behavior is to constrain the outputs to the range of probabilities, i.e. 0 to 1, with a sigmoid function.
         Set use_clipped_prediction=True to use prior behavior of clipping between 0 and 1 instead.
         &#34;&#34;&#34;
+        categorical_features = self._categorical_features(categorical_features)
         if hasattr(self, &#34;_encoder&#34;):
             X = self._encode_categories(
                 X, categorical_features=categorical_features, encoder_name=&#34;_encoder&#34;)
@@ -844,6 +895,15 @@ class FIGSCV(BaseEstimator):
         &#34;&#34;&#34;Return this model&#39;s rules as a DataFrame (see imodels.get_rules).&#34;&#34;&#34;
         from imodels.util.get_rules import get_rules
         return get_rules(self, feature_names=feature_names)
+
+    @property
+    def feature_importances_(self):
+        &#34;&#34;&#34;Mean decrease in impurity of the selected FIGS model.&#34;&#34;&#34;
+        return self.figs.feature_importances_
+    def apply(self, X):
+        &#34;&#34;&#34;Return the leaf each sample reaches (see imodels.util.apply.apply_leaves).&#34;&#34;&#34;
+        from imodels.util.apply import apply_leaves
+        return apply_leaves(self, X)
 
     def get_params(self, deep=True):
         # defined explicitly because __init__ takes *args/**kwargs, which sklearn&#39;s
@@ -1047,7 +1107,7 @@ if __name__ == &#34;__main__&#34;:
 <dl>
 <dt id="imodels.tree.figs.FIGS"><code class="flex name class">
 <span>class <span class="ident">FIGS</span></span>
-<span>(</span><span>max_rules: int = 12, max_trees: int = None, min_impurity_decrease: float = 0.0, random_state=None, max_features: str = None, max_depth: int = None, class_weight=None)</span>
+<span>(</span><span>max_rules: int = 12, max_trees: int = None, min_impurity_decrease: float = 0.0, random_state=None, max_features: str = None, max_depth: int = None, class_weight=None, verbose: int = 0, n_jobs: int = None)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>FIGS (sum of trees) classifier.
@@ -1065,6 +1125,15 @@ min_impurity_decrease: float
 A node will be split if this split induces a decrease of the impurity greater than or equal to this value.
 max_features
 The number of features to consider when looking for the best split (see <a href="https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html">https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html</a>)
+n_jobs: int, default=None
+Number of threads used to evaluate candidate splits, which are
+independent of one another. None means 1; -1 uses all processors.
+Only helps once there are several candidates to compare, i.e. on
+larger datasets or deeper models.
+verbose: int, default=0
+Controls progress reporting while fitting. 0 is silent; 1 reports each
+rule as it is added, with the running total; 2 also prints the model
+after every rule. Can be overridden per call via fit(verbose=&hellip;).
 class_weight: dict, list of dict or "balanced", default=None
 Classification only. Weights associated with classes, in the form
 {class_label: weight}. "balanced" weights each class by
@@ -1093,6 +1162,8 @@ when both are given.</p></div>
         max_features: str = None,
         max_depth: int = None,
         class_weight=None,
+        verbose: int = 0,
+        n_jobs: int = None,
     ):
         &#34;&#34;&#34;
         Params
@@ -1105,6 +1176,15 @@ when both are given.</p></div>
             A node will be split if this split induces a decrease of the impurity greater than or equal to this value.
         max_features
             The number of features to consider when looking for the best split (see https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html)
+        n_jobs: int, default=None
+            Number of threads used to evaluate candidate splits, which are
+            independent of one another. None means 1; -1 uses all processors.
+            Only helps once there are several candidates to compare, i.e. on
+            larger datasets or deeper models.
+        verbose: int, default=0
+            Controls progress reporting while fitting. 0 is silent; 1 reports each
+            rule as it is added, with the running total; 2 also prints the model
+            after every rule. Can be overridden per call via fit(verbose=...).
         class_weight: dict, list of dict or &#34;balanced&#34;, default=None
             Classification only. Weights associated with classes, in the form
             {class_label: weight}. &#34;balanced&#34; weights each class by
@@ -1120,6 +1200,8 @@ when both are given.</p></div>
         self.max_features = max_features
         self.max_depth = max_depth
         self.class_weight = class_weight
+        self.verbose = verbose
+        self.n_jobs = n_jobs
         self._init_decision_function()
         self.n_outputs = None
         self.need_to_reshape = False
@@ -1134,6 +1216,26 @@ when both are given.</p></div>
         &#34;&#34;&#34;Return the leaf each sample reaches (see imodels.util.apply.apply_leaves).&#34;&#34;&#34;
         from imodels.util.apply import apply_leaves
         return apply_leaves(self, X)
+    def _fit_candidate_stumps(self, X, potential_splits, y_residuals_per_tree,
+                              sample_weight):
+        &#34;&#34;&#34;Re-fit the stump for every candidate split, in parallel if asked.&#34;&#34;&#34;
+        def fit_stump(potential_split):
+            return self._construct_node_with_stump(
+                X=X,
+                y=y_residuals_per_tree[potential_split.tree_num],
+                idxs=potential_split.idxs,
+                tree_num=potential_split.tree_num,
+                sample_weight=sample_weight,
+                max_features=self.max_features,
+                depth=potential_split.depth + 1,
+            )
+
+        n_jobs = 1 if self.n_jobs is None else self.n_jobs
+        if n_jobs == 1 or len(potential_splits) &lt; 2:
+            return [fit_stump(split) for split in potential_splits]
+        return Parallel(n_jobs=n_jobs, backend=&#34;threading&#34;)(
+            delayed(fit_stump)(split) for split in potential_splits)
+
     def _apply_class_weight(self, y, sample_weight):
         &#34;&#34;&#34;Fold class_weight into sample_weight, which the splits already honor.&#34;&#34;&#34;
         if self.class_weight is None:
@@ -1276,7 +1378,7 @@ when both are given.</p></div>
         X,
         y=None,
         feature_names=None,
-        verbose=False,
+        verbose=None,
         sample_weight=None,
         categorical_features=None,
     ):
@@ -1288,6 +1390,11 @@ when both are given.</p></div>
             Splits that would create child nodes with net zero or negative weight
             are ignored while searching for a split in each node.
         &#34;&#34;&#34;
+        # fit(verbose=...) still wins, so existing callers are unaffected
+        verbose = int(self.verbose if verbose is None else verbose)
+
+        # remembered so that predict/predict_proba don&#39;t need them passed again
+        self.categorical_features_ = categorical_features
         if categorical_features is not None:
             X, self._encoder = encode_categories(X, categorical_features)
 
@@ -1374,8 +1481,6 @@ when both are given.</p></div>
                 continue
 
             # split on node
-            if verbose:
-                print(&#34;\nadding &#34; + str(split_node))
             self.complexity_ += 1
 
             # if added a tree root
@@ -1404,6 +1509,14 @@ when both are given.</p></div>
             potential_splits.append(split_node.left)
             potential_splits.append(split_node.right)
 
+            if verbose &gt;= 1:
+                # reported after the bookkeeping above, so the counts are final
+                budget = &#39;&#39; if self.max_rules is None else f&#39;/{self.max_rules}&#39;
+                condition = (f&#34;X_{split_node.feature} &lt;= {split_node.threshold:0.3f}&#34;
+                             if split_node.feature is not None else str(split_node))
+                print(f&#34;rule {self.complexity_}{budget} &#34;
+                      f&#34;({len(self.trees_)} tree(s)): {condition}&#34;)
+
             # update predictions for altered tree
             for tree_num_ in range(len(self.trees_)):
                 y_predictions_per_tree[tree_num_] = self._predict_tree(
@@ -1428,19 +1541,12 @@ when both are given.</p></div>
 
             # recompute all impurities + update potential_split children
             potential_splits_new = []
-            for potential_split in potential_splits:
-                y_target = y_residuals_per_tree[potential_split.tree_num]
-
-                # re-calculate the best split
-                potential_split_updated = self._construct_node_with_stump(
-                    X=X,
-                    y=y_target,
-                    idxs=potential_split.idxs,
-                    tree_num=potential_split.tree_num,
-                    sample_weight=sample_weight,
-                    max_features=self.max_features,
-                    depth=potential_split.depth+1,
-                )
+            # each candidate&#39;s stump is fit independently of the others, and
+            # sklearn&#39;s tree builder releases the GIL, so this threads well
+            updated_splits = self._fit_candidate_stumps(
+                X, potential_splits, y_residuals_per_tree, sample_weight)
+            for potential_split, potential_split_updated in zip(
+                    potential_splits, updated_splits):
 
                 # need to preserve certain attributes from before (value at this split + is_root)
                 # value may change because residuals may have changed, but we want it to store the value from before
@@ -1461,7 +1567,7 @@ when both are given.</p></div>
             potential_splits = sorted(
                 potential_splits_new, key=lambda x: x.impurity_reduction
             )
-            if verbose:
+            if verbose &gt;= 2:
                 print(self)
             if self.max_rules is not None and self.complexity_ &gt;= self.max_rules:
                 finished = True
@@ -1494,6 +1600,11 @@ when both are given.</p></div>
                 node.setattrs(node_id=next(node_counter),
                               value_sklearn=value_sklearn,
                               n_samples_=X.shape[0])
+
+                if node.left is None and node.right is None:
+                    # a leaf splits on nothing: its feature is the -2 placeholder,
+                    # which indexes the wrong column (or raises, with one feature)
+                    return
 
                 idxs_left = X[:, node.feature] &lt;= node.threshold
                 _annotate_node(node.left, X[idxs_left], y[idxs_left],
@@ -1609,6 +1720,7 @@ when both are given.</p></div>
         return s
 
     def predict(self, X, categorical_features=None, by_tree=False):
+        categorical_features = self._categorical_features(categorical_features)
         if hasattr(self, &#34;_encoder&#34;):
             X = self._encode_categories(
                 X, categorical_features=categorical_features, encoder_name=&#34;_encoder&#34;)
@@ -1637,11 +1749,18 @@ when both are given.</p></div>
 #             class_preds = (preds &gt; 0.5).astype(int)
 #             return np.array([self.classes_[i] for i in class_preds])
 
+    def _categorical_features(self, categorical_features):
+        &#34;&#34;&#34;Fall back on the categorical features the model was fitted with.&#34;&#34;&#34;
+        if categorical_features is None:
+            return getattr(self, &#39;categorical_features_&#39;, None)
+        return categorical_features
+
     def predict_proba(self, X, categorical_features=None, use_clipped_prediction=False):
         &#34;&#34;&#34;Predict probability for classifiers:
         Default behavior is to constrain the outputs to the range of probabilities, i.e. 0 to 1, with a sigmoid function.
         Set use_clipped_prediction=True to use prior behavior of clipping between 0 and 1 instead.
         &#34;&#34;&#34;
+        categorical_features = self._categorical_features(categorical_features)
         if hasattr(self, &#34;_encoder&#34;):
             X = self._encode_categories(
                 X, categorical_features=categorical_features, encoder_name=&#34;_encoder&#34;)
@@ -1802,7 +1921,7 @@ def feature_importances_(self):
 </details>
 </dd>
 <dt id="imodels.tree.figs.FIGS.fit"><code class="name flex">
-<span>def <span class="ident">fit</span></span>(<span>self, X, y=None, feature_names=None, verbose=False, sample_weight=None, categorical_features=None)</span>
+<span>def <span class="ident">fit</span></span>(<span>self, X, y=None, feature_names=None, verbose=None, sample_weight=None, categorical_features=None)</span>
 </code></dt>
 <dd>
 <div class="desc"><h2 id="params">Params</h2>
@@ -1819,7 +1938,7 @@ are ignored while searching for a split in each node.</p></div>
     X,
     y=None,
     feature_names=None,
-    verbose=False,
+    verbose=None,
     sample_weight=None,
     categorical_features=None,
 ):
@@ -1831,6 +1950,11 @@ are ignored while searching for a split in each node.</p></div>
         Splits that would create child nodes with net zero or negative weight
         are ignored while searching for a split in each node.
     &#34;&#34;&#34;
+    # fit(verbose=...) still wins, so existing callers are unaffected
+    verbose = int(self.verbose if verbose is None else verbose)
+
+    # remembered so that predict/predict_proba don&#39;t need them passed again
+    self.categorical_features_ = categorical_features
     if categorical_features is not None:
         X, self._encoder = encode_categories(X, categorical_features)
 
@@ -1917,8 +2041,6 @@ are ignored while searching for a split in each node.</p></div>
             continue
 
         # split on node
-        if verbose:
-            print(&#34;\nadding &#34; + str(split_node))
         self.complexity_ += 1
 
         # if added a tree root
@@ -1947,6 +2069,14 @@ are ignored while searching for a split in each node.</p></div>
         potential_splits.append(split_node.left)
         potential_splits.append(split_node.right)
 
+        if verbose &gt;= 1:
+            # reported after the bookkeeping above, so the counts are final
+            budget = &#39;&#39; if self.max_rules is None else f&#39;/{self.max_rules}&#39;
+            condition = (f&#34;X_{split_node.feature} &lt;= {split_node.threshold:0.3f}&#34;
+                         if split_node.feature is not None else str(split_node))
+            print(f&#34;rule {self.complexity_}{budget} &#34;
+                  f&#34;({len(self.trees_)} tree(s)): {condition}&#34;)
+
         # update predictions for altered tree
         for tree_num_ in range(len(self.trees_)):
             y_predictions_per_tree[tree_num_] = self._predict_tree(
@@ -1971,19 +2101,12 @@ are ignored while searching for a split in each node.</p></div>
 
         # recompute all impurities + update potential_split children
         potential_splits_new = []
-        for potential_split in potential_splits:
-            y_target = y_residuals_per_tree[potential_split.tree_num]
-
-            # re-calculate the best split
-            potential_split_updated = self._construct_node_with_stump(
-                X=X,
-                y=y_target,
-                idxs=potential_split.idxs,
-                tree_num=potential_split.tree_num,
-                sample_weight=sample_weight,
-                max_features=self.max_features,
-                depth=potential_split.depth+1,
-            )
+        # each candidate&#39;s stump is fit independently of the others, and
+        # sklearn&#39;s tree builder releases the GIL, so this threads well
+        updated_splits = self._fit_candidate_stumps(
+            X, potential_splits, y_residuals_per_tree, sample_weight)
+        for potential_split, potential_split_updated in zip(
+                potential_splits, updated_splits):
 
             # need to preserve certain attributes from before (value at this split + is_root)
             # value may change because residuals may have changed, but we want it to store the value from before
@@ -2004,7 +2127,7 @@ are ignored while searching for a split in each node.</p></div>
         potential_splits = sorted(
             potential_splits_new, key=lambda x: x.impurity_reduction
         )
-        if verbose:
+        if verbose &gt;= 2:
             print(self)
         if self.max_rules is not None and self.complexity_ &gt;= self.max_rules:
             finished = True
@@ -2037,6 +2160,11 @@ are ignored while searching for a split in each node.</p></div>
             node.setattrs(node_id=next(node_counter),
                           value_sklearn=value_sklearn,
                           n_samples_=X.shape[0])
+
+            if node.left is None and node.right is None:
+                # a leaf splits on nothing: its feature is the -2 placeholder,
+                # which indexes the wrong column (or raises, with one feature)
+                return
 
             idxs_left = X[:, node.feature] &lt;= node.threshold
             _annotate_node(node.left, X[idxs_left], y[idxs_left],
@@ -2173,6 +2301,7 @@ are ignored while searching for a split in each node.</p></div>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def predict(self, X, categorical_features=None, by_tree=False):
+    categorical_features = self._categorical_features(categorical_features)
     if hasattr(self, &#34;_encoder&#34;):
         X = self._encode_categories(
             X, categorical_features=categorical_features, encoder_name=&#34;_encoder&#34;)
@@ -2216,6 +2345,7 @@ Set use_clipped_prediction=True to use prior behavior of clipping between 0 and 
     Default behavior is to constrain the outputs to the range of probabilities, i.e. 0 to 1, with a sigmoid function.
     Set use_clipped_prediction=True to use prior behavior of clipping between 0 and 1 instead.
     &#34;&#34;&#34;
+    categorical_features = self._categorical_features(categorical_features)
     if hasattr(self, &#34;_encoder&#34;):
         X = self._encode_categories(
             X, categorical_features=categorical_features, encoder_name=&#34;_encoder&#34;)
@@ -2629,6 +2759,15 @@ array([3, 3, 3])
         from imodels.util.get_rules import get_rules
         return get_rules(self, feature_names=feature_names)
 
+    @property
+    def feature_importances_(self):
+        &#34;&#34;&#34;Mean decrease in impurity of the selected FIGS model.&#34;&#34;&#34;
+        return self.figs.feature_importances_
+    def apply(self, X):
+        &#34;&#34;&#34;Return the leaf each sample reaches (see imodels.util.apply.apply_leaves).&#34;&#34;&#34;
+        from imodels.util.apply import apply_leaves
+        return apply_leaves(self, X)
+
     def get_params(self, deep=True):
         # defined explicitly because __init__ takes *args/**kwargs, which sklearn&#39;s
         # automatic parameter introspection rejects
@@ -2706,6 +2845,19 @@ array([3, 3, 3])
 </ul>
 <h3>Instance variables</h3>
 <dl>
+<dt id="imodels.tree.figs.FIGSCV.feature_importances_"><code class="name">var <span class="ident">feature_importances_</span></code></dt>
+<dd>
+<div class="desc"><p>Mean decrease in impurity of the selected FIGS model.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def feature_importances_(self):
+    &#34;&#34;&#34;Mean decrease in impurity of the selected FIGS model.&#34;&#34;&#34;
+    return self.figs.feature_importances_</code></pre>
+</details>
+</dd>
 <dt id="imodels.tree.figs.FIGSCV.max_depth"><code class="name">var <span class="ident">max_depth</span></code></dt>
 <dd>
 <div class="desc"></div>
@@ -2769,6 +2921,21 @@ def trees_(self):
 </dl>
 <h3>Methods</h3>
 <dl>
+<dt id="imodels.tree.figs.FIGSCV.apply"><code class="name flex">
+<span>def <span class="ident">apply</span></span>(<span>self, X)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Return the leaf each sample reaches (see imodels.util.apply.apply_leaves).</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def apply(self, X):
+    &#34;&#34;&#34;Return the leaf each sample reaches (see imodels.util.apply.apply_leaves).&#34;&#34;&#34;
+    from imodels.util.apply import apply_leaves
+    return apply_leaves(self, X)</code></pre>
+</details>
+</dd>
 <dt id="imodels.tree.figs.FIGSCV.fit"><code class="name flex">
 <span>def <span class="ident">fit</span></span>(<span>self, X, y)</span>
 </code></dt>
@@ -3000,7 +3167,7 @@ default=<code>sklearn.utils.metadata_routing.UNCHANGED</code></dt>
 </dd>
 <dt id="imodels.tree.figs.FIGSClassifier"><code class="flex name class">
 <span>class <span class="ident">FIGSClassifier</span></span>
-<span>(</span><span>max_rules: int = 12, max_trees: int = None, min_impurity_decrease: float = 0.0, random_state=None, max_features: str = None, max_depth: int = None, class_weight=None)</span>
+<span>(</span><span>max_rules: int = 12, max_trees: int = None, min_impurity_decrease: float = 0.0, random_state=None, max_features: str = None, max_depth: int = None, class_weight=None, verbose: int = 0, n_jobs: int = None)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Mixin class for all classifiers in scikit-learn.</p>
@@ -3041,6 +3208,15 @@ min_impurity_decrease: float
 A node will be split if this split induces a decrease of the impurity greater than or equal to this value.
 max_features
 The number of features to consider when looking for the best split (see <a href="https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html">https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html</a>)
+n_jobs: int, default=None
+Number of threads used to evaluate candidate splits, which are
+independent of one another. None means 1; -1 uses all processors.
+Only helps once there are several candidates to compare, i.e. on
+larger datasets or deeper models.
+verbose: int, default=0
+Controls progress reporting while fitting. 0 is silent; 1 reports each
+rule as it is added, with the running total; 2 also prints the model
+after every rule. Can be overridden per call via fit(verbose=&hellip;).
 class_weight: dict, list of dict or "balanced", default=None
 Classification only. Weights associated with classes, in the form
 {class_label: weight}. "balanced" weights each class by
@@ -3366,6 +3542,8 @@ default=<code>sklearn.utils.metadata_routing.UNCHANGED</code></dt>
 <ul class="hlist">
 <li><code><b><a title="imodels.tree.figs.FIGSCV" href="#imodels.tree.figs.FIGSCV">FIGSCV</a></b></code>:
 <ul class="hlist">
+<li><code><a title="imodels.tree.figs.FIGSCV.apply" href="#imodels.tree.figs.FIGSCV.apply">apply</a></code></li>
+<li><code><a title="imodels.tree.figs.FIGSCV.feature_importances_" href="#imodels.tree.figs.FIGSCV.feature_importances_">feature_importances_</a></code></li>
 <li><code><a title="imodels.tree.figs.FIGSCV.get_params" href="#imodels.tree.figs.FIGSCV.get_params">get_params</a></code></li>
 <li><code><a title="imodels.tree.figs.FIGSCV.get_rules" href="#imodels.tree.figs.FIGSCV.get_rules">get_rules</a></code></li>
 <li><code><a title="imodels.tree.figs.FIGSCV.set_params" href="#imodels.tree.figs.FIGSCV.set_params">set_params</a></code></li>
@@ -3376,7 +3554,7 @@ default=<code>sklearn.utils.metadata_routing.UNCHANGED</code></dt>
 </dd>
 <dt id="imodels.tree.figs.FIGSRegressor"><code class="flex name class">
 <span>class <span class="ident">FIGSRegressor</span></span>
-<span>(</span><span>max_rules: int = 12, max_trees: int = None, min_impurity_decrease: float = 0.0, random_state=None, max_features: str = None, max_depth: int = None, class_weight=None)</span>
+<span>(</span><span>max_rules: int = 12, max_trees: int = None, min_impurity_decrease: float = 0.0, random_state=None, max_features: str = None, max_depth: int = None, class_weight=None, verbose: int = 0, n_jobs: int = None)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Mixin class for all regression estimators in scikit-learn.</p>
@@ -3417,6 +3595,15 @@ min_impurity_decrease: float
 A node will be split if this split induces a decrease of the impurity greater than or equal to this value.
 max_features
 The number of features to consider when looking for the best split (see <a href="https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html">https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html</a>)
+n_jobs: int, default=None
+Number of threads used to evaluate candidate splits, which are
+independent of one another. None means 1; -1 uses all processors.
+Only helps once there are several candidates to compare, i.e. on
+larger datasets or deeper models.
+verbose: int, default=0
+Controls progress reporting while fitting. 0 is silent; 1 reports each
+rule as it is added, with the running total; 2 also prints the model
+after every rule. Can be overridden per call via fit(verbose=&hellip;).
 class_weight: dict, list of dict or "balanced", default=None
 Classification only. Weights associated with classes, in the form
 {class_label: weight}. "balanced" weights each class by
@@ -3724,6 +3911,8 @@ default=<code>sklearn.utils.metadata_routing.UNCHANGED</code></dt>
 <ul class="hlist">
 <li><code><b><a title="imodels.tree.figs.FIGSCV" href="#imodels.tree.figs.FIGSCV">FIGSCV</a></b></code>:
 <ul class="hlist">
+<li><code><a title="imodels.tree.figs.FIGSCV.apply" href="#imodels.tree.figs.FIGSCV.apply">apply</a></code></li>
+<li><code><a title="imodels.tree.figs.FIGSCV.feature_importances_" href="#imodels.tree.figs.FIGSCV.feature_importances_">feature_importances_</a></code></li>
 <li><code><a title="imodels.tree.figs.FIGSCV.get_params" href="#imodels.tree.figs.FIGSCV.get_params">get_params</a></code></li>
 <li><code><a title="imodels.tree.figs.FIGSCV.get_rules" href="#imodels.tree.figs.FIGSCV.get_rules">get_rules</a></code></li>
 <li><code><a title="imodels.tree.figs.FIGSCV.set_params" href="#imodels.tree.figs.FIGSCV.set_params">set_params</a></code></li>
@@ -3902,6 +4091,8 @@ default=<code>sklearn.utils.metadata_routing.UNCHANGED</code></dt>
 <li>
 <h4><code><a title="imodels.tree.figs.FIGSCV" href="#imodels.tree.figs.FIGSCV">FIGSCV</a></code></h4>
 <ul class="">
+<li><code><a title="imodels.tree.figs.FIGSCV.apply" href="#imodels.tree.figs.FIGSCV.apply">apply</a></code></li>
+<li><code><a title="imodels.tree.figs.FIGSCV.feature_importances_" href="#imodels.tree.figs.FIGSCV.feature_importances_">feature_importances_</a></code></li>
 <li><code><a title="imodels.tree.figs.FIGSCV.fit" href="#imodels.tree.figs.FIGSCV.fit">fit</a></code></li>
 <li><code><a title="imodels.tree.figs.FIGSCV.get_params" href="#imodels.tree.figs.FIGSCV.get_params">get_params</a></code></li>
 <li><code><a title="imodels.tree.figs.FIGSCV.get_rules" href="#imodels.tree.figs.FIGSCV.get_rules">get_rules</a></code></li>

--- a/docs/tree/hierarchical_shrinkage.html
+++ b/docs/tree/hierarchical_shrinkage.html
@@ -36,6 +36,8 @@ from sklearn.ensemble import (
     GradientBoostingRegressor,
 )
 
+from sklearn.utils.validation import check_is_fitted
+
 from imodels.util import checks
 from imodels.util.arguments import check_fit_arguments
 from imodels.util.tree import compute_tree_complexity
@@ -114,6 +116,16 @@ class HSTree(BaseEstimator):
         from imodels.util.apply import apply_leaves
         return apply_leaves(self, X)
 
+    @property
+    def feature_importances_(self):
+        &#34;&#34;&#34;Mean decrease in impurity, as in sklearn&#39;s tree models.
+
+        Shrinkage rewrites node values but not the tree structure or its
+        impurities, so these match the underlying fitted estimator&#39;s.
+        &#34;&#34;&#34;
+        check_is_fitted(self.estimator_ if hasattr(self, &#39;estimator_&#39;) else self)
+        return self.estimator_.feature_importances_
+
     def get_params(self, deep=True):
         d = {
             &#34;reg_param&#34;: self.reg_param,
@@ -145,8 +157,8 @@ class HSTree(BaseEstimator):
             self.complexity_ = compute_tree_complexity(self.estimator_.tree_)
         elif hasattr(self.estimator_, &#34;estimators_&#34;):
             self.complexity_ = 0
-            for i in range(len(self.estimator_.estimators_)):
-                t = deepcopy(self.estimator_.estimators_[i])
+            for t in self.estimator_.estimators_:
+                # read-only, so no need to copy the tree
                 if isinstance(t, np.ndarray):
                     assert t.size == 1, &#34;multiple trees stored under tree_?&#34;
                     t = t[0]
@@ -180,7 +192,7 @@ class HSTree(BaseEstimator):
             or isinstance(self.estimator_, GradientBoostingClassifier)
             or values_normalized
         ):
-            val = deepcopy(tree.value[i, :, :])
+            val = tree.value[i, :, :].copy()
         else:  # If classification, counts need normalizing into a probability vector
             val = tree.value[i, :, :] / n_samples
 
@@ -222,7 +234,7 @@ class HSTree(BaseEstimator):
                 left,
                 parent_val=val,
                 parent_num=n_samples,
-                cum_sum=deepcopy(cum_sum),
+                cum_sum=np.copy(cum_sum),
                 values_normalized=values_normalized,
             )
             self._shrink_tree(
@@ -231,7 +243,7 @@ class HSTree(BaseEstimator):
                 right,
                 parent_val=val,
                 parent_num=n_samples,
-                cum_sum=deepcopy(cum_sum),
+                cum_sum=np.copy(cum_sum),
                 values_normalized=values_normalized,
             )
 
@@ -280,7 +292,10 @@ class HSTree(BaseEstimator):
 
     def predict(self, X, *args, **kwargs):
         preds = self.estimator_.predict(X, *args, **kwargs)
-        if hasattr(self.estimator_, &#34;classes_&#34;):
+        # fit encodes y as 0..n_classes-1, so map back onto the original labels.
+        # When the estimator was fitted elsewhere and passed in already fitted,
+        # there is no such encoding and its predictions are already labels.
+        if hasattr(self, &#34;classes_&#34;) and hasattr(self.estimator_, &#34;classes_&#34;):
             return np.array([self.classes_[int(i)] for i in preds])
         else:
             return preds
@@ -398,18 +413,27 @@ class HSTreeClassifier(ClassifierMixin, HSTree):
 
 
 def _get_cv_criterion(scorer):
-    y_true = np.random.binomial(n=1, p=0.5, size=100)
+    &#34;&#34;&#34;Whether the best score is the highest or the lowest one.
 
-    y_pred_good = y_true
-    y_pred_bad = np.random.uniform(0, 1, 100)
+    Probed on fixed data: a scorer&#39;s direction does not depend on the draw, and
+    sampling here would advance the caller&#39;s global numpy random stream.
+    &#34;&#34;&#34;
+    y_true = np.tile([0, 1], 50)
 
-    score_good = scorer(y_true, y_pred_good)
-    score_bad = scorer(y_true, y_pred_bad)
+    score_good = scorer(y_true, y_true)
+    score_bad = scorer(y_true, 1 - y_true)
 
     if score_good &gt; score_bad:
         return np.argmax
     elif score_good &lt; score_bad:
         return np.argmin
+
+    raise ValueError(
+        f&#34;Cannot tell whether higher or lower scores from &#34;
+        f&#34;{getattr(scorer, &#39;__name__&#39;, scorer)} are better: it scored a perfect &#34;
+        &#34;and a fully incorrect prediction the same. Pass a scoring function that &#34;
+        &#34;separates them.&#34;
+    )
 
 
 class HSTreeClassifierCV(HSTreeClassifier):
@@ -774,6 +798,16 @@ If estimator is None, then max_leaf_nodes is passed to the default decision tree
         from imodels.util.apply import apply_leaves
         return apply_leaves(self, X)
 
+    @property
+    def feature_importances_(self):
+        &#34;&#34;&#34;Mean decrease in impurity, as in sklearn&#39;s tree models.
+
+        Shrinkage rewrites node values but not the tree structure or its
+        impurities, so these match the underlying fitted estimator&#39;s.
+        &#34;&#34;&#34;
+        check_is_fitted(self.estimator_ if hasattr(self, &#39;estimator_&#39;) else self)
+        return self.estimator_.feature_importances_
+
     def get_params(self, deep=True):
         d = {
             &#34;reg_param&#34;: self.reg_param,
@@ -805,8 +839,8 @@ If estimator is None, then max_leaf_nodes is passed to the default decision tree
             self.complexity_ = compute_tree_complexity(self.estimator_.tree_)
         elif hasattr(self.estimator_, &#34;estimators_&#34;):
             self.complexity_ = 0
-            for i in range(len(self.estimator_.estimators_)):
-                t = deepcopy(self.estimator_.estimators_[i])
+            for t in self.estimator_.estimators_:
+                # read-only, so no need to copy the tree
                 if isinstance(t, np.ndarray):
                     assert t.size == 1, &#34;multiple trees stored under tree_?&#34;
                     t = t[0]
@@ -840,7 +874,7 @@ If estimator is None, then max_leaf_nodes is passed to the default decision tree
             or isinstance(self.estimator_, GradientBoostingClassifier)
             or values_normalized
         ):
-            val = deepcopy(tree.value[i, :, :])
+            val = tree.value[i, :, :].copy()
         else:  # If classification, counts need normalizing into a probability vector
             val = tree.value[i, :, :] / n_samples
 
@@ -882,7 +916,7 @@ If estimator is None, then max_leaf_nodes is passed to the default decision tree
                 left,
                 parent_val=val,
                 parent_num=n_samples,
-                cum_sum=deepcopy(cum_sum),
+                cum_sum=np.copy(cum_sum),
                 values_normalized=values_normalized,
             )
             self._shrink_tree(
@@ -891,7 +925,7 @@ If estimator is None, then max_leaf_nodes is passed to the default decision tree
                 right,
                 parent_val=val,
                 parent_num=n_samples,
-                cum_sum=deepcopy(cum_sum),
+                cum_sum=np.copy(cum_sum),
                 values_normalized=values_normalized,
             )
 
@@ -940,7 +974,10 @@ If estimator is None, then max_leaf_nodes is passed to the default decision tree
 
     def predict(self, X, *args, **kwargs):
         preds = self.estimator_.predict(X, *args, **kwargs)
-        if hasattr(self.estimator_, &#34;classes_&#34;):
+        # fit encodes y as 0..n_classes-1, so map back onto the original labels.
+        # When the estimator was fitted elsewhere and passed in already fitted,
+        # there is no such encoding and its predictions are already labels.
+        if hasattr(self, &#34;classes_&#34;) and hasattr(self.estimator_, &#34;classes_&#34;):
             return np.array([self.classes_[int(i)] for i in preds])
         else:
             return preds
@@ -1028,6 +1065,29 @@ If estimator is None, then max_leaf_nodes is passed to the default decision tree
 <li><a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifier" href="#imodels.tree.hierarchical_shrinkage.HSTreeClassifier">HSTreeClassifier</a></li>
 <li><a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressor" href="#imodels.tree.hierarchical_shrinkage.HSTreeRegressor">HSTreeRegressor</a></li>
 </ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="imodels.tree.hierarchical_shrinkage.HSTree.feature_importances_"><code class="name">var <span class="ident">feature_importances_</span></code></dt>
+<dd>
+<div class="desc"><p>Mean decrease in impurity, as in sklearn's tree models.</p>
+<p>Shrinkage rewrites node values but not the tree structure or its
+impurities, so these match the underlying fitted estimator's.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def feature_importances_(self):
+    &#34;&#34;&#34;Mean decrease in impurity, as in sklearn&#39;s tree models.
+
+    Shrinkage rewrites node values but not the tree structure or its
+    impurities, so these match the underlying fitted estimator&#39;s.
+    &#34;&#34;&#34;
+    check_is_fitted(self.estimator_ if hasattr(self, &#39;estimator_&#39;) else self)
+    return self.estimator_.feature_importances_</code></pre>
+</details>
+</dd>
+</dl>
 <h3>Methods</h3>
 <dl>
 <dt id="imodels.tree.hierarchical_shrinkage.HSTree.apply"><code class="name flex">
@@ -1074,8 +1134,8 @@ If estimator is None, then max_leaf_nodes is passed to the default decision tree
         self.complexity_ = compute_tree_complexity(self.estimator_.tree_)
     elif hasattr(self.estimator_, &#34;estimators_&#34;):
         self.complexity_ = 0
-        for i in range(len(self.estimator_.estimators_)):
-            t = deepcopy(self.estimator_.estimators_[i])
+        for t in self.estimator_.estimators_:
+            # read-only, so no need to copy the tree
             if isinstance(t, np.ndarray):
                 assert t.size == 1, &#34;multiple trees stored under tree_?&#34;
                 t = t[0]
@@ -1141,7 +1201,10 @@ contained subobjects that are estimators.</dd>
 </summary>
 <pre><code class="python">def predict(self, X, *args, **kwargs):
     preds = self.estimator_.predict(X, *args, **kwargs)
-    if hasattr(self.estimator_, &#34;classes_&#34;):
+    # fit encodes y as 0..n_classes-1, so map back onto the original labels.
+    # When the estimator was fitted elsewhere and passed in already fitted,
+    # there is no such encoding and its predictions are already labels.
+    if hasattr(self, &#34;classes_&#34;) and hasattr(self.estimator_, &#34;classes_&#34;):
         return np.array([self.classes_[int(i)] for i in preds])
     else:
         return preds</code></pre>
@@ -1437,6 +1500,7 @@ default=<code>sklearn.utils.metadata_routing.UNCHANGED</code></dt>
 <li><code><b><a title="imodels.tree.hierarchical_shrinkage.HSTree" href="#imodels.tree.hierarchical_shrinkage.HSTree">HSTree</a></b></code>:
 <ul class="hlist">
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTree.apply" href="#imodels.tree.hierarchical_shrinkage.HSTree.apply">apply</a></code></li>
+<li><code><a title="imodels.tree.hierarchical_shrinkage.HSTree.feature_importances_" href="#imodels.tree.hierarchical_shrinkage.HSTree.feature_importances_">feature_importances_</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTree.get_params" href="#imodels.tree.hierarchical_shrinkage.HSTree.get_params">get_params</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTree.get_rules" href="#imodels.tree.hierarchical_shrinkage.HSTree.get_rules">get_rules</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTree.set_fit_request" href="#imodels.tree.hierarchical_shrinkage.HSTree.set_fit_request">set_fit_request</a></code></li>
@@ -1692,6 +1756,7 @@ Note: args, kwargs are not used but left so that imodels-experiments can still p
 <li><code><b><a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifier" href="#imodels.tree.hierarchical_shrinkage.HSTreeClassifier">HSTreeClassifier</a></b></code>:
 <ul class="hlist">
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifier.apply" href="#imodels.tree.hierarchical_shrinkage.HSTree.apply">apply</a></code></li>
+<li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifier.feature_importances_" href="#imodels.tree.hierarchical_shrinkage.HSTree.feature_importances_">feature_importances_</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifier.get_params" href="#imodels.tree.hierarchical_shrinkage.HSTree.get_params">get_params</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifier.get_rules" href="#imodels.tree.hierarchical_shrinkage.HSTree.get_rules">get_rules</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifier.set_score_request" href="#imodels.tree.hierarchical_shrinkage.HSTreeClassifier.set_score_request">set_score_request</a></code></li>
@@ -1874,6 +1939,7 @@ default=<code>sklearn.utils.metadata_routing.UNCHANGED</code></dt>
 <li><code><b><a title="imodels.tree.hierarchical_shrinkage.HSTree" href="#imodels.tree.hierarchical_shrinkage.HSTree">HSTree</a></b></code>:
 <ul class="hlist">
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTree.apply" href="#imodels.tree.hierarchical_shrinkage.HSTree.apply">apply</a></code></li>
+<li><code><a title="imodels.tree.hierarchical_shrinkage.HSTree.feature_importances_" href="#imodels.tree.hierarchical_shrinkage.HSTree.feature_importances_">feature_importances_</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTree.get_params" href="#imodels.tree.hierarchical_shrinkage.HSTree.get_params">get_params</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTree.get_rules" href="#imodels.tree.hierarchical_shrinkage.HSTree.get_rules">get_rules</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTree.set_fit_request" href="#imodels.tree.hierarchical_shrinkage.HSTree.set_fit_request">set_fit_request</a></code></li>
@@ -2127,6 +2193,7 @@ Note: args, kwargs are not used but left so that imodels-experiments can still p
 <li><code><b><a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressor" href="#imodels.tree.hierarchical_shrinkage.HSTreeRegressor">HSTreeRegressor</a></b></code>:
 <ul class="hlist">
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressor.apply" href="#imodels.tree.hierarchical_shrinkage.HSTree.apply">apply</a></code></li>
+<li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressor.feature_importances_" href="#imodels.tree.hierarchical_shrinkage.HSTree.feature_importances_">feature_importances_</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressor.get_params" href="#imodels.tree.hierarchical_shrinkage.HSTree.get_params">get_params</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressor.get_rules" href="#imodels.tree.hierarchical_shrinkage.HSTree.get_rules">get_rules</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressor.set_score_request" href="#imodels.tree.hierarchical_shrinkage.HSTreeRegressor.set_score_request">set_score_request</a></code></li>
@@ -2152,8 +2219,9 @@ Note: args, kwargs are not used but left so that imodels-experiments can still p
 <ul>
 <li>
 <h4><code><a title="imodels.tree.hierarchical_shrinkage.HSTree" href="#imodels.tree.hierarchical_shrinkage.HSTree">HSTree</a></code></h4>
-<ul class="two-column">
+<ul class="">
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTree.apply" href="#imodels.tree.hierarchical_shrinkage.HSTree.apply">apply</a></code></li>
+<li><code><a title="imodels.tree.hierarchical_shrinkage.HSTree.feature_importances_" href="#imodels.tree.hierarchical_shrinkage.HSTree.feature_importances_">feature_importances_</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTree.fit" href="#imodels.tree.hierarchical_shrinkage.HSTree.fit">fit</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTree.get_params" href="#imodels.tree.hierarchical_shrinkage.HSTree.get_params">get_params</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTree.get_rules" href="#imodels.tree.hierarchical_shrinkage.HSTree.get_rules">get_rules</a></code></li>

--- a/docs/tree/tao.html
+++ b/docs/tree/tao.html
@@ -42,13 +42,13 @@ class TaoTree(BaseEstimator):
 
     def __init__(self, model_type: str = &#39;CART&#39;,
                  n_iters: int = 20,
-                 model_args: dict = {&#39;max_leaf_nodes&#39;: 15},
+                 model_args: dict = None,
                  randomize_tree=False,
                  update_scoring=&#39;accuracy&#39;,
                  min_node_samples_tao=3,
                  min_leaf_samples_tao=2,
                  node_model=&#39;stump&#39;,
-                 node_model_args: dict = {},
+                 node_model_args: dict = None,
                  reg_param: float = 1e-3,
                  weight_errors: bool = False,
                  verbose: int = 0,
@@ -104,13 +104,16 @@ class TaoTree(BaseEstimator):
         super().__init__()
         self.model_type = model_type
         self.n_iters = n_iters
-        self.model_args = model_args
+        # built per instance: a dict default in the signature is shared by every
+        # model, so mutating one would change the others
+        self.model_args = ({&#39;max_leaf_nodes&#39;: 15} if model_args is None
+                           else model_args)
         self.randomize_tree = randomize_tree
         self.update_scoring = update_scoring
         self.min_node_samples_tao = min_node_samples_tao
         self.min_leaf_samples_tao = min_leaf_samples_tao
         self.node_model = node_model
-        self.node_model_args = node_model_args
+        self.node_model_args = {} if node_model_args is None else node_model_args
         self.reg_param = reg_param
         self.weight_errors = weight_errors
         self.verbose = verbose
@@ -403,6 +406,11 @@ class TaoTree(BaseEstimator):
         from imodels.util.apply import apply_leaves
         return apply_leaves(self, X)
 
+    @property
+    def feature_importances_(self):
+        &#34;&#34;&#34;Mean decrease in impurity of the fitted tree, as in sklearn.&#34;&#34;&#34;
+        return self.model.feature_importances_
+
     def predict(self, X):
         preds = self.model.predict(X)
         if hasattr(self, &#34;classes_&#34;):
@@ -466,7 +474,7 @@ if __name__ == &#39;__main__&#39;:
 <dl>
 <dt id="imodels.tree.tao.TaoTree"><code class="flex name class">
 <span>class <span class="ident">TaoTree</span></span>
-<span>(</span><span>model_type: str = 'CART', n_iters: int = 20, model_args: dict = {'max_leaf_nodes': 15}, randomize_tree=False, update_scoring='accuracy', min_node_samples_tao=3, min_leaf_samples_tao=2, node_model='stump', node_model_args: dict = {}, reg_param: float = 0.001, weight_errors: bool = False, verbose: int = 0)</span>
+<span>(</span><span>model_type: str = 'CART', n_iters: int = 20, model_args: dict = None, randomize_tree=False, update_scoring='accuracy', min_node_samples_tao=3, min_leaf_samples_tao=2, node_model='stump', node_model_args: dict = None, reg_param: float = 0.001, weight_errors: bool = False, verbose: int = 0)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Base class for all estimators in scikit-learn.</p>
@@ -550,13 +558,13 @@ Note: this implementation learns single-feature splits rather than oblique trees
 
     def __init__(self, model_type: str = &#39;CART&#39;,
                  n_iters: int = 20,
-                 model_args: dict = {&#39;max_leaf_nodes&#39;: 15},
+                 model_args: dict = None,
                  randomize_tree=False,
                  update_scoring=&#39;accuracy&#39;,
                  min_node_samples_tao=3,
                  min_leaf_samples_tao=2,
                  node_model=&#39;stump&#39;,
-                 node_model_args: dict = {},
+                 node_model_args: dict = None,
                  reg_param: float = 1e-3,
                  weight_errors: bool = False,
                  verbose: int = 0,
@@ -612,13 +620,16 @@ Note: this implementation learns single-feature splits rather than oblique trees
         super().__init__()
         self.model_type = model_type
         self.n_iters = n_iters
-        self.model_args = model_args
+        # built per instance: a dict default in the signature is shared by every
+        # model, so mutating one would change the others
+        self.model_args = ({&#39;max_leaf_nodes&#39;: 15} if model_args is None
+                           else model_args)
         self.randomize_tree = randomize_tree
         self.update_scoring = update_scoring
         self.min_node_samples_tao = min_node_samples_tao
         self.min_leaf_samples_tao = min_leaf_samples_tao
         self.node_model = node_model
-        self.node_model_args = node_model_args
+        self.node_model_args = {} if node_model_args is None else node_model_args
         self.reg_param = reg_param
         self.weight_errors = weight_errors
         self.verbose = verbose
@@ -911,6 +922,11 @@ Note: this implementation learns single-feature splits rather than oblique trees
         from imodels.util.apply import apply_leaves
         return apply_leaves(self, X)
 
+    @property
+    def feature_importances_(self):
+        &#34;&#34;&#34;Mean decrease in impurity of the fitted tree, as in sklearn.&#34;&#34;&#34;
+        return self.model.feature_importances_
+
     def predict(self, X):
         preds = self.model.predict(X)
         if hasattr(self, &#34;classes_&#34;):
@@ -936,6 +952,22 @@ Note: this implementation learns single-feature splits rather than oblique trees
 <li><a title="imodels.tree.tao.TaoTreeClassifier" href="#imodels.tree.tao.TaoTreeClassifier">TaoTreeClassifier</a></li>
 <li><a title="imodels.tree.tao.TaoTreeRegressor" href="#imodels.tree.tao.TaoTreeRegressor">TaoTreeRegressor</a></li>
 </ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="imodels.tree.tao.TaoTree.feature_importances_"><code class="name">var <span class="ident">feature_importances_</span></code></dt>
+<dd>
+<div class="desc"><p>Mean decrease in impurity of the fitted tree, as in sklearn.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def feature_importances_(self):
+    &#34;&#34;&#34;Mean decrease in impurity of the fitted tree, as in sklearn.&#34;&#34;&#34;
+    return self.model.feature_importances_</code></pre>
+</details>
+</dd>
+</dl>
 <h3>Methods</h3>
 <dl>
 <dt id="imodels.tree.tao.TaoTree.apply"><code class="name flex">
@@ -1161,7 +1193,7 @@ default=<code>sklearn.utils.metadata_routing.UNCHANGED</code></dt>
 </dd>
 <dt id="imodels.tree.tao.TaoTreeClassifier"><code class="flex name class">
 <span>class <span class="ident">TaoTreeClassifier</span></span>
-<span>(</span><span>model_type: str = 'CART', n_iters: int = 20, model_args: dict = {'max_leaf_nodes': 15}, randomize_tree=False, update_scoring='accuracy', min_node_samples_tao=3, min_leaf_samples_tao=2, node_model='stump', node_model_args: dict = {}, reg_param: float = 0.001, weight_errors: bool = False, verbose: int = 0)</span>
+<span>(</span><span>model_type: str = 'CART', n_iters: int = 20, model_args: dict = None, randomize_tree=False, update_scoring='accuracy', min_node_samples_tao=3, min_leaf_samples_tao=2, node_model='stump', node_model_args: dict = None, reg_param: float = 0.001, weight_errors: bool = False, verbose: int = 0)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Base class for all estimators in scikit-learn.</p>
@@ -1355,6 +1387,7 @@ default=<code>sklearn.utils.metadata_routing.UNCHANGED</code></dt>
 <li><code><b><a title="imodels.tree.tao.TaoTree" href="#imodels.tree.tao.TaoTree">TaoTree</a></b></code>:
 <ul class="hlist">
 <li><code><a title="imodels.tree.tao.TaoTree.apply" href="#imodels.tree.tao.TaoTree.apply">apply</a></code></li>
+<li><code><a title="imodels.tree.tao.TaoTree.feature_importances_" href="#imodels.tree.tao.TaoTree.feature_importances_">feature_importances_</a></code></li>
 <li><code><a title="imodels.tree.tao.TaoTree.fit" href="#imodels.tree.tao.TaoTree.fit">fit</a></code></li>
 <li><code><a title="imodels.tree.tao.TaoTree.get_rules" href="#imodels.tree.tao.TaoTree.get_rules">get_rules</a></code></li>
 <li><code><a title="imodels.tree.tao.TaoTree.set_fit_request" href="#imodels.tree.tao.TaoTree.set_fit_request">set_fit_request</a></code></li>
@@ -1364,7 +1397,7 @@ default=<code>sklearn.utils.metadata_routing.UNCHANGED</code></dt>
 </dd>
 <dt id="imodels.tree.tao.TaoTreeRegressor"><code class="flex name class">
 <span>class <span class="ident">TaoTreeRegressor</span></span>
-<span>(</span><span>model_type: str = 'CART', n_iters: int = 20, model_args: dict = {'max_leaf_nodes': 15}, randomize_tree=False, update_scoring='accuracy', min_node_samples_tao=3, min_leaf_samples_tao=2, node_model='stump', node_model_args: dict = {}, reg_param: float = 0.001, weight_errors: bool = False, verbose: int = 0)</span>
+<span>(</span><span>model_type: str = 'CART', n_iters: int = 20, model_args: dict = None, randomize_tree=False, update_scoring='accuracy', min_node_samples_tao=3, min_leaf_samples_tao=2, node_model='stump', node_model_args: dict = None, reg_param: float = 0.001, weight_errors: bool = False, verbose: int = 0)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Base class for all estimators in scikit-learn.</p>
@@ -1558,6 +1591,7 @@ default=<code>sklearn.utils.metadata_routing.UNCHANGED</code></dt>
 <li><code><b><a title="imodels.tree.tao.TaoTree" href="#imodels.tree.tao.TaoTree">TaoTree</a></b></code>:
 <ul class="hlist">
 <li><code><a title="imodels.tree.tao.TaoTree.apply" href="#imodels.tree.tao.TaoTree.apply">apply</a></code></li>
+<li><code><a title="imodels.tree.tao.TaoTree.feature_importances_" href="#imodels.tree.tao.TaoTree.feature_importances_">feature_importances_</a></code></li>
 <li><code><a title="imodels.tree.tao.TaoTree.fit" href="#imodels.tree.tao.TaoTree.fit">fit</a></code></li>
 <li><code><a title="imodels.tree.tao.TaoTree.get_rules" href="#imodels.tree.tao.TaoTree.get_rules">get_rules</a></code></li>
 <li><code><a title="imodels.tree.tao.TaoTree.set_fit_request" href="#imodels.tree.tao.TaoTree.set_fit_request">set_fit_request</a></code></li>
@@ -1583,8 +1617,9 @@ default=<code>sklearn.utils.metadata_routing.UNCHANGED</code></dt>
 <ul>
 <li>
 <h4><code><a title="imodels.tree.tao.TaoTree" href="#imodels.tree.tao.TaoTree">TaoTree</a></code></h4>
-<ul class="two-column">
+<ul class="">
 <li><code><a title="imodels.tree.tao.TaoTree.apply" href="#imodels.tree.tao.TaoTree.apply">apply</a></code></li>
+<li><code><a title="imodels.tree.tao.TaoTree.feature_importances_" href="#imodels.tree.tao.TaoTree.feature_importances_">feature_importances_</a></code></li>
 <li><code><a title="imodels.tree.tao.TaoTree.fit" href="#imodels.tree.tao.TaoTree.fit">fit</a></code></li>
 <li><code><a title="imodels.tree.tao.TaoTree.get_rules" href="#imodels.tree.tao.TaoTree.get_rules">get_rules</a></code></li>
 <li><code><a title="imodels.tree.tao.TaoTree.predict" href="#imodels.tree.tao.TaoTree.predict">predict</a></code></li>

--- a/docs/tree/viz_utils.html
+++ b/docs/tree/viz_utils.html
@@ -153,9 +153,12 @@ def extract_sklearn_tree_from_figs(figs, tree_num, n_classes, with_leaf_predicti
         dt = DecisionTreeRegressor(max_depth=max_depth)
 
     try:
-        dt.__setstate__(_state);
-    except:
-        raise Exception(f&#39;Did not successfully run __setstate__() when translating to {type(dt)}, did sklearn update?&#39;)
+        dt.__setstate__(_state)
+    except Exception as e:
+        # chain the original error: what actually went wrong is the useful part
+        raise Exception(
+            f&#39;Did not successfully run __setstate__() when translating to &#39;
+            f&#39;{type(dt)}, did sklearn update?&#39;) from e
 
     if not with_leaf_predictions:
         return dt
@@ -259,9 +262,12 @@ def extract_sklearn_tree_from_figs(figs, tree_num, n_classes, with_leaf_predicti
         dt = DecisionTreeRegressor(max_depth=max_depth)
 
     try:
-        dt.__setstate__(_state);
-    except:
-        raise Exception(f&#39;Did not successfully run __setstate__() when translating to {type(dt)}, did sklearn update?&#39;)
+        dt.__setstate__(_state)
+    except Exception as e:
+        # chain the original error: what actually went wrong is the useful part
+        raise Exception(
+            f&#39;Did not successfully run __setstate__() when translating to &#39;
+            f&#39;{type(dt)}, did sklearn update?&#39;) from e
 
     if not with_leaf_predictions:
         return dt

--- a/docs/util/arguments.html
+++ b/docs/util/arguments.html
@@ -70,6 +70,23 @@ def check_fit_arguments(model, X, y, feature_names, multi_output=False, is_class
     return X, y, model.feature_names_
 
 
+def check_binary_target(model, y):
+    &#34;&#34;&#34;Raise if y has more than two classes, for models that only handle binary.
+
+    Without this a multiclass target is silently collapsed: the model fits, and
+    predict_proba returns two columns rather than one per class
+    (see https://github.com/csinva/imodels/issues/93).
+    &#34;&#34;&#34;
+    n_classes = len(np.unique(y))
+    if n_classes &gt; 2:
+        raise ValueError(
+            f&#34;{type(model).__name__} only supports binary classification, but y &#34;
+            f&#34;has {n_classes} classes. Models in imodels that do support &#34;
+            &#34;multiclass include FIGSClassifier, GreedyTreeClassifier, &#34;
+            &#34;HSTreeClassifier, TaoTreeClassifier and BoostedRulesClassifier.&#34;
+        )
+
+
 def _finite_check_kwarg(allow_nan):
     &#34;&#34;&#34;Spell the &#34;allow NaN&#34; option the way the installed sklearn expects.
 
@@ -126,6 +143,35 @@ def decode_labels(model, preds):
 <section>
 <h2 class="section-title" id="header-functions">Functions</h2>
 <dl>
+<dt id="imodels.util.arguments.check_binary_target"><code class="name flex">
+<span>def <span class="ident">check_binary_target</span></span>(<span>model, y)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Raise if y has more than two classes, for models that only handle binary.</p>
+<p>Without this a multiclass target is silently collapsed: the model fits, and
+predict_proba returns two columns rather than one per class
+(see <a href="https://github.com/csinva/imodels/issues/93">https://github.com/csinva/imodels/issues/93</a>).</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def check_binary_target(model, y):
+    &#34;&#34;&#34;Raise if y has more than two classes, for models that only handle binary.
+
+    Without this a multiclass target is silently collapsed: the model fits, and
+    predict_proba returns two columns rather than one per class
+    (see https://github.com/csinva/imodels/issues/93).
+    &#34;&#34;&#34;
+    n_classes = len(np.unique(y))
+    if n_classes &gt; 2:
+        raise ValueError(
+            f&#34;{type(model).__name__} only supports binary classification, but y &#34;
+            f&#34;has {n_classes} classes. Models in imodels that do support &#34;
+            &#34;multiclass include FIGSClassifier, GreedyTreeClassifier, &#34;
+            &#34;HSTreeClassifier, TaoTreeClassifier and BoostedRulesClassifier.&#34;
+        )</code></pre>
+</details>
+</dd>
 <dt id="imodels.util.arguments.check_fit_X"><code class="name flex">
 <span>def <span class="ident">check_fit_X</span></span>(<span>X)</span>
 </code></dt>
@@ -268,6 +314,7 @@ again afterwards.</p></div>
 </li>
 <li><h3><a href="#header-functions">Functions</a></h3>
 <ul class="">
+<li><code><a title="imodels.util.arguments.check_binary_target" href="#imodels.util.arguments.check_binary_target">check_binary_target</a></code></li>
 <li><code><a title="imodels.util.arguments.check_fit_X" href="#imodels.util.arguments.check_fit_X">check_fit_X</a></code></li>
 <li><code><a title="imodels.util.arguments.check_fit_arguments" href="#imodels.util.arguments.check_fit_arguments">check_fit_arguments</a></code></li>
 <li><code><a title="imodels.util.arguments.decode_labels" href="#imodels.util.arguments.decode_labels">decode_labels</a></code></li>

--- a/docs/util/convert.html
+++ b/docs/util/convert.html
@@ -27,6 +27,22 @@ from sklearn.tree import _tree
 from typing import Union, List, Tuple
 
 
+def _round_threshold(threshold, decimals: int = 5):
+    &#34;&#34;&#34;Shorten a split threshold without moving it onto the data.
+
+    Rounding to a fixed number of decimal places collapses thresholds on
+    small-scale features to 0.0, which changes which rows a rule selects (and
+    can turn two distinct splits into the same one). Rounding to significant
+    digits instead keeps the threshold in the right place at any scale.
+    &#34;&#34;&#34;
+    if threshold == 0 or not np.isfinite(threshold):
+        return threshold
+    magnitude = int(np.floor(np.log10(abs(threshold))))
+    # keep `decimals` digits after the point for values of order 1, and the
+    # equivalent precision for values that are much smaller or larger
+    return float(np.round(threshold, decimals=max(decimals, decimals - magnitude)))
+
+
 def tree_to_rules(tree: Union[DecisionTreeClassifier, DecisionTreeRegressor],
                   feature_names: List[str],
                   prediction_values: bool = False, round_thresholds=True) -&gt; List[str]:
@@ -59,7 +75,7 @@ def tree_to_rules(tree: Union[DecisionTreeClassifier, DecisionTreeRegressor],
             symbol2 = &#39;&gt;&#39;
             threshold = tree_.threshold[node]
             if round_thresholds:
-                threshold = np.round(threshold, decimals=5)
+                threshold = _round_threshold(threshold)
             text = base_name + [&#34;{} {} {}&#34;.format(name, symbol, threshold)]
             recurse(tree_.children_left[node], text)
 
@@ -175,7 +191,82 @@ def single_discretized_feature_to_rule(feat: str) -&gt; str:
     else:
         rule = f&#39;{feature_name} &gt; {lower_value} and {feature_name} &lt;= {upper_value}&#39;
 
-    return rule</code></pre>
+    return rule
+
+
+def is_xgboost_model(model) -&gt; bool:
+    &#34;&#34;&#34;Whether model is an XGBoost estimator, without importing xgboost.
+
+    xgboost is not a dependency of imodels, so this is duck-typed: it is only
+    true for something exposing a Booster.
+    &#34;&#34;&#34;
+    return hasattr(model, &#39;get_booster&#39;) and type(model).__module__.startswith(&#39;xgboost&#39;)
+
+
+def xgboost_to_rules(model, feature_names: List[str],
+                     prediction_values: bool = False) -&gt; List[str]:
+    &#34;&#34;&#34;Return a list of rules from a fitted XGBoost model.
+
+    XGBoost stores its trees in a Booster rather than sklearn&#39;s tree_ arrays, so
+    the paths are read off `trees_to_dataframe()`. Note XGBoost sends a sample
+    left when `feature &lt; threshold` (sklearn uses `&lt;=`), which is reflected here.
+
+    Thresholds are emitted at full precision. XGBoost compares in float32, so a
+    row sitting within float32 rounding of a threshold can be routed differently
+    when the rule is later evaluated in float64; evaluated in float32 the rules
+    reproduce XGBoost&#39;s leaf assignment exactly.
+
+    Parameters
+    ----------
+        model : a fitted XGBClassifier/XGBRegressor
+        feature_names: list of variable names
+
+    Returns
+    -------
+    rules : list of rules, or of (rule, leaf value) pairs if prediction_values
+    &#34;&#34;&#34;
+    booster = model.get_booster()
+    frame = booster.trees_to_dataframe()
+
+    # the booster names features f0, f1, ... when fitted on an array; map those
+    # back onto the caller&#39;s names by position
+    booster_names = booster.feature_names or []
+    name_by_booster_name = {booster_name: feature_names[i]
+                            for i, booster_name in enumerate(booster_names)
+                            if i &lt; len(feature_names)}
+
+    def resolve(booster_feature):
+        if booster_feature in name_by_booster_name:
+            return name_by_booster_name[booster_feature]
+        if booster_feature.startswith(&#39;f&#39;) and booster_feature[1:].isdigit():
+            index = int(booster_feature[1:])
+            if index &lt; len(feature_names):
+                return feature_names[index]
+        return booster_feature
+
+    rules = []
+    for _, tree in frame.groupby(&#39;Tree&#39;):
+        nodes = tree.set_index(&#39;ID&#39;)
+
+        def recurse(node_id, conditions):
+            node = nodes.loc[node_id]
+            if node[&#39;Feature&#39;] == &#39;Leaf&#39;:
+                condition = &#39; and &#39;.join(conditions)
+                if condition == &#39;&#39;:  # a stump that never splits selects everything
+                    condition = &#39; == &#39;.join([feature_names[0]] * 2)
+                # for a leaf, Gain holds the value the tree contributes
+                rules.append((condition, [float(node[&#39;Gain&#39;])])
+                             if prediction_values else condition)
+                return
+            name = resolve(node[&#39;Feature&#39;])
+            # full precision: rounding here would send rows that sit between the
+            # true and rounded threshold down the wrong branch
+            threshold = repr(float(node[&#39;Split&#39;]))
+            recurse(node[&#39;Yes&#39;], conditions + [f&#39;{name} &lt; {threshold}&#39;])
+            recurse(node[&#39;No&#39;], conditions + [f&#39;{name} &gt;= {threshold}&#39;])
+
+        recurse(tree[&#39;ID&#39;].iloc[0], [])
+    return rules</code></pre>
 </details>
 </section>
 <section>
@@ -228,6 +319,26 @@ rule: list of dict of schema
         )
 
     return output[:-5]</code></pre>
+</details>
+</dd>
+<dt id="imodels.util.convert.is_xgboost_model"><code class="name flex">
+<span>def <span class="ident">is_xgboost_model</span></span>(<span>model) ‑> bool</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Whether model is an XGBoost estimator, without importing xgboost.</p>
+<p>xgboost is not a dependency of imodels, so this is duck-typed: it is only
+true for something exposing a Booster.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def is_xgboost_model(model) -&gt; bool:
+    &#34;&#34;&#34;Whether model is an XGBoost estimator, without importing xgboost.
+
+    xgboost is not a dependency of imodels, so this is duck-typed: it is only
+    true for something exposing a Booster.
+    &#34;&#34;&#34;
+    return hasattr(model, &#39;get_booster&#39;) and type(model).__module__.startswith(&#39;xgboost&#39;)</code></pre>
 </details>
 </dd>
 <dt id="imodels.util.convert.itemsets_to_rules"><code class="name flex">
@@ -374,7 +485,7 @@ feature_names: list of variable names
             symbol2 = &#39;&gt;&#39;
             threshold = tree_.threshold[node]
             if round_thresholds:
-                threshold = np.round(threshold, decimals=5)
+                threshold = _round_threshold(threshold)
             text = base_name + [&#34;{} {} {}&#34;.format(name, symbol, threshold)]
             recurse(tree_.children_left[node], text)
 
@@ -396,6 +507,97 @@ feature_names: list of variable names
     return rules if len(rules) &gt; 0 else &#39;True&#39;</code></pre>
 </details>
 </dd>
+<dt id="imodels.util.convert.xgboost_to_rules"><code class="name flex">
+<span>def <span class="ident">xgboost_to_rules</span></span>(<span>model, feature_names: List[str], prediction_values: bool = False) ‑> List[str]</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Return a list of rules from a fitted XGBoost model.</p>
+<p>XGBoost stores its trees in a Booster rather than sklearn's tree_ arrays, so
+the paths are read off <code>trees_to_dataframe()</code>. Note XGBoost sends a sample
+left when <code>feature &lt; threshold</code> (sklearn uses <code>&lt;=</code>), which is reflected here.</p>
+<p>Thresholds are emitted at full precision. XGBoost compares in float32, so a
+row sitting within float32 rounding of a threshold can be routed differently
+when the rule is later evaluated in float64; evaluated in float32 the rules
+reproduce XGBoost's leaf assignment exactly.</p>
+<h2 id="parameters">Parameters</h2>
+<pre><code>model : a fitted XGBClassifier/XGBRegressor
+feature_names: list of variable names
+</code></pre>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><strong><code>rules</code></strong> :&ensp;<code>list</code> of <code>rules,</code> or <code>of (rule, leaf value) pairs if prediction_values</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def xgboost_to_rules(model, feature_names: List[str],
+                     prediction_values: bool = False) -&gt; List[str]:
+    &#34;&#34;&#34;Return a list of rules from a fitted XGBoost model.
+
+    XGBoost stores its trees in a Booster rather than sklearn&#39;s tree_ arrays, so
+    the paths are read off `trees_to_dataframe()`. Note XGBoost sends a sample
+    left when `feature &lt; threshold` (sklearn uses `&lt;=`), which is reflected here.
+
+    Thresholds are emitted at full precision. XGBoost compares in float32, so a
+    row sitting within float32 rounding of a threshold can be routed differently
+    when the rule is later evaluated in float64; evaluated in float32 the rules
+    reproduce XGBoost&#39;s leaf assignment exactly.
+
+    Parameters
+    ----------
+        model : a fitted XGBClassifier/XGBRegressor
+        feature_names: list of variable names
+
+    Returns
+    -------
+    rules : list of rules, or of (rule, leaf value) pairs if prediction_values
+    &#34;&#34;&#34;
+    booster = model.get_booster()
+    frame = booster.trees_to_dataframe()
+
+    # the booster names features f0, f1, ... when fitted on an array; map those
+    # back onto the caller&#39;s names by position
+    booster_names = booster.feature_names or []
+    name_by_booster_name = {booster_name: feature_names[i]
+                            for i, booster_name in enumerate(booster_names)
+                            if i &lt; len(feature_names)}
+
+    def resolve(booster_feature):
+        if booster_feature in name_by_booster_name:
+            return name_by_booster_name[booster_feature]
+        if booster_feature.startswith(&#39;f&#39;) and booster_feature[1:].isdigit():
+            index = int(booster_feature[1:])
+            if index &lt; len(feature_names):
+                return feature_names[index]
+        return booster_feature
+
+    rules = []
+    for _, tree in frame.groupby(&#39;Tree&#39;):
+        nodes = tree.set_index(&#39;ID&#39;)
+
+        def recurse(node_id, conditions):
+            node = nodes.loc[node_id]
+            if node[&#39;Feature&#39;] == &#39;Leaf&#39;:
+                condition = &#39; and &#39;.join(conditions)
+                if condition == &#39;&#39;:  # a stump that never splits selects everything
+                    condition = &#39; == &#39;.join([feature_names[0]] * 2)
+                # for a leaf, Gain holds the value the tree contributes
+                rules.append((condition, [float(node[&#39;Gain&#39;])])
+                             if prediction_values else condition)
+                return
+            name = resolve(node[&#39;Feature&#39;])
+            # full precision: rounding here would send rows that sit between the
+            # true and rounded threshold down the wrong branch
+            threshold = repr(float(node[&#39;Split&#39;]))
+            recurse(node[&#39;Yes&#39;], conditions + [f&#39;{name} &lt; {threshold}&#39;])
+            recurse(node[&#39;No&#39;], conditions + [f&#39;{name} &gt;= {threshold}&#39;])
+
+        recurse(tree[&#39;ID&#39;].iloc[0], [])
+    return rules</code></pre>
+</details>
+</dd>
 </dl>
 </section>
 <section>
@@ -415,10 +617,12 @@ feature_names: list of variable names
 <li><h3><a href="#header-functions">Functions</a></h3>
 <ul class="">
 <li><code><a title="imodels.util.convert.dict_to_rule" href="#imodels.util.convert.dict_to_rule">dict_to_rule</a></code></li>
+<li><code><a title="imodels.util.convert.is_xgboost_model" href="#imodels.util.convert.is_xgboost_model">is_xgboost_model</a></code></li>
 <li><code><a title="imodels.util.convert.itemsets_to_rules" href="#imodels.util.convert.itemsets_to_rules">itemsets_to_rules</a></code></li>
 <li><code><a title="imodels.util.convert.single_discretized_feature_to_rule" href="#imodels.util.convert.single_discretized_feature_to_rule">single_discretized_feature_to_rule</a></code></li>
 <li><code><a title="imodels.util.convert.tree_to_code" href="#imodels.util.convert.tree_to_code">tree_to_code</a></code></li>
 <li><code><a title="imodels.util.convert.tree_to_rules" href="#imodels.util.convert.tree_to_rules">tree_to_rules</a></code></li>
+<li><code><a title="imodels.util.convert.xgboost_to_rules" href="#imodels.util.convert.xgboost_to_rules">xgboost_to_rules</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/util/data_util.html
+++ b/docs/util/data_util.html
@@ -160,9 +160,12 @@ def get_clean_dataset(
     ```
     &#34;&#34;&#34;
     if dataset_name in DSET_KWARGS:
+        # resolving the shorthand name is not a logging step: it used to sit
+        # inside the verbose branch, so verbose=False looked the dataset up
+        # under its shorthand and 404&#39;d
+        data_source = DSET_KWARGS[dataset_name][&#34;data_source&#34;]
+        dataset_name = DSET_KWARGS[dataset_name][&#34;dataset_name&#34;]
         if verbose:
-            data_source = DSET_KWARGS[dataset_name][&#34;data_source&#34;]
-            dataset_name = DSET_KWARGS[dataset_name][&#34;dataset_name&#34;]
             print(f&#34;fetching {dataset_name} from {data_source}&#34;)
     assert data_source in [&#34;imodels&#34;, &#34;pmlb&#34;, &#34;imodels-multitask&#34;, &#34;sklearn&#34;, &#34;openml&#34;, &#34;synthetic&#34;], (
         data_source + &#34; not correct&#34;
@@ -507,9 +510,12 @@ X, y, feature_names = imodels.get_clean_dataset('california_housing', data_sourc
     ```
     &#34;&#34;&#34;
     if dataset_name in DSET_KWARGS:
+        # resolving the shorthand name is not a logging step: it used to sit
+        # inside the verbose branch, so verbose=False looked the dataset up
+        # under its shorthand and 404&#39;d
+        data_source = DSET_KWARGS[dataset_name][&#34;data_source&#34;]
+        dataset_name = DSET_KWARGS[dataset_name][&#34;dataset_name&#34;]
         if verbose:
-            data_source = DSET_KWARGS[dataset_name][&#34;data_source&#34;]
-            dataset_name = DSET_KWARGS[dataset_name][&#34;dataset_name&#34;]
             print(f&#34;fetching {dataset_name} from {data_source}&#34;)
     assert data_source in [&#34;imodels&#34;, &#34;pmlb&#34;, &#34;imodels-multitask&#34;, &#34;sklearn&#34;, &#34;openml&#34;, &#34;synthetic&#34;], (
         data_source + &#34; not correct&#34;

--- a/docs/util/extract.html
+++ b/docs/util/extract.html
@@ -74,11 +74,13 @@ def extract_rulefit(X, y, feature_names,
                                                    random_state=random_state,
                                                    max_depth=100)
 
-    if type(tree_generator) not in [GradientBoostingClassifier, GradientBoostingRegressor,
-                                    RandomForestRegressor, RandomForestClassifier]:
+    is_xgboost = convert.is_xgboost_model(tree_generator)
+    if not is_xgboost and type(tree_generator) not in [
+            GradientBoostingClassifier, GradientBoostingRegressor,
+            RandomForestRegressor, RandomForestClassifier]:
         raise ValueError(
             &#34;RuleFit only works with GradientBoostingClassifier(), GradientBoostingRegressor(), &#34;
-            &#34;RandomForestRegressor() or RandomForestClassifier()&#34;)
+            &#34;RandomForestRegressor(), RandomForestClassifier(), or an XGBoost model&#34;)
 
     # work on a copy: rule extraction refits the generator and overrides some of
     # its parameters, which would otherwise modify the caller&#39;s estimator. Cloning
@@ -86,7 +88,11 @@ def extract_rulefit(X, y, feature_names,
     tree_generator = clone(tree_generator)
 
     # fit tree generator
-    if not exp_rand_tree_size:  # simply fit with constant tree size
+    if is_xgboost:
+        # XGBoost has no sklearn-style warm_start, so the varying-tree-size
+        # scheme below doesn&#39;t apply; its own n_estimators controls the ensemble
+        tree_generator.fit(X, y)
+    elif not exp_rand_tree_size:  # simply fit with constant tree size
         tree_generator.fit(X, y)
     else:  # randomise tree size as per Friedman 2005 Sec 3.3
         np.random.seed(random_state)
@@ -107,21 +113,28 @@ def extract_rulefit(X, y, feature_names,
             curr_est_ = curr_est_ + 1
         tree_generator.set_params(warm_start=False)
 
-    if isinstance(tree_generator, RandomForestRegressor) or isinstance(tree_generator, RandomForestClassifier):
-        estimators_ = [[x] for x in tree_generator.estimators_]
+    if is_xgboost:
+        rule_value_pairs = convert.xgboost_to_rules(
+            tree_generator, list(feature_names), prediction_values=True)
     else:
-        estimators_ = tree_generator.estimators_
+        if isinstance(tree_generator, RandomForestRegressor) or isinstance(tree_generator, RandomForestClassifier):
+            estimators_ = [[x] for x in tree_generator.estimators_]
+        else:
+            estimators_ = tree_generator.estimators_
+        rule_value_pairs = [
+            pair for estimator in estimators_
+            for pair in convert.tree_to_rules(
+                estimator[0], np.array(feature_names), prediction_values=True)
+        ]
 
     seen_rules = set()
     extracted_rules = []
-    for estimator in estimators_:
-        for rule_value_pair in convert.tree_to_rules(estimator[0], np.array(feature_names), prediction_values=True):
+    for rule_value_pair in rule_value_pairs:
+        rule_obj = rule.Rule(rule_value_pair[0])
 
-            rule_obj = rule.Rule(rule_value_pair[0])
-
-            if rule_obj not in seen_rules:
-                extracted_rules.append(rule_value_pair)
-                seen_rules.add(rule_obj)
+        if rule_obj not in seen_rules:
+            extracted_rules.append(rule_value_pair)
+            seen_rules.add(rule_obj)
 
     extracted_rules = sorted(extracted_rules, key=lambda x: x[1])
     extracted_rules = list(map(lambda x: x[0], extracted_rules))
@@ -377,11 +390,13 @@ The maximum number of evaluations to make for each feature</p>
                                                    random_state=random_state,
                                                    max_depth=100)
 
-    if type(tree_generator) not in [GradientBoostingClassifier, GradientBoostingRegressor,
-                                    RandomForestRegressor, RandomForestClassifier]:
+    is_xgboost = convert.is_xgboost_model(tree_generator)
+    if not is_xgboost and type(tree_generator) not in [
+            GradientBoostingClassifier, GradientBoostingRegressor,
+            RandomForestRegressor, RandomForestClassifier]:
         raise ValueError(
             &#34;RuleFit only works with GradientBoostingClassifier(), GradientBoostingRegressor(), &#34;
-            &#34;RandomForestRegressor() or RandomForestClassifier()&#34;)
+            &#34;RandomForestRegressor(), RandomForestClassifier(), or an XGBoost model&#34;)
 
     # work on a copy: rule extraction refits the generator and overrides some of
     # its parameters, which would otherwise modify the caller&#39;s estimator. Cloning
@@ -389,7 +404,11 @@ The maximum number of evaluations to make for each feature</p>
     tree_generator = clone(tree_generator)
 
     # fit tree generator
-    if not exp_rand_tree_size:  # simply fit with constant tree size
+    if is_xgboost:
+        # XGBoost has no sklearn-style warm_start, so the varying-tree-size
+        # scheme below doesn&#39;t apply; its own n_estimators controls the ensemble
+        tree_generator.fit(X, y)
+    elif not exp_rand_tree_size:  # simply fit with constant tree size
         tree_generator.fit(X, y)
     else:  # randomise tree size as per Friedman 2005 Sec 3.3
         np.random.seed(random_state)
@@ -410,21 +429,28 @@ The maximum number of evaluations to make for each feature</p>
             curr_est_ = curr_est_ + 1
         tree_generator.set_params(warm_start=False)
 
-    if isinstance(tree_generator, RandomForestRegressor) or isinstance(tree_generator, RandomForestClassifier):
-        estimators_ = [[x] for x in tree_generator.estimators_]
+    if is_xgboost:
+        rule_value_pairs = convert.xgboost_to_rules(
+            tree_generator, list(feature_names), prediction_values=True)
     else:
-        estimators_ = tree_generator.estimators_
+        if isinstance(tree_generator, RandomForestRegressor) or isinstance(tree_generator, RandomForestClassifier):
+            estimators_ = [[x] for x in tree_generator.estimators_]
+        else:
+            estimators_ = tree_generator.estimators_
+        rule_value_pairs = [
+            pair for estimator in estimators_
+            for pair in convert.tree_to_rules(
+                estimator[0], np.array(feature_names), prediction_values=True)
+        ]
 
     seen_rules = set()
     extracted_rules = []
-    for estimator in estimators_:
-        for rule_value_pair in convert.tree_to_rules(estimator[0], np.array(feature_names), prediction_values=True):
+    for rule_value_pair in rule_value_pairs:
+        rule_obj = rule.Rule(rule_value_pair[0])
 
-            rule_obj = rule.Rule(rule_value_pair[0])
-
-            if rule_obj not in seen_rules:
-                extracted_rules.append(rule_value_pair)
-                seen_rules.add(rule_obj)
+        if rule_obj not in seen_rules:
+            extracted_rules.append(rule_value_pair)
+            seen_rules.add(rule_obj)
 
     extracted_rules = sorted(extracted_rules, key=lambda x: x[1])
     extracted_rules = list(map(lambda x: x[0], extracted_rules))

--- a/docs/util/get_rules.html
+++ b/docs/util/get_rules.html
@@ -38,6 +38,11 @@ import numpy as np
 import pandas as pd
 
 from imodels.util.convert import tree_to_rules
+from imodels.util.model_trees import (
+    WRAPPED_MODEL_ATTRS,
+    is_sklearn_tree,
+    sklearn_trees,
+)
 
 #: Columns every `get_rules` result has, in the order they appear.
 CORE_COLUMNS = [&#39;rule&#39;, &#39;prediction&#39;]
@@ -61,9 +66,13 @@ def get_rules(model, feature_names=None) -&gt; pd.DataFrame:
 
         - ``rule``: the condition as a string, e.g. ``&#34;age &lt;= 30.5 and bmi &gt; 24.1&#34;``.
           The catch-all final rule of a rule list is ``&#34;else&#34;``.
-        - ``prediction``: what the model predicts when that rule applies. For
-          classifiers this is the predicted value/probability held in the leaf;
-          it is ``NaN`` where a model defines no per-rule prediction.
+        - ``prediction``: what the rule itself predicts. For a single tree this is
+          the value held in the leaf, so it is the model&#39;s prediction. For models
+          that combine several rules the meaning follows the model: an additive
+          model like FIGS contributes its trees&#39; values, so they sum to the
+          output, while a boosted ensemble takes a weighted vote and reports each
+          tree&#39;s own prediction alongside a ``weight`` column. It is ``NaN``
+          where a model defines no per-rule prediction.
 
         Models add their own columns on top of these, for example ``coef``,
         ``support`` and ``importance`` for RuleFit, or ``tree`` and ``depth`` for
@@ -127,7 +136,7 @@ def _get_feature_names(model, feature_names, n_features=None):
 
 def _rules_from_wrapped_model(model, feature_names):
     &#34;&#34;&#34;Models that delegate to another fitted model (shrinkage, CV wrappers).&#34;&#34;&#34;
-    for attr in (&#39;figs&#39;, &#39;estimator_&#39;, &#39;model&#39;):
+    for attr in WRAPPED_MODEL_ATTRS:
         inner = getattr(model, attr, None)
         # an unfitted sklearn tree has no tree_; don&#39;t recurse into it
         if inner is not None and inner is not model and _has_rules(inner):
@@ -137,15 +146,10 @@ def _rules_from_wrapped_model(model, feature_names):
     return None
 
 
-def _is_sklearn_tree(model):
-    # C45TreeClassifier also has a tree_, but it holds XML rather than a tree
-    return hasattr(getattr(model, &#39;tree_&#39;, None), &#39;feature&#39;)
-
-
 def _has_rules(model):
     if getattr(model, &#39;rules_&#39;, None) is not None:
         return True
-    if _is_sklearn_tree(model):
+    if is_sklearn_tree(model):
         return True
     return any(hasattr(model, attr) for attr in (&#39;trees_&#39;, &#39;estimators_&#39;))
 
@@ -236,6 +240,8 @@ def _rules_from_c45(model, feature_names):
 
     # flags mark how a child splits its parent: less-than, right (&gt;=) or equal
     comparisons = {&#39;l&#39;: &#39;&lt;&#39;, &#39;r&#39;: &#39;&gt;=&#39;, &#39;m&#39;: &#39;==&#39;}
+    # the tree stores XML-safe names; report the ones the caller used
+    original_names = getattr(model, &#39;xml_name_to_feature_name_&#39;, {})
     rows = []
 
     def walk(node, conditions):
@@ -251,8 +257,8 @@ def _rules_from_c45(model, feature_names):
             flag = child.getAttribute(&#39;flag&#39;)
             threshold = child.getAttribute(&#39;feature&#39;)
             comparison = comparisons.get(flag, flag)
-            walk(child, conditions +
-                 [f&#34;{child.nodeName} {comparison} {threshold}&#34;])
+            name = original_names.get(child.nodeName, child.nodeName)
+            walk(child, conditions + [f&#34;{name} {comparison} {threshold}&#34;])
 
     walk(dom.childNodes[0], [])
     return pd.DataFrame(rows)
@@ -305,14 +311,23 @@ def _rules_from_trees(model, feature_names):
         n_features = trees[0].n_features_in_
     names = _get_feature_names(model, feature_names, n_features)
 
+    # boosted ensembles combine their trees by weighted vote, so report the
+    # weight alongside each tree&#39;s own prediction
+    tree_weights = getattr(model, &#39;estimator_weights_&#39;, None)
+    if tree_weights is not None and len(tree_weights) != len(trees):
+        tree_weights = None
+
     rows = []
     for tree_num, tree in enumerate(trees):
         for rule, value in tree_to_rules(tree, names, prediction_values=True):
-            rows.append({
+            row = {
                 &#39;rule&#39;: rule,
                 &#39;prediction&#39;: value[-1] if len(value) &gt; 1 else value[0],
                 &#39;tree&#39;: tree_num,
-            })
+            }
+            if tree_weights is not None:
+                row[&#39;weight&#39;] = tree_weights[tree_num]
+            rows.append(row)
     rules = pd.DataFrame(rows)
     if len(trees) == 1:  # a single tree needs no tree index
         rules = rules.drop(columns=&#39;tree&#39;)
@@ -320,22 +335,12 @@ def _rules_from_trees(model, feature_names):
 
 
 def _collect_trees(model):
-    &#34;&#34;&#34;The sklearn trees making up a model, or None if it isn&#39;t tree-based.&#34;&#34;&#34;
-    if _is_sklearn_tree(model):
-        return [model]
+    &#34;&#34;&#34;The sklearn trees making up a model, or None if it isn&#39;t tree-based.
 
-    subestimators = getattr(model, &#39;estimators_&#39;, None)
-    if subestimators is not None and len(subestimators) &gt; 0:
-        trees = []
-        for estimator in subestimators:
-            if isinstance(estimator, np.ndarray):  # gradient boosting nests them
-                estimator = estimator[0]
-            if not _is_sklearn_tree(estimator):
-                return None
-            trees.append(estimator)
-        return trees
-
-    return None</code></pre>
+    FIGS is excluded: _rules_from_figs reads its nodes directly, because the
+    converted sklearn trees hold class counts rather than predictions.
+    &#34;&#34;&#34;
+    return sklearn_trees(model, convert_figs=False)</code></pre>
 </details>
 </section>
 <section>
@@ -373,9 +378,13 @@ fitted with, falling back to X0, X1, &hellip; .</dd>
 <ul>
 <li><code>rule</code>: the condition as a string, e.g. <code>"age &lt;= 30.5 and bmi &gt; 24.1"</code>.
 The catch-all final rule of a rule list is <code>"else"</code>.</li>
-<li><code>prediction</code>: what the model predicts when that rule applies. For
-classifiers this is the predicted value/probability held in the leaf;
-it is <code>NaN</code> where a model defines no per-rule prediction.</li>
+<li><code>prediction</code>: what the rule itself predicts. For a single tree this is
+the value held in the leaf, so it is the model's prediction. For models
+that combine several rules the meaning follows the model: an additive
+model like FIGS contributes its trees' values, so they sum to the
+output, while a boosted ensemble takes a weighted vote and reports each
+tree's own prediction alongside a <code>weight</code> column. It is <code>NaN</code>
+where a model defines no per-rule prediction.</li>
 </ul>
 <p>Models add their own columns on top of these, for example <code>coef</code>,
 <code>support</code> and <code>importance</code> for RuleFit, or <code>tree</code> and <code>depth</code> for
@@ -418,9 +427,13 @@ tree-based models. Those extra columns vary by model; only <code>rule</code> and
 
         - ``rule``: the condition as a string, e.g. ``&#34;age &lt;= 30.5 and bmi &gt; 24.1&#34;``.
           The catch-all final rule of a rule list is ``&#34;else&#34;``.
-        - ``prediction``: what the model predicts when that rule applies. For
-          classifiers this is the predicted value/probability held in the leaf;
-          it is ``NaN`` where a model defines no per-rule prediction.
+        - ``prediction``: what the rule itself predicts. For a single tree this is
+          the value held in the leaf, so it is the model&#39;s prediction. For models
+          that combine several rules the meaning follows the model: an additive
+          model like FIGS contributes its trees&#39; values, so they sum to the
+          output, while a boosted ensemble takes a weighted vote and reports each
+          tree&#39;s own prediction alongside a ``weight`` column. It is ``NaN``
+          where a model defines no per-rule prediction.
 
         Models add their own columns on top of these, for example ``coef``,
         ``support`` and ``importance`` for RuleFit, or ``tree`` and ``depth`` for

--- a/docs/util/index.html
+++ b/docs/util/index.html
@@ -77,6 +77,10 @@
 <dd>
 <div class="desc"></div>
 </dd>
+<dt><code class="name"><a title="imodels.util.model_trees" href="model_trees.html">imodels.util.model_trees</a></code></dt>
+<dd>
+<div class="desc"><p>Find the scikit-learn trees behind a fitted imodels model …</p></div>
+</dd>
 <dt><code class="name"><a title="imodels.util.neural_nets" href="neural_nets.html">imodels.util.neural_nets</a></code></dt>
 <dd>
 <div class="desc"><p>Bridging random forests and deep neural networks. Code to convert a sklearn decision tree to a pytorch neural network
@@ -109,6 +113,10 @@ following "Neural Random …</p></div>
 <dt><code class="name"><a title="imodels.util.tree_interaction_utils" href="tree_interaction_utils.html">imodels.util.tree_interaction_utils</a></code></dt>
 <dd>
 <div class="desc"></div>
+</dd>
+<dt><code class="name"><a title="imodels.util.tree_viz" href="tree_viz.html">imodels.util.tree_viz</a></code></dt>
+<dd>
+<div class="desc"><p>Plot imodels trees with dtreeviz …</p></div>
 </dd>
 </dl>
 </section>
@@ -151,6 +159,7 @@ following "Neural Random …</p></div>
 <li><code><a title="imodels.util.extract" href="extract.html">imodels.util.extract</a></code></li>
 <li><code><a title="imodels.util.get_rules" href="get_rules.html">imodels.util.get_rules</a></code></li>
 <li><code><a title="imodels.util.metrics" href="metrics.html">imodels.util.metrics</a></code></li>
+<li><code><a title="imodels.util.model_trees" href="model_trees.html">imodels.util.model_trees</a></code></li>
 <li><code><a title="imodels.util.neural_nets" href="neural_nets.html">imodels.util.neural_nets</a></code></li>
 <li><code><a title="imodels.util.prune" href="prune.html">imodels.util.prune</a></code></li>
 <li><code><a title="imodels.util.rule" href="rule.html">imodels.util.rule</a></code></li>
@@ -159,6 +168,7 @@ following "Neural Random …</p></div>
 <li><code><a title="imodels.util.transforms" href="transforms.html">imodels.util.transforms</a></code></li>
 <li><code><a title="imodels.util.tree" href="tree.html">imodels.util.tree</a></code></li>
 <li><code><a title="imodels.util.tree_interaction_utils" href="tree_interaction_utils.html">imodels.util.tree_interaction_utils</a></code></li>
+<li><code><a title="imodels.util.tree_viz" href="tree_viz.html">imodels.util.tree_viz</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/util/model_trees.html
+++ b/docs/util/model_trees.html
@@ -17,182 +17,205 @@
 <main>
 <article id="content">
 <section id="section-intro">
+<p>Find the scikit-learn trees behind a fitted imodels model.</p>
+<p>Several features (rule extraction, leaf membership) need the same thing: the
+sklearn tree structures a model is built from, whatever shape the model takes.
+Keeping that in one place stops those features from disagreeing about which
+models are tree-based.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">import numpy as np
-import pandas as pd
-from sklearn.base import BaseEstimator
-from sklearn.utils.validation import check_X_y
+<pre><code class="python">&#34;&#34;&#34;Find the scikit-learn trees behind a fitted imodels model.
 
-import imodels
+Several features (rule extraction, leaf membership) need the same thing: the
+sklearn tree structures a model is built from, whatever shape the model takes.
+Keeping that in one place stops those features from disagreeing about which
+models are tree-based.
+&#34;&#34;&#34;
+
+import numpy as np
+
+#: attributes under which a model may keep the fitted model it delegates to
+WRAPPED_MODEL_ATTRS = (&#39;figs&#39;, &#39;estimator_&#39;, &#39;model&#39;)
 
 
-def explain_classification_errors(X, predictions, y,
-                                  feature_names: list = None,
-                                  target_name: str = None,
-                                  classifier: BaseEstimator = None,
-                                  target_one_hot_encode: bool = False,
-                                  print_rules: bool = True):
-    &#34;&#34;&#34;Explains the classification errors of a model by fitting an interpretable model to them.
-    Currently only supports binary classification.
+def is_sklearn_tree(estimator) -&gt; bool:
+    &#34;&#34;&#34;Whether `estimator` holds a fitted sklearn tree.
+
+    Checks the tree structure itself, since C45TreeClassifier also has a `tree_`
+    but stores XML in it.
+    &#34;&#34;&#34;
+    return hasattr(getattr(estimator, &#39;tree_&#39;, None), &#39;feature&#39;)
+
+
+def n_tree_outputs(model) -&gt; int:
+    &#34;&#34;&#34;Number of values each leaf of `model` holds (classes, or 1 for regression).&#34;&#34;&#34;
+    n_outputs = getattr(model, &#39;n_outputs&#39;, None)
+    if n_outputs:
+        return int(n_outputs)
+    classes = getattr(model, &#39;classes_&#39;, None)
+    return len(classes) if classes is not None else 1
+
+
+def sklearn_trees(model, convert_figs=True):
+    &#34;&#34;&#34;The fitted sklearn trees making up `model`, or None if it has none.
 
     Parameters
     ----------
-    X: array_like
-        (n, n_features)
-    predictions: array_like
-        (n, 1) predictions
-    y
-        (n, 1) targets with integer values representing class
-    feature_names
-        n_features
-    classifier
-        Interpretable model fitted to the errors. A new GreedyTreeClassifier is
-        used if none is given.
-
-    Returns
-    -------
-    model: BaseEstimator
+    model
+        A fitted model.
+    convert_figs : bool
+        Whether to convert a FIGS model&#39;s own tree objects into sklearn trees.
+        Set False when the caller reads FIGS nodes directly (the converted trees
+        store class counts rather than predictions).
     &#34;&#34;&#34;
-    # built per call: a default constructed in the signature is created once at
-    # import, so every call would share and refit the same classifier
-    if classifier is None:
-        classifier = imodels.GreedyTreeClassifier()
+    if hasattr(model, &#39;trees_&#39;):  # FIGS: a sum of its own tree objects
+        if not convert_figs:
+            return None
+        from imodels.tree.viz_utils import extract_sklearn_tree_from_figs
+        n_outputs = n_tree_outputs(model)
+        return [extract_sklearn_tree_from_figs(model, i, n_outputs)
+                for i in range(len(model.trees_))]
 
-    # deal with names
-    if feature_names is None:
-        if isinstance(X, pd.DataFrame):
-            feature_names = X.columns.tolist()
-        else:
-            feature_names = [f&#39;X{i + 1}&#39; for i in range(X.shape[1])]
+    if is_sklearn_tree(model):
+        return [model]
 
-    if target_name is None:
-        if isinstance(y, pd.DataFrame):
-            target_name = y.columns[0]
-        elif isinstance(y, pd.Series):
-            target_name = y.name
-        else:
-            target_name = &#39;target&#39;
-    if isinstance(predictions, pd.Series) or isinstance(predictions, pd.DataFrame):
-        predictions = predictions.values
+    # models that delegate to another fitted model (shrinkage, CV wrappers, TAO)
+    for attr in WRAPPED_MODEL_ATTRS:
+        inner = getattr(model, attr, None)
+        if inner is not None and inner is not model:
+            trees = sklearn_trees(inner, convert_figs=convert_figs)
+            if trees is not None:
+                return trees
 
-    X, y = check_X_y(X, y)  # converts to np
-    if len(y.shape) == 1:
-        y = y.reshape(-1, 1)
-    if len(predictions.shape) == 1:
-        predictions = predictions.reshape(-1, 1)
+    subestimators = getattr(model, &#39;estimators_&#39;, None)
+    if subestimators is not None and len(subestimators) &gt; 0:
+        trees = []
+        for estimator in subestimators:
+            if isinstance(estimator, np.ndarray):  # gradient boosting nests them
+                estimator = estimator[0]
+            if not is_sklearn_tree(estimator):
+                return None
+            trees.append(estimator)
+        return trees
 
-    errors = np.array(predictions != y).astype(int)
-
-    features = pd.DataFrame(np.hstack((X, y)))
-    features.columns = [*feature_names, target_name]
-    classifier.fit(features, errors.flatten())
-    if print_rules:
-        print(classifier)
-    return classifier, features.columns</code></pre>
+    return None</code></pre>
 </details>
 </section>
 <section>
 </section>
 <section>
+<h2 class="section-title" id="header-variables">Global variables</h2>
+<dl>
+<dt id="imodels.util.model_trees.WRAPPED_MODEL_ATTRS"><code class="name">var <span class="ident">WRAPPED_MODEL_ATTRS</span></code></dt>
+<dd>
+<div class="desc"><p>attributes under which a model may keep the fitted model it delegates to</p></div>
+</dd>
+</dl>
 </section>
 <section>
 <h2 class="section-title" id="header-functions">Functions</h2>
 <dl>
-<dt id="imodels.util.explain_errors.explain_classification_errors"><code class="name flex">
-<span>def <span class="ident">explain_classification_errors</span></span>(<span>X, predictions, y, feature_names: list = None, target_name: str = None, classifier: sklearn.base.BaseEstimator = None, target_one_hot_encode: bool = False, print_rules: bool = True)</span>
+<dt id="imodels.util.model_trees.is_sklearn_tree"><code class="name flex">
+<span>def <span class="ident">is_sklearn_tree</span></span>(<span>estimator) ‑> bool</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Explains the classification errors of a model by fitting an interpretable model to them.
-Currently only supports binary classification.</p>
+<div class="desc"><p>Whether <code>estimator</code> holds a fitted sklearn tree.</p>
+<p>Checks the tree structure itself, since C45TreeClassifier also has a <code>tree_</code>
+but stores XML in it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def is_sklearn_tree(estimator) -&gt; bool:
+    &#34;&#34;&#34;Whether `estimator` holds a fitted sklearn tree.
+
+    Checks the tree structure itself, since C45TreeClassifier also has a `tree_`
+    but stores XML in it.
+    &#34;&#34;&#34;
+    return hasattr(getattr(estimator, &#39;tree_&#39;, None), &#39;feature&#39;)</code></pre>
+</details>
+</dd>
+<dt id="imodels.util.model_trees.n_tree_outputs"><code class="name flex">
+<span>def <span class="ident">n_tree_outputs</span></span>(<span>model) ‑> int</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Number of values each leaf of <code>model</code> holds (classes, or 1 for regression).</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def n_tree_outputs(model) -&gt; int:
+    &#34;&#34;&#34;Number of values each leaf of `model` holds (classes, or 1 for regression).&#34;&#34;&#34;
+    n_outputs = getattr(model, &#39;n_outputs&#39;, None)
+    if n_outputs:
+        return int(n_outputs)
+    classes = getattr(model, &#39;classes_&#39;, None)
+    return len(classes) if classes is not None else 1</code></pre>
+</details>
+</dd>
+<dt id="imodels.util.model_trees.sklearn_trees"><code class="name flex">
+<span>def <span class="ident">sklearn_trees</span></span>(<span>model, convert_figs=True)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>The fitted sklearn trees making up <code>model</code>, or None if it has none.</p>
 <h2 id="parameters">Parameters</h2>
 <dl>
-<dt><strong><code>X</code></strong> :&ensp;<code>array_like</code></dt>
-<dd>(n, n_features)</dd>
-<dt><strong><code>predictions</code></strong> :&ensp;<code>array_like</code></dt>
-<dd>(n, 1) predictions</dd>
-<dt><strong><code>y</code></strong></dt>
-<dd>(n, 1) targets with integer values representing class</dd>
-<dt><strong><code>feature_names</code></strong></dt>
-<dd>n_features</dd>
-<dt><strong><code>classifier</code></strong></dt>
-<dd>Interpretable model fitted to the errors. A new GreedyTreeClassifier is
-used if none is given.</dd>
-</dl>
-<h2 id="returns">Returns</h2>
-<dl>
-<dt><strong><code>model</code></strong> :&ensp;<code>BaseEstimator</code></dt>
-<dd>&nbsp;</dd>
+<dt><strong><code>model</code></strong></dt>
+<dd>A fitted model.</dd>
+<dt><strong><code>convert_figs</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Whether to convert a FIGS model's own tree objects into sklearn trees.
+Set False when the caller reads FIGS nodes directly (the converted trees
+store class counts rather than predictions).</dd>
 </dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def explain_classification_errors(X, predictions, y,
-                                  feature_names: list = None,
-                                  target_name: str = None,
-                                  classifier: BaseEstimator = None,
-                                  target_one_hot_encode: bool = False,
-                                  print_rules: bool = True):
-    &#34;&#34;&#34;Explains the classification errors of a model by fitting an interpretable model to them.
-    Currently only supports binary classification.
+<pre><code class="python">def sklearn_trees(model, convert_figs=True):
+    &#34;&#34;&#34;The fitted sklearn trees making up `model`, or None if it has none.
 
     Parameters
     ----------
-    X: array_like
-        (n, n_features)
-    predictions: array_like
-        (n, 1) predictions
-    y
-        (n, 1) targets with integer values representing class
-    feature_names
-        n_features
-    classifier
-        Interpretable model fitted to the errors. A new GreedyTreeClassifier is
-        used if none is given.
-
-    Returns
-    -------
-    model: BaseEstimator
+    model
+        A fitted model.
+    convert_figs : bool
+        Whether to convert a FIGS model&#39;s own tree objects into sklearn trees.
+        Set False when the caller reads FIGS nodes directly (the converted trees
+        store class counts rather than predictions).
     &#34;&#34;&#34;
-    # built per call: a default constructed in the signature is created once at
-    # import, so every call would share and refit the same classifier
-    if classifier is None:
-        classifier = imodels.GreedyTreeClassifier()
+    if hasattr(model, &#39;trees_&#39;):  # FIGS: a sum of its own tree objects
+        if not convert_figs:
+            return None
+        from imodels.tree.viz_utils import extract_sklearn_tree_from_figs
+        n_outputs = n_tree_outputs(model)
+        return [extract_sklearn_tree_from_figs(model, i, n_outputs)
+                for i in range(len(model.trees_))]
 
-    # deal with names
-    if feature_names is None:
-        if isinstance(X, pd.DataFrame):
-            feature_names = X.columns.tolist()
-        else:
-            feature_names = [f&#39;X{i + 1}&#39; for i in range(X.shape[1])]
+    if is_sklearn_tree(model):
+        return [model]
 
-    if target_name is None:
-        if isinstance(y, pd.DataFrame):
-            target_name = y.columns[0]
-        elif isinstance(y, pd.Series):
-            target_name = y.name
-        else:
-            target_name = &#39;target&#39;
-    if isinstance(predictions, pd.Series) or isinstance(predictions, pd.DataFrame):
-        predictions = predictions.values
+    # models that delegate to another fitted model (shrinkage, CV wrappers, TAO)
+    for attr in WRAPPED_MODEL_ATTRS:
+        inner = getattr(model, attr, None)
+        if inner is not None and inner is not model:
+            trees = sklearn_trees(inner, convert_figs=convert_figs)
+            if trees is not None:
+                return trees
 
-    X, y = check_X_y(X, y)  # converts to np
-    if len(y.shape) == 1:
-        y = y.reshape(-1, 1)
-    if len(predictions.shape) == 1:
-        predictions = predictions.reshape(-1, 1)
+    subestimators = getattr(model, &#39;estimators_&#39;, None)
+    if subestimators is not None and len(subestimators) &gt; 0:
+        trees = []
+        for estimator in subestimators:
+            if isinstance(estimator, np.ndarray):  # gradient boosting nests them
+                estimator = estimator[0]
+            if not is_sklearn_tree(estimator):
+                return None
+            trees.append(estimator)
+        return trees
 
-    errors = np.array(predictions != y).astype(int)
-
-    features = pd.DataFrame(np.hstack((X, y)))
-    features.columns = [*feature_names, target_name]
-    classifier.fit(features, errors.flatten())
-    if print_rules:
-        print(classifier)
-    return classifier, features.columns</code></pre>
+    return None</code></pre>
 </details>
 </dd>
 </dl>
@@ -211,9 +234,16 @@ used if none is given.</dd>
 <li><code><a title="imodels.util" href="index.html">imodels.util</a></code></li>
 </ul>
 </li>
+<li><h3><a href="#header-variables">Global variables</a></h3>
+<ul class="">
+<li><code><a title="imodels.util.model_trees.WRAPPED_MODEL_ATTRS" href="#imodels.util.model_trees.WRAPPED_MODEL_ATTRS">WRAPPED_MODEL_ATTRS</a></code></li>
+</ul>
+</li>
 <li><h3><a href="#header-functions">Functions</a></h3>
 <ul class="">
-<li><code><a title="imodels.util.explain_errors.explain_classification_errors" href="#imodels.util.explain_errors.explain_classification_errors">explain_classification_errors</a></code></li>
+<li><code><a title="imodels.util.model_trees.is_sklearn_tree" href="#imodels.util.model_trees.is_sklearn_tree">is_sklearn_tree</a></code></li>
+<li><code><a title="imodels.util.model_trees.n_tree_outputs" href="#imodels.util.model_trees.n_tree_outputs">n_tree_outputs</a></code></li>
+<li><code><a title="imodels.util.model_trees.sklearn_trees" href="#imodels.util.model_trees.sklearn_trees">sklearn_trees</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/util/score.html
+++ b/docs/util/score.html
@@ -68,8 +68,10 @@ def score_precision_recall(X,
             columns=np.array(feature_names)[curr_features_to_use]
         )
 
-        if X_oob.shape[1] &lt;= 1:  # otherwise pandas bug (cf. issue #16363)
-            return []
+        # a guard for pandas issue #16363 used to skip estimators that use a
+        # single feature, and did so with `return []`, discarding every rule
+        # scored so far. That pandas bug is long fixed, and on data with few
+        # features every estimator uses one feature, so no rules survived.
 
         y_oob = y[mask]
         y_oob = np.array((y_oob != 0))
@@ -346,8 +348,10 @@ def get_best_alpha_under_max_rules(X, y, rules: List[str],
             columns=np.array(feature_names)[curr_features_to_use]
         )
 
-        if X_oob.shape[1] &lt;= 1:  # otherwise pandas bug (cf. issue #16363)
-            return []
+        # a guard for pandas issue #16363 used to skip estimators that use a
+        # single feature, and did so with `return []`, discarding every rule
+        # scored so far. That pandas bug is long fixed, and on data with few
+        # features every estimator uses one feature, so no rules survived.
 
         y_oob = y[mask]
         y_oob = np.array((y_oob != 0))

--- a/docs/util/transforms.html
+++ b/docs/util/transforms.html
@@ -99,9 +99,12 @@ class CorrelationScreenTransformer(BaseEstimator, TransformerMixin):
     def __init__(self, threshold=1.0):
         # Initialize with a correlation threshold
         self.threshold = threshold
-        self.correlated_feature_sets = []
 
     def fit(self, X, y=None):
+        # started fresh each time: appending to sets kept from a previous fit
+        # would screen out features that are not correlated in this data
+        self.correlated_feature_sets = []
+
         # Check if X is a pandas DataFrame; if not, convert it to DataFrame
         if not isinstance(X, pd.DataFrame):
             X = pd.DataFrame(X)
@@ -144,7 +147,7 @@ class CorrelationScreenTransformer(BaseEstimator, TransformerMixin):
             X_transformed.iloc[:, to_remove] = 0
 
         if input_type == np.ndarray:
-            X_transformed == X_transformed.values
+            X_transformed = X_transformed.values
 
         return X_transformed
 
@@ -188,9 +191,12 @@ and zeros out all but the first of them</p></div>
     def __init__(self, threshold=1.0):
         # Initialize with a correlation threshold
         self.threshold = threshold
-        self.correlated_feature_sets = []
 
     def fit(self, X, y=None):
+        # started fresh each time: appending to sets kept from a previous fit
+        # would screen out features that are not correlated in this data
+        self.correlated_feature_sets = []
+
         # Check if X is a pandas DataFrame; if not, convert it to DataFrame
         if not isinstance(X, pd.DataFrame):
             X = pd.DataFrame(X)
@@ -233,7 +239,7 @@ and zeros out all but the first of them</p></div>
             X_transformed.iloc[:, to_remove] = 0
 
         if input_type == np.ndarray:
-            X_transformed == X_transformed.values
+            X_transformed = X_transformed.values
 
         return X_transformed</code></pre>
 </details>
@@ -258,6 +264,10 @@ and zeros out all but the first of them</p></div>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def fit(self, X, y=None):
+    # started fresh each time: appending to sets kept from a previous fit
+    # would screen out features that are not correlated in this data
+    self.correlated_feature_sets = []
+
     # Check if X is a pandas DataFrame; if not, convert it to DataFrame
     if not isinstance(X, pd.DataFrame):
         X = pd.DataFrame(X)
@@ -310,7 +320,7 @@ and zeros out all but the first of them</p></div>
         X_transformed.iloc[:, to_remove] = 0
 
     if input_type == np.ndarray:
-        X_transformed == X_transformed.values
+        X_transformed = X_transformed.values
 
     return X_transformed</code></pre>
 </details>

--- a/docs/util/tree.html
+++ b/docs/util/tree.html
@@ -59,11 +59,18 @@ def compute_tree_complexity(tree, complexity_measure=&#39;num_rules&#39;):
 
 def _validate_feature_costs(feature_costs, n_features):
     if feature_costs is None:
-        feature_costs = np.ones(n_features, dtype=np.float64)
-    else:
-        assert len(
-            feature_costs) == n_features, f&#39;{len(feature_costs)} != {n_features}&#39;
-        np.min(feature_costs) &gt;= 0
+        return np.ones(n_features, dtype=np.float64)
+
+    if len(feature_costs) != n_features:
+        raise ValueError(
+            f&#39;feature_costs has {len(feature_costs)} entries but there are &#39;
+            f&#39;{n_features} features&#39;)
+    # this was written as a bare comparison, so negative costs passed through
+    # and produced negative depths
+    if np.min(feature_costs) &lt; 0:
+        raise ValueError(
+            f&#39;feature_costs must be non-negative, got a minimum of &#39;
+            f&#39;{np.min(feature_costs)}&#39;)
     return feature_costs
 
 
@@ -160,18 +167,15 @@ def calculate_mean_unique_calls_in_ensemble(ensemble, X, feature_costs=None):
     &#39;&#39;&#39;
     if X is None:
         # Should pass X, this is just for testing
-        n_features_in = ensemble.n_features_in_
-        X = np.random.randint(2, size=(100, n_features_in))
+        X = np.random.randint(
+            2, size=(100, ensemble.n_features_in_))
 
-    if feature_costs is None:
-        feature_costs = np.ones(n_features_in, dtype=np.float64)
-    else:
-        assert len(
-            feature_costs) == n_features_in, f&#39;{len(feature_costs)} != {n_features_in}&#39;
-        np.min(feature_costs) &gt;= 0
+    # n_features_in used to be read from a branch that only ran when X was None,
+    # so passing X -- the documented use -- raised UnboundLocalError
+    feature_costs = _validate_feature_costs(feature_costs, np.shape(X)[1])
 
-    # extract the decision path for each sample
-    ests = ensemble.estimators_.flatten()
+    # estimators_ is a list for forests and a 2d array for gradient boosting
+    ests = np.asarray(ensemble.estimators_).flatten()
     feats = [set() for _ in range(len(X))]
     for i in range(len(ests)):
         est = ests[i]
@@ -258,18 +262,15 @@ This is the average depth of the path from the root to the point.</p></div>
     &#39;&#39;&#39;
     if X is None:
         # Should pass X, this is just for testing
-        n_features_in = ensemble.n_features_in_
-        X = np.random.randint(2, size=(100, n_features_in))
+        X = np.random.randint(
+            2, size=(100, ensemble.n_features_in_))
 
-    if feature_costs is None:
-        feature_costs = np.ones(n_features_in, dtype=np.float64)
-    else:
-        assert len(
-            feature_costs) == n_features_in, f&#39;{len(feature_costs)} != {n_features_in}&#39;
-        np.min(feature_costs) &gt;= 0
+    # n_features_in used to be read from a branch that only ran when X was None,
+    # so passing X -- the documented use -- raised UnboundLocalError
+    feature_costs = _validate_feature_costs(feature_costs, np.shape(X)[1])
 
-    # extract the decision path for each sample
-    ests = ensemble.estimators_.flatten()
+    # estimators_ is a list for forests and a 2d array for gradient boosting
+    ests = np.asarray(ensemble.estimators_).flatten()
     feats = [set() for _ in range(len(X))]
     for i in range(len(ests)):
         est = ests[i]

--- a/docs/util/tree_viz.html
+++ b/docs/util/tree_viz.html
@@ -17,64 +17,110 @@
 <main>
 <article id="content">
 <section id="section-intro">
-<p>Map samples to the leaves they land in, like sklearn's <code>tree.apply</code>.</p>
+<p>Plot imodels trees with dtreeviz.</p>
+<p>dtreeviz draws a <code>ShadowDecTree</code>; imodels models are built from scikit-learn
+trees underneath, so one can be built with dtreeviz's own <code>ShadowSKDTree</code>
+(<a href="https://github.com/parrt/dtreeviz">https://github.com/parrt/dtreeviz</a>). dtreeviz is not a dependency of imodels and
+is imported only when this is called.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">&#34;&#34;&#34;Map samples to the leaves they land in, like sklearn&#39;s `tree.apply`.&#34;&#34;&#34;
+<pre><code class="python">&#34;&#34;&#34;Plot imodels trees with dtreeviz.
+
+dtreeviz draws a `ShadowDecTree`; imodels models are built from scikit-learn
+trees underneath, so one can be built with dtreeviz&#39;s own `ShadowSKDTree`
+(https://github.com/parrt/dtreeviz). dtreeviz is not a dependency of imodels and
+is imported only when this is called.
+&#34;&#34;&#34;
 
 import numpy as np
-from sklearn.utils.validation import check_array
 
-from imodels.util.arguments import _finite_check_kwarg
-from imodels.util.model_trees import sklearn_trees
+from imodels.util.model_trees import n_tree_outputs, sklearn_trees
 
 
-def apply_leaves(model, X) -&gt; np.ndarray:
-    &#34;&#34;&#34;Return the leaf each sample reaches, for a tree-based model.
+def shadow_tree(model, X, y, feature_names=None, target_name=&#39;target&#39;,
+                class_names=None, tree_num=0):
+    &#34;&#34;&#34;Build a dtreeviz ShadowSKDTree for one of a model&#39;s trees.
 
     Parameters
     ----------
     model
-        A fitted tree-based imodels model.
-    X : array-like of shape (n_samples, n_features)
+        A fitted tree-based imodels model (FIGS, hierarchical shrinkage, CART,
+        TAO, boosted rules, ...).
+    X, y : the data to annotate the tree with, as dtreeviz requires.
+    feature_names : list of str, optional
+        Defaults to the names the model was fitted with, else X0, X1, ... .
+    target_name : str
+        Name shown for the target.
+    class_names : list, optional
+        Classification only. Defaults to the model&#39;s ``classes_``.
+    tree_num : int
+        Which tree to draw, for models made of several (FIGS, boosted rules).
 
     Returns
     -------
-    numpy.ndarray
-        For a model built from a single tree, shape ``(n_samples,)``: the index
-        of the leaf each sample falls in, using the same node numbering as
-        scikit-learn&#39;s ``DecisionTree.apply``.
-
-        For a model built from several trees (FIGS, boosted rules, TreeGAM),
-        shape ``(n_samples, n_trees)``, matching ``RandomForest.apply``: column
-        ``t`` holds the leaf reached in tree ``t``.
+    dtreeviz.models.sklearn_decision_trees.ShadowSKDTree
 
     Raises
     ------
+    ImportError
+        If dtreeviz is not installed.
     ValueError
-        If the model is not tree-based, or is not fitted yet.
+        If the model is not tree-based, or tree_num is out of range.
 
     Examples
     --------
-    &gt;&gt;&gt; model = FIGSClassifier(max_rules=3).fit(X, y)   # doctest: +SKIP
-    &gt;&gt;&gt; model.apply(X).shape                            # doctest: +SKIP
-    (100, 2)
+    &gt;&gt;&gt; import dtreeviz                                       # doctest: +SKIP
+    &gt;&gt;&gt; from imodels import FIGSClassifier, shadow_tree       # doctest: +SKIP
+    &gt;&gt;&gt; model = FIGSClassifier(max_rules=5).fit(X, y)         # doctest: +SKIP
+    &gt;&gt;&gt; viz = dtreeviz.trees.DTreeVizAPI(                     # doctest: +SKIP
+    ...     shadow_tree(model, X, y, tree_num=0))
+    &gt;&gt;&gt; viz.view()                                            # doctest: +SKIP
     &#34;&#34;&#34;
+    try:
+        from dtreeviz.models.sklearn_decision_trees import ShadowSKDTree
+    except ImportError as error:  # pragma: no cover - depends on the environment
+        raise ImportError(
+            &#34;dtreeviz is needed to plot imodels trees but is not installed &#34;
+            &#34;(&#39;pip install dtreeviz&#39;). It is not a dependency of imodels.&#34;
+        ) from error
+
     trees = sklearn_trees(model)
     if trees is None:
         raise ValueError(
-            f&#34;Don&#39;t know how to get leaf membership for {type(model).__name__}. &#34;
-            &#34;apply is defined for tree-based models; if the model is not fitted &#34;
-            &#34;yet, fit it first.&#34;
+            f&#34;Don&#39;t know how to draw {type(model).__name__}. dtreeviz support &#34;
+            &#34;covers tree-based models; if the model is not fitted yet, fit it first.&#34;
+        )
+    if not 0 &lt;= tree_num &lt; len(trees):
+        raise ValueError(
+            f&#34;tree_num must be in [0, {len(trees)}) for this model, got {tree_num}.&#34;
         )
 
-    # missing values are left to the tree, which handles them for sklearn trees;
-    # fit and predict accept them, so apply must too
-    X = check_array(X, **_finite_check_kwarg(allow_nan=True))
-    leaves = np.column_stack([tree.apply(X) for tree in trees])
-    return leaves[:, 0] if len(trees) == 1 else leaves</code></pre>
+    X = np.asarray(X)
+    if feature_names is None:
+        feature_names = _feature_names(model, X.shape[1])
+    if class_names is None:
+        class_names = _class_names(model)
+
+    return ShadowSKDTree(trees[tree_num], X, np.asarray(y),
+                         list(feature_names), target_name, class_names)
+
+
+def _feature_names(model, n_features):
+    for attr in (&#39;feature_names_in_&#39;, &#39;feature_names_&#39;, &#39;feature_names&#39;):
+        names = getattr(model, attr, None)
+        if names is not None and len(names) == n_features:
+            return [str(name) for name in names]
+    return [f&#39;X{i}&#39; for i in range(n_features)]
+
+
+def _class_names(model):
+    &#34;&#34;&#34;dtreeviz wants class labels for classifiers and None for regressors.&#34;&#34;&#34;
+    classes = getattr(model, &#39;classes_&#39;, None)
+    if classes is None or n_tree_outputs(model) == 1:
+        return None
+    return [str(label) for label in classes]</code></pre>
 </details>
 </section>
 <section>
@@ -84,88 +130,116 @@ def apply_leaves(model, X) -&gt; np.ndarray:
 <section>
 <h2 class="section-title" id="header-functions">Functions</h2>
 <dl>
-<dt id="imodels.util.apply.apply_leaves"><code class="name flex">
-<span>def <span class="ident">apply_leaves</span></span>(<span>model, X) ‑> numpy.ndarray</span>
+<dt id="imodels.util.tree_viz.shadow_tree"><code class="name flex">
+<span>def <span class="ident">shadow_tree</span></span>(<span>model, X, y, feature_names=None, target_name='target', class_names=None, tree_num=0)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Return the leaf each sample reaches, for a tree-based model.</p>
+<div class="desc"><p>Build a dtreeviz ShadowSKDTree for one of a model's trees.</p>
 <h2 id="parameters">Parameters</h2>
 <dl>
 <dt><strong><code>model</code></strong></dt>
-<dd>A fitted tree-based imodels model.</dd>
-<dt><strong><code>X</code></strong> :&ensp;<code>array-like</code> of <code>shape (n_samples, n_features)</code></dt>
-<dd>&nbsp;</dd>
+<dd>A fitted tree-based imodels model (FIGS, hierarchical shrinkage, CART,
+TAO, boosted rules, &hellip;).</dd>
+<dt>X, y : the data to annotate the tree with, as dtreeviz requires.</dt>
+<dt><strong><code>feature_names</code></strong> :&ensp;<code>list</code> of <code>str</code>, optional</dt>
+<dd>Defaults to the names the model was fitted with, else X0, X1, &hellip; .</dd>
+<dt><strong><code>target_name</code></strong> :&ensp;<code>str</code></dt>
+<dd>Name shown for the target.</dd>
+<dt><strong><code>class_names</code></strong> :&ensp;<code>list</code>, optional</dt>
+<dd>Classification only. Defaults to the model's <code>classes_</code>.</dd>
+<dt><strong><code>tree_num</code></strong> :&ensp;<code>int</code></dt>
+<dd>Which tree to draw, for models made of several (FIGS, boosted rules).</dd>
 </dl>
 <h2 id="returns">Returns</h2>
 <dl>
-<dt><code>numpy.ndarray</code></dt>
-<dd>
-<p>For a model built from a single tree, shape <code>(n_samples,)</code>: the index
-of the leaf each sample falls in, using the same node numbering as
-scikit-learn's <code>DecisionTree.apply</code>.</p>
-<p>For a model built from several trees (FIGS, boosted rules, TreeGAM),
-shape <code>(n_samples, n_trees)</code>, matching <code>RandomForest.apply</code>: column
-<code>t</code> holds the leaf reached in tree <code>t</code>.</p>
-</dd>
+<dt><code>dtreeviz.models.sklearn_decision_trees.ShadowSKDTree</code></dt>
+<dd>&nbsp;</dd>
 </dl>
 <h2 id="raises">Raises</h2>
 <dl>
+<dt><code>ImportError</code></dt>
+<dd>If dtreeviz is not installed.</dd>
 <dt><code>ValueError</code></dt>
-<dd>If the model is not tree-based, or is not fitted yet.</dd>
+<dd>If the model is not tree-based, or tree_num is out of range.</dd>
 </dl>
 <h2 id="examples">Examples</h2>
-<pre><code class="language-python-repl">&gt;&gt;&gt; model = FIGSClassifier(max_rules=3).fit(X, y)   # doctest: +SKIP
-&gt;&gt;&gt; model.apply(X).shape                            # doctest: +SKIP
-(100, 2)
+<pre><code class="language-python-repl">&gt;&gt;&gt; import dtreeviz                                       # doctest: +SKIP
+&gt;&gt;&gt; from imodels import FIGSClassifier, shadow_tree       # doctest: +SKIP
+&gt;&gt;&gt; model = FIGSClassifier(max_rules=5).fit(X, y)         # doctest: +SKIP
+&gt;&gt;&gt; viz = dtreeviz.trees.DTreeVizAPI(                     # doctest: +SKIP
+...     shadow_tree(model, X, y, tree_num=0))
+&gt;&gt;&gt; viz.view()                                            # doctest: +SKIP
 </code></pre></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def apply_leaves(model, X) -&gt; np.ndarray:
-    &#34;&#34;&#34;Return the leaf each sample reaches, for a tree-based model.
+<pre><code class="python">def shadow_tree(model, X, y, feature_names=None, target_name=&#39;target&#39;,
+                class_names=None, tree_num=0):
+    &#34;&#34;&#34;Build a dtreeviz ShadowSKDTree for one of a model&#39;s trees.
 
     Parameters
     ----------
     model
-        A fitted tree-based imodels model.
-    X : array-like of shape (n_samples, n_features)
+        A fitted tree-based imodels model (FIGS, hierarchical shrinkage, CART,
+        TAO, boosted rules, ...).
+    X, y : the data to annotate the tree with, as dtreeviz requires.
+    feature_names : list of str, optional
+        Defaults to the names the model was fitted with, else X0, X1, ... .
+    target_name : str
+        Name shown for the target.
+    class_names : list, optional
+        Classification only. Defaults to the model&#39;s ``classes_``.
+    tree_num : int
+        Which tree to draw, for models made of several (FIGS, boosted rules).
 
     Returns
     -------
-    numpy.ndarray
-        For a model built from a single tree, shape ``(n_samples,)``: the index
-        of the leaf each sample falls in, using the same node numbering as
-        scikit-learn&#39;s ``DecisionTree.apply``.
-
-        For a model built from several trees (FIGS, boosted rules, TreeGAM),
-        shape ``(n_samples, n_trees)``, matching ``RandomForest.apply``: column
-        ``t`` holds the leaf reached in tree ``t``.
+    dtreeviz.models.sklearn_decision_trees.ShadowSKDTree
 
     Raises
     ------
+    ImportError
+        If dtreeviz is not installed.
     ValueError
-        If the model is not tree-based, or is not fitted yet.
+        If the model is not tree-based, or tree_num is out of range.
 
     Examples
     --------
-    &gt;&gt;&gt; model = FIGSClassifier(max_rules=3).fit(X, y)   # doctest: +SKIP
-    &gt;&gt;&gt; model.apply(X).shape                            # doctest: +SKIP
-    (100, 2)
+    &gt;&gt;&gt; import dtreeviz                                       # doctest: +SKIP
+    &gt;&gt;&gt; from imodels import FIGSClassifier, shadow_tree       # doctest: +SKIP
+    &gt;&gt;&gt; model = FIGSClassifier(max_rules=5).fit(X, y)         # doctest: +SKIP
+    &gt;&gt;&gt; viz = dtreeviz.trees.DTreeVizAPI(                     # doctest: +SKIP
+    ...     shadow_tree(model, X, y, tree_num=0))
+    &gt;&gt;&gt; viz.view()                                            # doctest: +SKIP
     &#34;&#34;&#34;
+    try:
+        from dtreeviz.models.sklearn_decision_trees import ShadowSKDTree
+    except ImportError as error:  # pragma: no cover - depends on the environment
+        raise ImportError(
+            &#34;dtreeviz is needed to plot imodels trees but is not installed &#34;
+            &#34;(&#39;pip install dtreeviz&#39;). It is not a dependency of imodels.&#34;
+        ) from error
+
     trees = sklearn_trees(model)
     if trees is None:
         raise ValueError(
-            f&#34;Don&#39;t know how to get leaf membership for {type(model).__name__}. &#34;
-            &#34;apply is defined for tree-based models; if the model is not fitted &#34;
-            &#34;yet, fit it first.&#34;
+            f&#34;Don&#39;t know how to draw {type(model).__name__}. dtreeviz support &#34;
+            &#34;covers tree-based models; if the model is not fitted yet, fit it first.&#34;
+        )
+    if not 0 &lt;= tree_num &lt; len(trees):
+        raise ValueError(
+            f&#34;tree_num must be in [0, {len(trees)}) for this model, got {tree_num}.&#34;
         )
 
-    # missing values are left to the tree, which handles them for sklearn trees;
-    # fit and predict accept them, so apply must too
-    X = check_array(X, **_finite_check_kwarg(allow_nan=True))
-    leaves = np.column_stack([tree.apply(X) for tree in trees])
-    return leaves[:, 0] if len(trees) == 1 else leaves</code></pre>
+    X = np.asarray(X)
+    if feature_names is None:
+        feature_names = _feature_names(model, X.shape[1])
+    if class_names is None:
+        class_names = _class_names(model)
+
+    return ShadowSKDTree(trees[tree_num], X, np.asarray(y),
+                         list(feature_names), target_name, class_names)</code></pre>
 </details>
 </dd>
 </dl>
@@ -186,7 +260,7 @@ shape <code>(n_samples, n_trees)</code>, matching <code>RandomForest.apply</code
 </li>
 <li><h3><a href="#header-functions">Functions</a></h3>
 <ul class="">
-<li><code><a title="imodels.util.apply.apply_leaves" href="#imodels.util.apply.apply_leaves">apply_leaves</a></code></li>
+<li><code><a title="imodels.util.tree_viz.shadow_tree" href="#imodels.util.tree_viz.shadow_tree">shadow_tree</a></code></li>
 </ul>
 </li>
 </ul>

--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,7 @@ Install with `pip install imodels` (see [here](https://github.com/csinva/imodels
 
 ## Demo notebooks
 
-Demos are contained in the [notebooks](notebooks) folder.
+Demos are contained in the [notebooks](notebooks) folder. (The standalone Colab notebook has been retired; please refer to the demos below, which are kept up to date with the package.)
 
 <details>
 <summary><a href="https://github.com/csinva/imodels/blob/master/notebooks/imodels_demo.ipynb">Quickstart demo</a></summary>
@@ -104,11 +104,6 @@ Shows how to fit, predict, and visualize with different interpretable models
 <details>
 <summary><a href="https://auto.gluon.ai/dev/tutorials/tabular_prediction/tabular-interpretability.html">Autogluon demo</a></summary>
 Fit/select an interpretable model automatically using Autogluon AutoML
-</details>
-
-<details>
-<summary><a href="https://colab.research.google.com/drive/1WfqvSjegygT7p0gyqiWpRpiwz2ePtiao#scrollTo=bLnLknIuoWtQ">Quickstart colab demo</a> <a href="https://colab.research.google.com/drive/1WfqvSjegygT7p0gyqiWpRpiwz2ePtiao#scrollTo=bLnLknIuoWtQ"> <img src="https://colab.research.google.com/assets/colab-badge.svg"></a></summary>
-Shows how to fit, predict, and visualize with different interpretable models
 </details>
 
 <details>


### PR DESCRIPTION
Fixes #197

## What

The issue reports that the linked Colab notebook "required a lot of updations". Rather than refresh a standalone copy that will drift again, this removes the link and points readers at the demos in the repo, which live alongside the code:

> Demos are contained in the [notebooks](notebooks) folder. (The standalone Colab notebook has been retired; please refer to the demos below, which are kept up to date with the package.)

The Colab entry and its badge are gone from the demo list; the quickstart, autogluon, clinical-decision-rule and posthoc demos remain.

## Heads-up on the diff size

`docs/index.html` embeds the readme, so it still showed the link until the docs were rebuilt. Running the normal `build_docs.sh` flow does that — but it also picked up **source changes that had accumulated since the last docs build**, so 31 generated pages change and 3 modules get pages they never had (`fast_frugal_tree`, `model_trees`, `tree_viz`).

Those extra updates are legitimate (the checked-in docs were stale relative to the code), but they're not what this PR is about. Happy to split them out and land only the readme if you'd rather keep this minimal — the readme is the source of truth either way.

## Verification
- [x] No `colab.research.google.com` links remain anywhere in the repo; the only remaining mention of the word is the sentence explaining the retirement
- [x] `pytest tests` — 777 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf