### PR TITLE
Reject reordered feature columns at predict time

### DIFF
--- a/imodels/algebraic/marginal_shrinkage_linear_model.py
+++ b/imodels/algebraic/marginal_shrinkage_linear_model.py
@@ -6,7 +6,7 @@ from sklearn.linear_model import LinearRegression, RidgeCV, Ridge, ElasticNet, E
 from sklearn.tree import DecisionTreeRegressor
 from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_X_y, check_array, _check_sample_weight
-from imodels.util.arguments import set_feature_names_in
+from imodels.util.arguments import check_predict_X, set_feature_names_in
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score, roc_auc_score
 from tqdm import tqdm
@@ -185,10 +185,12 @@ class MarginalShrinkageLinearModel(BaseEstimator):
             )
 
     def predict_proba(self, X):
+        check_predict_X(self, X)
         X = self.scalar_X_.transform(X)
         return self.est_main_.predict_proba(X)
 
     def predict(self, X):
+        check_predict_X(self, X)
         X = self.scalar_X_.transform(X)
         pred = self.est_main_.predict(X)
         return self.scalar_y_.inverse_transform(pred.reshape(-1, 1)).squeeze()

--- a/imodels/algebraic/slim.py
+++ b/imodels/algebraic/slim.py
@@ -15,7 +15,7 @@ from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.linear_model import LinearRegression, Lasso, LogisticRegression
 from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
-from imodels.util.arguments import set_feature_names_in
+from imodels.util.arguments import check_predict_X, set_feature_names_in
 
 class SLIMRegressor(RegressorMixin, BaseEstimator):
     '''Sparse integer linear model
@@ -86,11 +86,8 @@ class SLIMRegressor(RegressorMixin, BaseEstimator):
 
     def predict(self, X):
         check_is_fitted(self)
+        check_predict_X(self, X)
         X = check_array(X)
-        # ensure input feature count matches training
-        if hasattr(self, 'n_features_in_') and X.shape[1] != self.n_features_in_:
-            raise ValueError("X has %d features, but %s is expecting %d features as input" %
-                             (X.shape[1], self.__class__.__name__, self.n_features_in_))
         return self.model_.predict(X)
 
 
@@ -167,18 +164,12 @@ class SLIMClassifier(ClassifierMixin, BaseEstimator):
 
     def predict(self, X):
         check_is_fitted(self)
+        check_predict_X(self, X)
         X = check_array(X)
-        # ensure input feature count matches training
-        if hasattr(self, 'n_features_in_') and X.shape[1] != self.n_features_in_:
-            raise ValueError("X has %d features, but %s is expecting %d features as input" %
-                             (X.shape[1], self.__class__.__name__, self.n_features_in_))
         return self.model_.predict(X)
 
     def predict_proba(self, X):
         check_is_fitted(self)
+        check_predict_X(self, X)
         X = check_array(X)
-        # ensure input feature count matches training
-        if hasattr(self, 'n_features_in_') and X.shape[1] != self.n_features_in_:
-            raise ValueError("X has %d features, but %s is expecting %d features as input" %
-                             (X.shape[1], self.__class__.__name__, self.n_features_in_))
         return self.model_.predict_proba(X)

--- a/imodels/algebraic/tree_gam.py
+++ b/imodels/algebraic/tree_gam.py
@@ -17,7 +17,7 @@ from tqdm import tqdm
 import imodels
 
 from sklearn.base import RegressorMixin, ClassifierMixin
-from imodels.util.arguments import (check_binary_target, decode_labels,
+from imodels.util.arguments import (check_binary_target, check_predict_X, decode_labels,
                                     set_feature_names_in)
 
 
@@ -317,6 +317,7 @@ class TreeGAM(BaseEstimator):
         marginal_only: bool
             If True, only use the marginal effects.
         """
+        check_predict_X(self, X)
         X = check_array(X, accept_sparse=False, dtype=None)
         check_is_fitted(self)
         probs1 = np.ones(X.shape[0]) * self.bias_

--- a/imodels/rule_list/bayesian_rule_list/bayesian_rule_list.py
+++ b/imodels/rule_list/bayesian_rule_list/bayesian_rule_list.py
@@ -12,7 +12,8 @@ from imodels.rule_list.bayesian_rule_list.brl_util import (
 from imodels.rule_list.rule_list import RuleList
 from imodels.util.convert import itemsets_to_rules
 from imodels.util.extract import extract_fpgrowth
-from imodels.util.arguments import decode_labels, set_feature_names_in
+from imodels.util.arguments import (check_predict_X, decode_labels,
+                                    set_feature_names_in)
 from imodels.util.rule import get_feature_dict, replace_feature_name, Rule
 
 
@@ -282,6 +283,7 @@ class BayesianRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
             order, as they appear in the attribute `classes_`.
         """
         check_is_fitted(self)
+        check_predict_X(self, X)
         X = check_array(X)
 
         D = pd.DataFrame(X, columns=self.feature_placeholders)
@@ -309,6 +311,7 @@ class BayesianRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
             Class labels for samples in X.
         """
         check_is_fitted(self)
+        check_predict_X(self, X)
         X = check_array(X)
 
         return decode_labels(self, 1 * (self.predict_proba(X)[:, 1] >= threshold))

--- a/imodels/rule_list/fast_frugal_tree.py
+++ b/imodels/rule_list/fast_frugal_tree.py
@@ -131,7 +131,7 @@ class FastFrugalTreeClassifier(BaseEstimator, RuleList, ClassifierMixin):
 
     def predict_proba(self, X):
         check_is_fitted(self)
-        X = check_predict_X(self, check_array(X))
+        X = check_array(check_predict_X(self, X))
 
         probs = np.zeros(X.shape[0])
         undecided = np.ones(X.shape[0], dtype=bool)

--- a/imodels/rule_list/greedy_rule_list.py
+++ b/imodels/rule_list/greedy_rule_list.py
@@ -125,7 +125,7 @@ class GreedyRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
 
     def predict_proba(self, X):
         check_is_fitted(self)
-        X = check_predict_X(self, check_array(X))
+        X = check_array(check_predict_X(self, X))
         n = X.shape[0]
         probs = np.zeros(n)
         for i in range(n):
@@ -144,7 +144,7 @@ class GreedyRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
 
     def predict(self, X):
         check_is_fitted(self)
-        X = check_predict_X(self, check_array(X))
+        X = check_array(check_predict_X(self, X))
         return decode_labels(self, np.argmax(self.predict_proba(X), axis=1))
 
 

--- a/imodels/rule_set/rule_fit.py
+++ b/imodels/rule_set/rule_fit.py
@@ -19,7 +19,7 @@ from sklearn.utils.multiclass import unique_labels
 from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
 
 from imodels.rule_set.rule_set import RuleSet
-from imodels.util.arguments import check_fit_arguments
+from imodels.util.arguments import check_fit_arguments, check_predict_X
 from imodels.util.extract import extract_rulefit
 from imodels.util.rule import get_feature_dict, replace_feature_name, Rule
 from imodels.util.score import score_linear
@@ -157,6 +157,7 @@ class RuleFit(BaseEstimator, TransformerMixin, RuleSet):
         For classification, returns discrete output.
         '''
         check_is_fitted(self)
+        check_predict_X(self, X)
         if scipy.sparse.issparse(X):
             X = X.toarray()
         X = check_array(X)
@@ -168,6 +169,7 @@ class RuleFit(BaseEstimator, TransformerMixin, RuleSet):
 
     def predict_proba(self, X):
         check_is_fitted(self)
+        check_predict_X(self, X)
         if scipy.sparse.issparse(X):
             X = X.toarray()
         X = check_array(X)

--- a/imodels/rule_set/skope_rules.py
+++ b/imodels/rule_set/skope_rules.py
@@ -84,7 +84,8 @@ from sklearn.utils.multiclass import check_classification_targets, unique_labels
 from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
 
 from imodels.rule_set.rule_set import RuleSet
-from imodels.util.arguments import check_binary_target, check_fit_arguments, decode_labels
+from imodels.util.arguments import (check_binary_target, check_fit_arguments,
+                                    check_predict_X, decode_labels)
 from imodels.util.rule import replace_feature_name, get_feature_dict, Rule
 from imodels.util.extract import extract_skope
 from imodels.util.score import score_precision_recall
@@ -349,6 +350,7 @@ class SkopeRulesClassifier(BaseEstimator, RuleSet, ClassifierMixin):
             For each observations, tells whether or not (1 or 0) it should
             be considered as an outlier according to the selected rules.
         """
+        check_predict_X(self, X)
         X = check_array(X)
         return decode_labels(self, np.argmax(self.predict_proba(X), axis=1))
 
@@ -356,6 +358,7 @@ class SkopeRulesClassifier(BaseEstimator, RuleSet, ClassifierMixin):
         '''Predict probability of a particular sample being an outlier or not
 
         '''
+        check_predict_X(self, X)
         X = check_array(X)
         weight_sum = np.sum([w[0] for (r, w) in self.rules_without_feature_names_])
         if weight_sum == 0:

--- a/imodels/tree/c45_tree/c45_tree.py
+++ b/imodels/tree/c45_tree/c45_tree.py
@@ -228,7 +228,7 @@ class C45TreeClassifier(BaseEstimator, ClassifierMixin):
 
     def raw_preds(self, X):
         check_is_fitted(self, ['tree_', 'resultType', 'feature_names'])
-        X = check_predict_X(self, check_array(X))
+        X = check_array(check_predict_X(self, X))
         if isinstance(X, pd.DataFrame):
             X = deepcopy(X)
             X.columns = self.feature_names

--- a/imodels/tree/figs.py
+++ b/imodels/tree/figs.py
@@ -687,7 +687,7 @@ class FIGS(BaseEstimator):
         if hasattr(self, "_encoder"):
             X = self._encode_categories(
                 X, categorical_features=categorical_features, encoder_name="_encoder")
-        X = check_predict_X(self, check_array(X))
+        X = check_array(check_predict_X(self, X))
         preds = np.zeros((X.shape[0], self.n_outputs, len(self.trees_)))
         for i, tree in enumerate(self.trees_):
             preds[:, :, i] += self._predict_tree(tree, X)
@@ -727,7 +727,7 @@ class FIGS(BaseEstimator):
         if hasattr(self, "_encoder"):
             X = self._encode_categories(
                 X, categorical_features=categorical_features, encoder_name="_encoder")
-        X = check_predict_X(self, check_array(X))
+        X = check_array(check_predict_X(self, X))
         if isinstance(self, RegressorMixin):
             return NotImplemented
         preds = np.zeros((X.shape[0], self.n_outputs))

--- a/imodels/tree/hierarchical_shrinkage.py
+++ b/imodels/tree/hierarchical_shrinkage.py
@@ -16,7 +16,7 @@ from sklearn.ensemble import (
 from sklearn.utils.validation import check_is_fitted
 
 from imodels.util import checks
-from imodels.util.arguments import check_fit_arguments
+from imodels.util.arguments import check_fit_arguments, check_predict_X
 from imodels.util.tree import compute_tree_complexity
 
 
@@ -268,6 +268,7 @@ class HSTree(BaseEstimator):
                 self._shrink_tree(self._unwrap_tree(t), self.reg_param)
 
     def predict(self, X, *args, **kwargs):
+        check_predict_X(self, X)
         preds = self.estimator_.predict(X, *args, **kwargs)
         # fit encodes y as 0..n_classes-1, so map back onto the original labels.
         # When the estimator was fitted elsewhere and passed in already fitted,
@@ -278,6 +279,7 @@ class HSTree(BaseEstimator):
             return preds
 
     def predict_proba(self, X, *args, **kwargs):
+        check_predict_X(self, X)
         if hasattr(self.estimator_, "predict_proba"):
             probs = self.estimator_.predict_proba(X, *args, **kwargs)
             # the shrinkage arithmetic can leave values a hair outside [0, 1]

--- a/imodels/tree/tao.py
+++ b/imodels/tree/tao.py
@@ -12,7 +12,7 @@ from sklearn.model_selection import train_test_split
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor, export_text
 from sklearn.utils import check_X_y
 
-from imodels.util.arguments import check_fit_arguments
+from imodels.util.arguments import check_fit_arguments, check_predict_X
 
 
 class TaoTree(BaseEstimator):
@@ -389,6 +389,7 @@ class TaoTree(BaseEstimator):
         return self.model.feature_importances_
 
     def predict(self, X):
+        check_predict_X(self, X)
         preds = self.model.predict(X)
         if hasattr(self, "classes_"):
             return np.array([self.classes_[int(i)] for i in preds])
@@ -396,6 +397,7 @@ class TaoTree(BaseEstimator):
             return preds
 
     def predict_proba(self, X):
+        check_predict_X(self, X)
         return self.model.predict_proba(X)
 
     # def score(self, X, y):

--- a/imodels/util/arguments.py
+++ b/imodels/util/arguments.py
@@ -82,14 +82,35 @@ def check_predict_X(model, X):
 
     Models that index X by a stored feature number silently accept extra
     columns, returning predictions that look reasonable but ignore part of the
-    input. sklearn raises instead, and so should we.
+    input. They equally silently accept the right columns in the wrong order,
+    which quietly returns predictions for the wrong features. sklearn raises in
+    both cases, and so should we.
+
+    Pass X before converting it to an array, or the column names are gone by the
+    time this sees them.
     """
+    # read the shape off X directly: np.shape() would coerce X, and sklearn's
+    # estimator checks pass array-likes that must reach check_array untouched
+    shape = getattr(X, 'shape', None)
+    n_given = shape[1] if shape is not None and len(shape) == 2 else None
+
     n_features = getattr(model, 'n_features_in_', None)
-    if n_features is not None and np.shape(X)[1] != n_features:
+    if n_features is not None and n_given is not None and n_given != n_features:
         raise ValueError(
-            f"X has {np.shape(X)[1]} features, but "
+            f"X has {n_given} features, but "
             f"{type(model).__name__} is expecting {n_features} features as input."
         )
+
+    fitted_names = getattr(model, 'feature_names_in_', None)
+    if fitted_names is not None and hasattr(X, 'columns'):
+        given = np.asarray(X.columns, dtype=object)
+        if not np.array_equal(given, np.asarray(fitted_names, dtype=object)):
+            raise ValueError(
+                "The feature names should match those that were passed during "
+                f"fit.\nFeature names seen at fit time, in order:\n"
+                f"{list(fitted_names)}\nFeature names given, in order:\n"
+                f"{list(given)}"
+            )
     return X
 
 

--- a/tests/predict_feature_names_test.py
+++ b/tests/predict_feature_names_test.py
@@ -1,0 +1,66 @@
+"""Predicting with columns in a different order must not silently mislead.
+
+Models index X by feature position, so a DataFrame whose columns are in a
+different order than at fit produces predictions for the wrong features.
+sklearn raises in that case; so should imodels.
+"""
+
+import contextlib
+import io
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import imodels
+from tests.model_configs import (BINARY_INPUT_MODELS, EXCLUDED_MODELS,
+                                 MODEL_KWARGS)
+
+FEATURE_NAMES = ['a', 'b', 'c', 'd']
+MODELS = [m for m in imodels.ESTIMATORS if m.__name__ not in EXCLUDED_MODELS]
+IDS = [m.__name__ for m in MODELS]
+
+
+def _fit(model_type):
+    rng = np.random.RandomState(0)
+    X = pd.DataFrame(rng.randn(200, 4), columns=FEATURE_NAMES)
+    if model_type.__name__ in BINARY_INPUT_MODELS:
+        X = (X > 0).astype(int)
+    if model_type in imodels.CLASSIFIERS:
+        y = (X['a'] > 0).astype(int)
+    else:
+        y = X['a'] + 0.01 * rng.randn(200)
+    model = model_type(**MODEL_KWARGS.get(model_type.__name__, {}))
+    with contextlib.redirect_stdout(io.StringIO()):
+        model.fit(X, y)
+    return model, X
+
+
+@pytest.mark.parametrize('model_type', MODELS, ids=IDS)
+def test_reordered_columns_raise(model_type):
+    """Reordering the columns must raise, not quietly change the answer"""
+    model, X = _fit(model_type)
+    shuffled = X[FEATURE_NAMES[::-1]]
+
+    with pytest.raises(ValueError):
+        with contextlib.redirect_stdout(io.StringIO()):
+            model.predict(shuffled)
+
+
+@pytest.mark.parametrize('model_type', MODELS, ids=IDS)
+def test_matching_columns_and_arrays_still_work(model_type):
+    """The check must not disturb ordinary use"""
+    model, X = _fit(model_type)
+    with contextlib.redirect_stdout(io.StringIO()):
+        from_frame = np.asarray(model.predict(X), dtype=float)
+        from_array = np.asarray(model.predict(X.values), dtype=float)
+
+    assert from_frame.shape[0] == len(X)
+    # an unnamed array carries no column order to check, and must be unchanged
+    assert np.allclose(from_frame, from_array)
+
+
+def test_wrong_number_of_columns_raises():
+    model, X = _fit(imodels.FIGSClassifier)
+    with pytest.raises(ValueError, match='features'):
+        model.predict(X[['a', 'b']])


### PR DESCRIPTION
Found while auditing the package for bugs.

## Problem

Models index X by feature *position*. So handing `predict` a DataFrame whose columns are in a different order than at fit returns predictions computed from the wrong features — quietly:

```python
model.fit(X[['a', 'b', 'c', 'd']], y)
model.predict(X[['d', 'c', 'b', 'a']])   # different numbers, no error
```

sklearn raises `ValueError: The feature names should match those that were passed during fit`. **26 of the 35 registered models did not** — including FIGS, hierarchical shrinkage, RuleFit, SkopeRules, TreeGAM, C4.5 and BART. The 9 that did were the ones inheriting sklearn's own validation.

This is easy to hit: selecting columns in a different order, rebuilding a test frame, or joining data before scoring.

## Fix

`check_predict_X` now compares `feature_names_in_` against the columns it is given, using sklearn's wording, and the models that lacked the check call it.

The four that *already* called it were passing `check_array(X)` into it — which strips column names before they can be compared, so the check could never have seen them. Those calls now pass X first.

**After: all 35 raise.** Unnamed input carries no order to check and is unaffected — all 35 return identical predictions for the same data as a plain numpy array, which the tests assert.

## One subtlety

Routing `SLIMClassifier` through the shared helper broke sklearn's `check_estimator`:

```
TypeError: Don't want to call array_function shape!
```

sklearn's checks deliberately pass array-likes that must reach `check_array` untouched, and my helper called `np.shape(X)` on them. It now reads `X.shape` directly and skips the count check when there is no shape, leaving `check_array` to handle those inputs. Worth knowing before adding this call anywhere else.

## Test plan
- [x] New `tests/predict_feature_names_test.py`: every registered model raises on reordered columns, **and** still returns identical predictions for DataFrame vs plain-array input, plus the wrong-column-count case
- [x] `pytest tests` — 905 passed on pinned deps, 888 passed on latest (sklearn 1.9 / pandas 3.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf