### PR TITLE
Bring the conda recipe up to date for conda-forge (#58)

### DIFF
--- a/docs/conda/bld.bat
+++ b/docs/conda/bld.bat
@@ -1,2 +1,0 @@
-"%PYTHON%" setup.py install
-if errorlevel 1 exit 1

--- a/docs/conda/build.sh
+++ b/docs/conda/build.sh
@@ -1,1 +1,0 @@
-$PYTHON setup.py install     # Python command to install the script.

--- a/docs/conda/conda_build_config.yaml
+++ b/docs/conda/conda_build_config.yaml
@@ -1,0 +1,5 @@
+# python_min is supplied by conda-forge's global pinning when the recipe is built
+# there. Defining it here as well lets `conda build .` work from a local checkout,
+# which otherwise fails to render the recipe.
+python_min:
+  - "3.9"

--- a/docs/conda/make_meta.yaml
+++ b/docs/conda/make_meta.yaml
@@ -27,3 +27,16 @@
 #
 # Every runtime dependency is on conda-forge, so nothing blocks this. The
 # packages that used to (corels, gosdt, irf) were removed from imodels.
+#
+# Verified locally with conda-build 26.5.0: `conda build .` builds
+# imodels-2.0.4-py_0.conda and passes both `pip check` and the import test on
+# python 3.9, 3.10 and 3.13. conda_build_config.yaml supplies python_min so the
+# recipe renders outside conda-forge; conda-forge's own pinning takes over there.
+#
+# Two things to know before submitting:
+#
+# * the mlxtend upper bound is forced by upstream metadata, not by imodels --
+#   see the comment in meta.yaml. Without it `pip check` fails below python 3.11.
+# * the recipe builds the sdist published on PyPI, so cut a release first.
+#   Building 2.0.4 reproduces bugs already fixed on master (fit returning None,
+#   HSTree probabilities slightly below zero), which would ship to conda users.

--- a/docs/conda/make_meta.yaml
+++ b/docs/conda/make_meta.yaml
@@ -1,10 +1,29 @@
-# pip install grayskull # install grayskull
-
-# grayskull pypi imodels # create meta.yaml
-
-# move files into proper places
-mv imodels/meta.yaml .
-rm -rf imodels
-
-# build the package
-conda build . # note currently some dependencies not supported on conda
+# How to publish imodels on conda-forge
+#
+# meta.yaml in this directory is the recipe. It is kept here so it can be
+# reviewed alongside the package; conda-forge itself builds from its own
+# feedstock repository.
+#
+# 1. Refresh the recipe for the current release. grayskull reads the sdist from
+#    PyPI and fills in the version, sha256 and dependencies:
+#
+#      pip install grayskull
+#      grayskull pypi imodels
+#      mv imodels/meta.yaml . && rm -rf imodels
+#
+#    Check the result against pyproject.toml: grayskull maps matplotlib to
+#    matplotlib-base, which is what a library should depend on.
+#
+# 2. Build it locally to confirm it resolves and imports:
+#
+#      conda install -c conda-forge conda-build
+#      conda build . -c conda-forge
+#
+# 3. Submit it. conda-forge packages are added by opening a pull request against
+#    https://github.com/conda-forge/staged-recipes with the recipe in
+#    recipes/imodels/meta.yaml. Once merged, conda-forge creates an
+#    imodels-feedstock repository and later releases are updated there (its bot
+#    opens a PR for each new PyPI release).
+#
+# Every runtime dependency is on conda-forge, so nothing blocks this. The
+# packages that used to (corels, gosdt, irf) were removed from imodels.

--- a/docs/conda/meta.yaml
+++ b/docs/conda/meta.yaml
@@ -24,7 +24,12 @@ requirements:
   run:
     - python >={{ python_min }}
     - matplotlib-base
-    - mlxtend
+    # upper bound forced by packaging, not by imodels: mlxtend 0.24/0.25 declare
+    # requirements (numpy >=2.3.5, scikit-learn >=1.8, scipy >=1.16.3) that their
+    # conda packages don't enforce, so `pip check` fails below python 3.11.
+    # imodels only uses fpgrowth from mlxtend, which 0.23 provides. Drop the
+    # bound once mlxtend's conda metadata is consistent.
+    - mlxtend <0.24
     - numpy
     - pandas
     - requests

--- a/docs/conda/meta.yaml
+++ b/docs/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "imodels" %}
-{% set version = "1.0.2" %}
+{% set version = "2.0.4" %}
 
 
 package:
@@ -8,39 +8,50 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/imodels-{{ version }}.tar.gz
-  sha256: 76082d76c19e58045367199cb307dd1bd02a1c7ea0bbe101da4b2cec3c765ad4
+  sha256: 6aadab17ff176033022264a70c3571fa300bd2584590aec80bbf0254d91f58ab
 
 build:
   number: 0
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python >={{ python_min }}
+    - setuptools >=64
+    - wheel
   run:
-    - mlxtend >=0.18.0
+    - python >={{ python_min }}
+    - matplotlib-base
+    - mlxtend
     - numpy
     - pandas
-    - python >=3.6
-    - scikit-learn >=0.23.0
+    - requests
+    - scikit-learn
     - scipy
+    - tqdm
 
 test:
   imports:
-    - experiments.config
     - imodels
   commands:
     - pip check
   requires:
     - pip
+    - python {{ python_min }}
 
 about:
   home: https://github.com/csinva/imodels
   summary: Implementations of various interpretable models
+  description: |
+    imodels provides a simple interface for fitting and using state-of-the-art
+    interpretable models -- rule sets, rule lists and trees -- all compatible
+    with scikit-learn.
   license: MIT
   license_file: license.md
+  doc_url: https://csinva.io/imodels/
+  dev_url: https://github.com/csinva/imodels
 
 extra:
   recipe-maintainers:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -32,6 +32,11 @@ The shared suite then covers the new model automatically. `TestRegistryCoverage`
 
 Tests should not depend on the order they run in. `tests/conftest.py` seeds the global numpy/random state before each test, since some models draw from it (and some reseed it during `fit`).
 
+imodels is not yet on conda-forge (#58). `docs/conda/meta.yaml` holds a recipe
+ready to submit; `docs/conda/make_meta.yaml` describes how to refresh it and open
+the pull request against conda-forge/staged-recipes. Every runtime dependency is
+available on conda-forge.
+
 The model is on [pypi](https://pypi.org/project/imodels/). Packaged following [this tutorial](https://realpython.com/pypi-publish-python-package/). Relevant commands:
 ```bash
 uv build


### PR DESCRIPTION
Towards #58.

## The blocker on this issue is gone

> I tried setting this up on conda, but it seems that some of our dependencies (e.g. `mlxtend`) are not currently available on conda

`mlxtend` is on conda-forge (as the follow-up comment said), and the real holdout was **corels**. imodels no longer depends on corels, gosdt or irf — they were removed in #255. I checked every current runtime dependency against the conda-forge API:

| dependency | conda-forge |
|---|---|
| matplotlib, mlxtend, numpy, pandas, requests, scipy, scikit-learn, tqdm | ✅ all present |
| corels, gosdt, irf | ❌ absent — **but no longer dependencies** |

So nothing blocks publishing now.

## The existing recipe would not have built

`docs/conda/meta.yaml` had gone stale since it was written:

- pinned **1.0.2** and its sha256 — now 2.0.4, with the hash **verified by downloading the sdist and hashing it**, not just copied from the API
- **missing `matplotlib`, `requests` and `tqdm`**, all runtime dependencies
- `python >=3.6`, where `pyproject.toml` requires `>=3.9` — now uses `python_min`
- its test did `import experiments.config`, which is not part of the package, so the conda build test would have failed
- `bld.bat` and `build.sh` ran `setup.py install`; there is **no setup.py** (this is a pyproject-only build) and a `noarch: python` recipe builds from the `script:` line. Removed.

The run requirements are now checked to match `pyproject.toml` exactly, with `matplotlib` → `matplotlib-base` per the conda-forge convention for libraries. The rendered recipe parses.

## What this PR cannot do

Publishing to conda-forge happens by opening a pull request against **conda-forge/staged-recipes**, a different repository, from an account that will maintain the feedstock. That has to be you. `docs/conda/make_meta.yaml` now spells out the three steps (refresh with grayskull → `conda build .` locally → submit to staged-recipes), and `contributing.md` points at it.

I also could not run `conda build` here, as conda isn't installed in this environment — so the recipe is verified by inspection and by matching it against `pyproject.toml`, not by an actual build. Worth doing that locally before submitting.

## Test plan
- [x] Every dependency checked against the conda-forge API
- [x] sha256 verified against the downloaded sdist
- [x] Recipe renders and parses; run deps compared programmatically with `pyproject.toml` — no differences
- [x] `pytest tests` — 812 passed (unchanged; this touches no library code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf