### PR TITLE
Fit a trivial FIGS model when there is nothing to split on

### DIFF
--- a/imodels/tree/figs.py
+++ b/imodels/tree/figs.py
@@ -423,8 +423,19 @@ class FIGS(BaseEstimator):
             # get node with max impurity_reduction (since it's sorted)
             split_node = potential_splits.pop()
 
-            # don't split on node
-            if split_node.impurity_reduction < self.min_impurity_decrease:
+            # don't split on node.
+            # impurity_reduction is None when the stump found no valid split,
+            # which happens when y is constant over the node -- there is nothing
+            # left to fit, so stop rather than compare None to a float
+            if (split_node.impurity_reduction is None
+                    or split_node.impurity_reduction < self.min_impurity_decrease):
+                # nothing worth splitting on. If that happened before any tree
+                # was grown, keep this node as a single leaf: predictions are a
+                # sum over trees, so with none at all the model would return 0
+                # whatever y is, rather than y's mean.
+                if split_node.is_root and not self.trees_:
+                    split_node.setattrs(tree_num=0, left=None, right=None)
+                    self.trees_.append(split_node)
                 finished = True
                 break
             elif (

--- a/tests/figs_test.py
+++ b/tests/figs_test.py
@@ -330,3 +330,33 @@ def test_n_jobs_gives_identical_models():
     # it round-trips as an ordinary parameter
     assert FIGSRegressor(n_jobs=4).get_params()['n_jobs'] == 4
     assert FIGSRegressor().get_params()['n_jobs'] is None
+
+
+def test_constant_target():
+    """FIGS should fit a trivial model when there is nothing to split on
+
+    It used to raise TypeError comparing None to a float, because a stump that
+    finds no split reports impurity_reduction=None. Once that was handled, a
+    model with no trees predicted 0 whatever y was, since predictions are a sum
+    over trees.
+    """
+    from imodels import FIGSClassifier, FIGSRegressor
+
+    X = np.random.RandomState(0).randn(50, 3)
+
+    # a constant target is predicted exactly, not as 0
+    for constant in (3.7, 0.0, -2.5, 100.0):
+        model = FIGSRegressor(max_rules=5).fit(X, np.full(50, constant))
+        assert np.allclose(model.predict(X), constant), constant
+
+    # a single-class target predicts that class
+    for label in (0, 1):
+        model = FIGSClassifier(max_rules=5).fit(X, np.full(50, label, dtype=int))
+        assert set(np.unique(model.predict(X))) == {label}
+        assert model.predict_proba(X).shape[0] == 50
+
+    # ordinary data is unaffected
+    y = X[:, 0] + 0.01 * np.random.RandomState(1).randn(50)
+    fitted = FIGSRegressor(max_rules=6).fit(X, y)
+    assert len(fitted.trees_) >= 1
+    assert 1 - np.var(y - fitted.predict(X)) / np.var(y) > 0.9


### PR DESCRIPTION
Found while auditing the package for bugs.

## Two bugs, one behind the other

**1. FIGS crashes on a constant target.**

```python
FIGSClassifier().fit(X, np.zeros(len(X)))
TypeError: '<' not supported between instances of 'NoneType' and 'float'
```

A stump that finds no split reports `impurity_reduction=None`, and the greedy loop compares that against `min_impurity_decrease`. The loop already filters `None` for later candidates — just not for the first one, so a target that is constant at the root goes straight into the comparison.

This isn't only a degenerate-input concern: a cross-validation fold that happens to contain one class is enough to crash a fit, which is how `FIGSClassifierCV` failed too.

**2. Fixing that exposed a worse one.** With no trees grown, predictions are a sum over an empty set, so:

```python
FIGSRegressor().fit(X, np.full(len(X), -2.5)).predict(X)   # -> 0.0, not -2.5
```

A wrong answer, silently. It happened to look right for `y = 0`.

The root node is now kept as a single leaf, so the trivial model predicts the mean — what CART does in the same situation.

## Verification

| constant y | before | after |
|---|---|---|
| 3.7 | 3.7 (1 tree, by luck) | 3.7 |
| 0.0 | 0.0 (0 trees, right by accident) | 0.0 |
| −2.5 | **0.0** ❌ | −2.5 |
| 100.0 | **0.0** ❌ | 100.0 |

Single-class classification now fits and predicts that class, matching the 10 other imodels classifiers that already handled this. Ordinary data is unchanged (R² 0.979 on the same check).

## Test plan
- [x] `test_constant_target` — four constants predicted exactly, both single-class labels, and ordinary data still fitting normally
- [x] `pytest tests` — 835 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf