### PR TITLE
Warn when SLIM's integer rounding removes most of the model

### DIFF
--- a/imodels/algebraic/slim.py
+++ b/imodels/algebraic/slim.py
@@ -17,6 +17,27 @@ from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
 from imodels.util.arguments import set_feature_names_in
 
+def _warn_if_rounding_collapsed(coef, rounded):
+    """Warn when rounding to integers has destroyed the fitted model.
+
+    SLIM's coefficients are integers, so a feature whose natural coefficient is
+    much smaller than 1 rounds to zero. On data whose columns are on very
+    different scales that silently removes most of the model: on breast_cancer,
+    raw features give a below-chance classifier while standardized ones reach
+    0.99 AUC.
+    """
+    nonzero_before = int(np.count_nonzero(coef))
+    nonzero_after = int(np.count_nonzero(rounded))
+    if nonzero_before and nonzero_after * 2 < nonzero_before:
+        warnings.warn(
+            f"Rounding coefficients to integers left {nonzero_after} of "
+            f"{nonzero_before} nonzero, so most of the fitted model was lost. "
+            "SLIM uses integer coefficients, so features on very different "
+            "scales collapse when rounded; scale X first (for example with "
+            "sklearn.preprocessing.StandardScaler)."
+        )
+
+
 class SLIMRegressor(RegressorMixin, BaseEstimator):
     '''Sparse integer linear model
     Params
@@ -81,7 +102,9 @@ class SLIMRegressor(RegressorMixin, BaseEstimator):
     def _fit_backup(self, X, y, sample_weight):
         m = Lasso(alpha=self.alpha)
         m.fit(X, y, sample_weight=sample_weight)
-        self.model_.coef_ = np.round(m.coef_).astype(int)
+        rounded = np.round(m.coef_).astype(int)
+        _warn_if_rounding_collapsed(m.coef_, rounded)
+        self.model_.coef_ = rounded
         self.model_.intercept_ = m.intercept_
 
     def predict(self, X):
@@ -162,7 +185,9 @@ class SLIMClassifier(ClassifierMixin, BaseEstimator):
     def _fit_backup(self, X, y, sample_weight=None):
         m = LogisticRegression(C=1 / self.alpha)
         m.fit(X, y, sample_weight=sample_weight)
-        self.model_.coef_ = np.round(m.coef_).astype(int)
+        rounded = np.round(m.coef_).astype(int)
+        _warn_if_rounding_collapsed(m.coef_, rounded)
+        self.model_.coef_ = rounded
         self.model_.intercept_ = m.intercept_
 
     def predict(self, X):

--- a/readme.md
+++ b/readme.md
@@ -180,6 +180,11 @@ All of these models follow the standard sklearn estimator API, which is checked 
 | AutoML model | [AutoInterpretableClassifier️](https://csinva.io/imodels/util/automl.html)  | [AutoInterpretableRegressor️](https://csinva.io/imodels/util/automl.html) | |
 
 
+**Feature scaling.** Most models here work on raw features. `SLIMClassifier` and
+`SLIMRegressor` are the exception: their coefficients are integers, so features
+on very different scales collapse to zero when rounded. Standardize X before
+fitting them (they warn if rounding has removed most of the model).
+
 **Multiclass.** These classifiers handle more than two classes: `FIGSClassifier`,
 `GreedyTreeClassifier`, `HSTreeClassifier`, `TaoTreeClassifier`,
 `BoostedRulesClassifier`, `SLIMClassifier`, `C45TreeClassifier`,

--- a/tests/slim_test.py
+++ b/tests/slim_test.py
@@ -1,0 +1,57 @@
+"""Tests for SLIM's integer coefficients."""
+
+import warnings
+
+import numpy as np
+import pytest
+from sklearn.datasets import load_breast_cancer
+from sklearn.metrics import roc_auc_score
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+
+from imodels import SLIMClassifier, SLIMRegressor
+
+
+def test_warns_when_rounding_destroys_the_model():
+    """Integer coefficients collapse on unscaled data, and should say so
+
+    On breast_cancer the feature scales span five orders of magnitude, so
+    rounding the fitted coefficients to integers zeroes most of them and the
+    classifier scores below chance. Nothing said why.
+    """
+    X, y = load_breast_cancer(return_X_y=True)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        raw = SLIMClassifier().fit(X_train, y_train)
+    messages = [str(w.message) for w in caught]
+    assert any('Rounding coefficients to integers' in m for m in messages), messages
+    assert any('scale X first' in m or 'StandardScaler' in m for m in messages)
+
+    # scaling is what the warning recommends, and it works
+    scaler = StandardScaler().fit(X_train)
+    with warnings.catch_warnings(record=True) as caught_scaled:
+        warnings.simplefilter('always')
+        scaled = SLIMClassifier().fit(scaler.transform(X_train), y_train)
+    assert not any('Rounding coefficients to integers' in str(w.message)
+                   for w in caught_scaled), 'should not warn once scaled'
+
+    raw_auc = roc_auc_score(y_test, raw.predict_proba(X_test)[:, 1])
+    scaled_auc = roc_auc_score(
+        y_test, scaled.predict_proba(scaler.transform(X_test))[:, 1])
+    assert scaled_auc > 0.9 and scaled_auc > raw_auc
+
+
+def test_no_warning_when_coefficients_survive():
+    """Data already on a sensible scale fits without complaint"""
+    rng = np.random.RandomState(0)
+    X = rng.randn(200, 4)
+    y = 3 * X[:, 0] - 2 * X[:, 1] + 0.1 * rng.randn(200)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        model = SLIMRegressor().fit(X, y)
+    assert not any('Rounding coefficients to integers' in str(w.message)
+                   for w in caught)
+    assert np.count_nonzero(model.model_.coef_) > 0


### PR DESCRIPTION
Found while auditing the package for bugs.

## Problem

I benchmarked every model on `breast_cancer`. Everything scored 0.85–0.99 AUC except:

```
SLIMClassifier    0.483   <-- below chance
```

SLIM's coefficients are integers, so a feature whose natural coefficient is much smaller than 1 rounds to zero. `breast_cancer`'s feature standard deviations span **0.0026 to 568.9** — five orders of magnitude — so rounding deletes most of the model:

| features | AUC | nonzero coefficients |
|---|---|---|
| raw | **0.483** | 5 of 30 |
| standardized | **0.992** | 16 |

Nothing indicated why. The existing warning only covers a missing cvxpy — and installing cvxpy doesn't help, because the mixed-integer solvers it wants (gurobi, mosek, cplex) are commercial, so most users get the rounding path regardless.

## Fix

Both SLIM fits now warn when rounding leaves fewer than half the nonzero coefficients:

> `Rounding coefficients to integers left 5 of 30 nonzero, so most of the fitted model was lost. SLIM uses integer coefficients, so features on very different scales collapse when rounded; scale X first (for example with sklearn.preprocessing.StandardScaler).`

It stays silent once the data is scaled, and on data already on a sensible scale.

I chose a warning over standardizing internally on purpose: SLIM's value is integer coefficients a person can apply by hand, and rescaling behind the caller's back would make those coefficients refer to units they never see.

The readme now notes that SLIM is the exception to imodels working on raw features.

## Test plan
- [x] `tests/slim_test.py` — warns on raw `breast_cancer` and names scaling as the fix; silent once scaled; scaled AUC > 0.9 and beats raw; no warning on well-scaled synthetic data
- [x] `pytest tests` — 836 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf