### PR TITLE
Give the MDLP discretizers a working transformer API

### DIFF
--- a/imodels/discretization/mdlp.py
+++ b/imodels/discretization/mdlp.py
@@ -18,7 +18,7 @@ from imodels.util.metrics import entropy, cut_point_information_gain
 
 
 class MDLPDiscretizer(object):
-    def __init__(self, dataset, class_label, out_path_data=None, out_path_bins=None, features=None):
+    def __init__(self, dataset=None, class_label=None, out_path_data=None, out_path_bins=None, features=None):
         '''
         initializes discretizer object:
             saves raw copy of data and creates self._data with only features to discretize and class
@@ -32,12 +32,20 @@ class MDLPDiscretizer(object):
         Params
         ------
         dataset
-            pandas dataframe with data to discretize
+            pandas dataframe with data to discretize. If None, the cut points
+            are computed later by calling fit(X, y).
         class_label
             name of the column containing class in input dataframe
         features
             if !None, features that the user wants to discretize specifically
         '''
+        self._out_path_data = out_path_data
+        self._out_path_bins = out_path_bins
+        self._requested_features = features
+
+        if dataset is None:  # defer the work to fit
+            self._class_name = class_label
+            return
 
         if not isinstance(dataset, pd.core.frame.DataFrame):  # class needs a pandas dataframe
             raise AttributeError('input dataset should be a pandas data frame')
@@ -234,6 +242,61 @@ class MDLPDiscretizer(object):
             self._single_feature_accepted_cutpoints(feature=attr)
         return
 
+    def _bin_labels(self, attr):
+        '''Names of the bins a feature is cut into (a feature with no accepted
+        cut point stays in one catch-all bin).
+        '''
+        if len(self._cuts[attr]) == 0:
+            return ['All']
+        cuts = [-np.inf] + self._cuts[attr] + [np.inf]
+        return ['%s_to_%s' % (str(cuts[i]), str(cuts[i + 1]))
+                for i in range(len(cuts) - 1)]
+
+    def _bin_column(self, attr, column):
+        '''Applies this feature's cut points to any column of its values.'''
+        if len(self._cuts[attr]) == 0:
+            return 'All'
+        cuts = [-np.inf] + self._cuts[attr] + [np.inf]
+        return pd.cut(x=np.asarray(column), bins=cuts, right=False,
+                      labels=self._bin_labels(attr), precision=6,
+                      include_lowest=True)
+
+    def fit(self, X, y):
+        '''Learns cut points for the numeric columns of X, in the sklearn style.
+
+        Equivalent to constructing with a dataset, but lets the same fitted
+        discretizer be applied to new data with transform.
+        '''
+        X = pd.DataFrame(X).copy()
+        X.columns = [str(c) for c in X.columns]
+        class_label = self._class_name if self._class_name is not None else 'y'
+        while class_label in X.columns:  # don't collide with a real feature
+            class_label += '_'
+        X[class_label] = np.asarray(y)
+        MDLPDiscretizer.__init__(
+            self, dataset=X, class_label=class_label,
+            out_path_data=self._out_path_data,
+            out_path_bins=self._out_path_bins,
+            features=self._requested_features)
+        return self
+
+    def transform(self, X):
+        '''Bins X with the cut points found by fit. Columns that were not
+        discretized are passed through unchanged.
+        '''
+        if not hasattr(self, '_cuts'):
+            raise ValueError(
+                'This MDLPDiscretizer is not fitted yet. Call fit before transform.')
+        X = pd.DataFrame(X).copy()
+        X.columns = [str(c) for c in X.columns]
+        for attr in self._features:
+            if attr in X.columns:
+                X[attr] = self._bin_column(attr, X[attr])
+        return X
+
+    def fit_transform(self, X, y):
+        return self.fit(X, y).transform(X)
+
     def _apply_cutpoints(self, out_data_path=None, out_bins_path=None):
         '''
         Discretizes data by applying bins according to self._cuts. Saves a new, discretized file, and a description of
@@ -244,16 +307,9 @@ class MDLPDiscretizer(object):
         '''
         bin_label_collection = {}
         for attr in self._features:
-            if len(self._cuts[attr]) == 0:
-                self._data[attr] = 'All'
-                bin_label_collection[attr] = ['All']
-            else:
-                cuts = [-np.inf] + self._cuts[attr] + [np.inf]
-                start_bin_indices = range(0, len(cuts) - 1)
-                bin_labels = ['%s_to_%s' % (str(cuts[i]), str(cuts[i + 1])) for i in start_bin_indices]
-                bin_label_collection[attr] = bin_labels
-                self._data[attr] = pd.cut(x=self._data[attr].values, bins=cuts, right=False, labels=bin_labels,
-                                          precision=6, include_lowest=True)
+            bin_label_collection[attr] = self._bin_labels(attr)
+            self._data[attr] = self._bin_column(attr, self._data[attr])
+        self.bin_labels_ = bin_label_collection
 
         # reconstitute full data, now discretized
         if self._ignored_features:
@@ -286,6 +342,10 @@ class BRLDiscretizer:
         # check which features are numeric (to be discretized)
         self.discretized_features = []
 
+        # _encode_strings indexes positionally, so a DataFrame has to be
+        # unwrapped here the same way transform does
+        if isinstance(X, (pd.DataFrame, pd.Series)):
+            X = X.values
         X_str_disc = self._encode_strings(X)
 
         for fi in range(X_str_disc.shape[1]):
@@ -310,7 +370,11 @@ class BRLDiscretizer:
             self.discretized_X = X_str_and_num_disc
         else:
             self.discretizer = None
-            return
+        return self
+
+    def fit_transform(self, X, y, undiscretized_features=[], return_onehot=True):
+        return self.fit(X, y, undiscretized_features).transform(
+            X, return_onehot=return_onehot)
 
     def discretize(self, X, y):
         '''Discretize the features specified in self.discretized_features
@@ -320,7 +384,9 @@ class BRLDiscretizer:
         D = pd.DataFrame(np.hstack((X, np.expand_dims(y, axis=1))), columns=list(self.feature_labels) + ["y"])
         self.discretizer = MDLPDiscretizer(dataset=D, class_label="y", features=self.discretized_features)
 
-        cat_data = pd.DataFrame(np.zeros_like(X))
+        # object dtype: the columns are filled with bin-label strings, which
+        # pandas refuses to write into the float frame np.zeros_like would give
+        cat_data = pd.DataFrame(np.zeros(np.shape(X), dtype=object))
         for i in range(len(self.feature_labels)):
             label = self.feature_labels[i]
             if label in self.discretized_features:

--- a/tests/mdlp_discretizer_test.py
+++ b/tests/mdlp_discretizer_test.py
@@ -1,0 +1,113 @@
+"""Checks the two discretizers imodels exports from the MDLP module.
+
+Both are advertised in imodels.DISCRETIZERS alongside sklearn-style
+transformers, but neither could actually be used that way: MDLPDiscretizer had
+no fit/transform at all, and BRLDiscretizer's fit crashed on a DataFrame and
+returned None instead of self.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import imodels
+from imodels.discretization.mdlp import BRLDiscretizer, MDLPDiscretizer
+
+FEATURES = ['a', 'b', 'c']
+
+
+@pytest.fixture
+def data():
+    rng = np.random.RandomState(0)
+    X = pd.DataFrame(rng.randn(200, 3), columns=FEATURES)
+    y = (X['a'] > 0).astype(int)
+    return X, y
+
+
+def test_every_exported_discretizer_has_the_transformer_api():
+    """Anything in DISCRETIZERS should be usable as a transformer"""
+    for discretizer in imodels.DISCRETIZERS:
+        for method in ('fit', 'transform', 'fit_transform'):
+            assert hasattr(discretizer, method), \
+                f'{discretizer.__name__} has no {method}'
+
+
+class TestMDLPDiscretizer:
+
+    def test_fit_transform(self, data):
+        X, y = data
+        out = MDLPDiscretizer().fit(X, y).transform(X)
+        assert out.shape == X.shape
+        assert list(out.columns) == FEATURES
+        # the informative feature gets cut, so it is no longer numeric
+        assert out['a'].nunique() > 1
+        assert not np.issubdtype(np.asarray(out['a']).dtype, np.number)
+
+    def test_transform_reuses_the_fitted_bins(self, data):
+        """New data must be binned with the cut points found during fit"""
+        X, y = data
+        discretizer = MDLPDiscretizer().fit(X, y)
+        train_bins = set(map(str, discretizer.transform(X)['a']))
+        held_out = set(map(str, discretizer.transform(X.iloc[:20])['a']))
+        assert held_out <= train_bins
+
+    def test_fit_transform_matches_fit_then_transform(self, data):
+        X, y = data
+        assert MDLPDiscretizer().fit_transform(X, y).equals(
+            MDLPDiscretizer().fit(X, y).transform(X))
+
+    def test_accepts_numpy(self, data):
+        X, y = data
+        assert MDLPDiscretizer().fit(X.values, y).transform(X.values).shape \
+            == X.shape
+
+    def test_transform_before_fit_says_so(self, data):
+        X, _ = data
+        with pytest.raises(ValueError, match='not fitted'):
+            MDLPDiscretizer().transform(X)
+
+    def test_eager_construction_still_works(self, data):
+        """BRLDiscretizer builds one by passing the dataset to __init__"""
+        X, y = data
+        dataset = X.copy()
+        dataset['y'] = y.values
+        discretizer = MDLPDiscretizer(dataset=dataset, class_label='y',
+                                      features=FEATURES)
+        assert list(discretizer._data.columns) == FEATURES + ['y']
+        assert sorted(discretizer.bin_labels_) == FEATURES
+
+
+class TestBRLDiscretizer:
+
+    @pytest.mark.parametrize('as_numpy', [False, True], ids=['df', 'numpy'])
+    def test_fit_transform(self, data, as_numpy):
+        X, y = data
+        X_in = X.values if as_numpy else X
+        discretizer = BRLDiscretizer(feature_labels=FEATURES).fit(X_in, y)
+        assert isinstance(discretizer, BRLDiscretizer), 'fit must return self'
+        out = discretizer.transform(X_in)
+        assert out.shape[0] == len(X)
+
+    def test_dataframe_and_numpy_agree(self, data):
+        X, y = data
+        from_df = BRLDiscretizer(feature_labels=FEATURES).fit(X, y).transform(X)
+        from_np = BRLDiscretizer(
+            feature_labels=FEATURES).fit(X.values, y).transform(X.values)
+        assert list(from_df.columns) == list(from_np.columns)
+
+    def test_binary_data_passes_through(self, data):
+        """Nothing to discretize -- the columns should survive untouched"""
+        X, y = data
+        X_binary = (X > 0).astype(int)
+        out = BRLDiscretizer(feature_labels=FEATURES).fit(
+            X_binary, y).transform(X_binary)
+        assert list(out.columns) == FEATURES
+
+    def test_mixed_string_and_numeric(self, data):
+        X, y = data
+        X_mixed = X.copy()
+        X_mixed['c'] = np.where(X_mixed['c'] > 0, 'hi', 'lo')
+        out = BRLDiscretizer(feature_labels=FEATURES).fit(
+            X_mixed, y).transform(X_mixed)
+        assert out.shape[0] == len(X)
+        assert any('hi' in str(col) for col in out.columns)


### PR DESCRIPTION
Found while auditing the discretizers. Both classes `imodels` exports from `imodels/discretization/mdlp.py` appear in the public `imodels.DISCRETIZERS` list alongside `BasicDiscretizer` and `RFDiscretizer`, but neither could be used as a transformer.

### `MDLPDiscretizer` had no transformer methods at all

`hasattr(MDLPDiscretizer, 'fit')`, `'transform'`, and `'fit_transform'` were all `False` — its only public method was `MDLPC_criterion`. All the work happened in `__init__` against a fixed dataset, so there was no way to apply the learned cut points to new data.

It now supports the sklearn convention: `dataset` is optional, `fit(X, y)` computes the cuts, and `transform(X)` bins any data with them. Constructing it eagerly with a dataset behaves exactly as before — that is how `BRLDiscretizer` uses it, and a test pins that path.

### `BRLDiscretizer.fit` crashed, and returned `None`

Used as documented, with its own `feature_labels` signature:

```python
BRLDiscretizer(feature_labels=['a', 'b', 'c']).fit(X, y)   # KeyError: 0
```

`_encode_strings` indexes positionally (`X[0][fi]`, `X[:, fi]`), but only `transform` unwrapped a DataFrame first, so `X[0]` looked up a *column* named `0`. Passing numpy instead got past that and then failed on `transform`, because `fit` returned `None` from both branches rather than `self`. It also had no `fit_transform`.

### Also

`discretize` built its output with `np.zeros_like(X)` and then wrote bin-label strings into the resulting float frame — a `FutureWarning` today and an error in pandas 3.

### Tests

`tests/mdlp_discretizer_test.py` covers fit/transform for both classes, DataFrame and numpy input agreeing, bins from `fit` being reused on held-out data, the all-binary and mixed string/numeric paths, and a registry test asserting every entry in `imodels.DISCRETIZERS` has the transformer API — so a future addition can't drift the same way.

Full suite: 846 passed, 1 skipped, on both the pinned environment and latest sklearn 1.9 / pandas 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf