### PR TITLE
Honor sample_weight in rule scoring, and stop mutating the base estimator

### DIFF
--- a/imodels/rule_set/fpskope.py
+++ b/imodels/rule_set/fpskope.py
@@ -68,4 +68,5 @@ class FPSkopeClassifier(SkopeRulesClassifier):
                                       self.estimators_samples_,
                                       self.estimators_features_,
                                       self.feature_placeholders,
-                                      oob=False)
+                                      oob=False,
+                                      sample_weight=self.sample_weight)

--- a/imodels/rule_set/skope_rules.py
+++ b/imodels/rule_set/skope_rules.py
@@ -488,7 +488,8 @@ class SkopeRulesClassifier(BaseEstimator, RuleSet, ClassifierMixin):
                              verbose=self.verbose)
 
     def _score_rules(self, X, y, rules) -> List[Rule]:
-        return score_precision_recall(X, y, rules, self.estimators_samples_, self.estimators_features_, self.feature_placeholders)
+        return score_precision_recall(X, y, rules, self.estimators_samples_, self.estimators_features_,
+                                      self.feature_placeholders, sample_weight=self.sample_weight)
 
     def _prune_rules(self, rules) -> List[Rule]:
         return deduplicate(

--- a/imodels/tree/cart_ccp.py
+++ b/imodels/tree/cart_ccp.py
@@ -70,6 +70,9 @@ class DecisionTreeCCPClassifier(ClassifierMixin, BaseEstimator):
         # self.alpha = closest_alpha
 
     def fit(self, X, y, sample_weight=None, *args, **kwargs):
+        # fit a copy, so the estimator passed to __init__ is left untouched and
+        # two models sharing one estimator cannot interfere with each other
+        self.estimator_ = deepcopy(self.estimator_)
         params_for_fitting = self.estimator_.get_params()
         self._get_alpha(X, y, sample_weight, *args, **kwargs)
         params_for_fitting['ccp_alpha'] = self.alpha
@@ -175,6 +178,8 @@ class DecisionTreeCCPRegressor(BaseEstimator):
     #  self.alpha = closest_alpha
 
     def fit(self, X, y, sample_weight=None):
+        # fit a copy (see DecisionTreeCCPClassifier.fit)
+        self.estimator_ = deepcopy(self.estimator_)
         params_for_fitting = self.estimator_.get_params()
         self._get_alpha(X, y, sample_weight)
         params_for_fitting['ccp_alpha'] = self.alpha

--- a/imodels/tree/hierarchical_shrinkage.py
+++ b/imodels/tree/hierarchical_shrinkage.py
@@ -124,7 +124,10 @@ class HSTree(BaseEstimator):
             self, X, y, feature_names, allow_nan=True)
         if feature_names is not None:
             self.feature_names = feature_names
-        self.estimator_ = self.estimator_.fit(
+        # fit a copy: shrinkage rewrites the tree in place, so fitting the
+        # object handed to __init__ would shrink it out from under any other
+        # model built on the same estimator
+        self.estimator_ = deepcopy(self.estimator_).fit(
             X, y, *args, sample_weight=sample_weight, **kwargs
         )
         self._shrink()

--- a/imodels/util/score.py
+++ b/imodels/util/score.py
@@ -20,7 +20,8 @@ def score_precision_recall(X,
                            samples: List[List[int]],
                            features: List[List[int]],
                            feature_names: List[str],
-                           oob: bool = True) -> List[Rule]:
+                           oob: bool = True,
+                           sample_weight=None) -> List[Rule]:
 
     scored_rules = []
 
@@ -52,26 +53,37 @@ def score_precision_recall(X,
 
         y_oob = y[mask]
         y_oob = np.array((y_oob != 0))
+        # the weights have to follow the same samples the rules are scored on
+        w_oob = None if sample_weight is None else np.asarray(
+            sample_weight, dtype=float)[mask]
 
         # Add OOB performances to rules:
         scored_rules += [
-            Rule(r, args=_eval_rule_perf(r, X_oob, y_oob))
+            Rule(r, args=_eval_rule_perf(r, X_oob, y_oob, w_oob))
             for r in set(curr_rules)
         ]
 
     return scored_rules
 
 
-def _eval_rule_perf(rule: str, X, y) -> Tuple[float, float]:
+def _eval_rule_perf(rule: str, X, y, sample_weight=None) -> Tuple[float, float]:
     detected_index = list(X.query(rule).index)
     if len(detected_index) <= 1:
         return (0, 0)
     y_detected = y[detected_index]
-    true_pos = y_detected[y_detected > 0].sum()
+    # with uniform weights these are exactly the unweighted precision and
+    # recall, so passing no weights leaves rule selection unchanged
+    weights = np.ones(len(y)) if sample_weight is None else np.asarray(
+        sample_weight, dtype=float)
+    w_detected = weights[detected_index]
+    true_pos = float((w_detected * (y_detected > 0)).sum())
     if true_pos == 0:
         return (0, 0)
-    pos = y[y > 0].sum()
-    return y_detected.mean(), float(true_pos) / pos
+    pos = float((weights * (y > 0)).sum())
+    detected = float(w_detected.sum())
+    if detected == 0 or pos == 0:
+        return (0, 0)
+    return true_pos / detected, true_pos / pos
 
 
 def score_linear(X, y, rules: List[str],

--- a/tests/estimator_isolation_test.py
+++ b/tests/estimator_isolation_test.py
@@ -1,0 +1,96 @@
+"""Wrapper models must not modify the estimator they were handed.
+
+HSTree and DecisionTreeCCP take a base estimator and fit it in place. Because
+shrinkage and pruning rewrite the tree, two wrappers built on one estimator
+silently became the same model -- the second refit and reshrank the very tree
+the first was still pointing at.
+"""
+
+import numpy as np
+import pytest
+from sklearn.exceptions import NotFittedError
+from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
+from sklearn.utils.validation import check_is_fitted
+
+import imodels
+
+
+@pytest.fixture
+def data():
+    rng = np.random.RandomState(0)
+    X = rng.randn(200, 4)
+    y = (X[:, 0] > 0).astype(int)
+    return X, y
+
+
+def _base(regression=False):
+    tree = DecisionTreeRegressor if regression else DecisionTreeClassifier
+    return tree(max_leaf_nodes=8, random_state=0)
+
+
+WRAPPERS = [
+    ('HSTreeClassifier', {}),
+    ('HSTreeClassifierCV', {}),
+    ('DecisionTreeCCPClassifier', {'desired_complexity': 4}),
+]
+
+
+@pytest.mark.parametrize('name,kwargs', WRAPPERS, ids=[w[0] for w in WRAPPERS])
+def test_fit_leaves_the_given_estimator_unfitted(name, kwargs, data):
+    """sklearn estimators must not modify their __init__ arguments"""
+    X, y = data
+    base = _base()
+    getattr(imodels, name)(estimator_=base, **kwargs).fit(X, y)
+
+    with pytest.raises(NotFittedError):
+        check_is_fitted(base)
+
+
+def test_two_models_can_share_one_base_estimator(data):
+    """The consequence: sharing an estimator collapsed both models into one
+
+    Both wrappers ended up holding the same tree object, so the second fit
+    overwrote the first and reg_param stopped mattering entirely.
+    """
+    X, y = data
+    base = _base()
+
+    light = imodels.HSTreeClassifier(estimator_=base, reg_param=0.1).fit(X, y)
+    heavy = imodels.HSTreeClassifier(estimator_=base, reg_param=500.0).fit(X, y)
+
+    assert light.estimator_ is not heavy.estimator_
+    assert not np.allclose(light.predict_proba(X), heavy.predict_proba(X))
+
+
+def test_ccp_models_can_share_one_base_estimator(data):
+    X, y = data
+    base = _base()
+
+    coarse = imodels.DecisionTreeCCPClassifier(
+        estimator_=base, desired_complexity=2).fit(X, y)
+    fine = imodels.DecisionTreeCCPClassifier(
+        estimator_=base, desired_complexity=8).fit(X, y)
+
+    assert coarse.estimator_ is not fine.estimator_
+    assert coarse.estimator_.tree_.node_count <= fine.estimator_.tree_.node_count
+
+
+def test_regressor_wrappers_too(data):
+    X, y = data
+    y = y.astype(float)
+    base = _base(regression=True)
+    imodels.HSTreeRegressor(estimator_=base).fit(X, y)
+    imodels.DecisionTreeCCPRegressor(
+        estimator_=base, desired_complexity=4).fit(X, y)
+
+    with pytest.raises(NotFittedError):
+        check_is_fitted(base)
+
+
+def test_refitting_a_wrapper_still_works(data):
+    """Copying at fit time must not break an ordinary refit"""
+    X, y = data
+    model = imodels.HSTreeClassifier(estimator_=_base(), reg_param=1.0)
+    first = model.fit(X, y).predict_proba(X)
+    second = model.fit(X, y).predict_proba(X)
+    assert np.allclose(first, second)

--- a/tests/sample_weight_test.py
+++ b/tests/sample_weight_test.py
@@ -1,0 +1,109 @@
+"""Checks that models advertising sample_weight actually use it.
+
+A model that accepts sample_weight and quietly discards it is worse than one
+that refuses it: the caller believes the data has been reweighted. The test
+below makes the weights impossible to ignore -- half the labels are corrupted
+and then given zero weight -- so a model that honors them recovers the clean
+rule and one that doesn't cannot.
+"""
+
+import contextlib
+import inspect
+import io
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import imodels
+from tests.model_configs import (BINARY_INPUT_MODELS, EXCLUDED_MODELS,
+                                 MODEL_KWARGS)
+
+N = 300
+
+WEIGHTED_MODELS = [
+    m for m in imodels.ESTIMATORS
+    if m.__name__ not in EXCLUDED_MODELS
+    and 'sample_weight' in inspect.signature(m.fit).parameters
+]
+
+
+def _data(model_type):
+    rng = np.random.RandomState(0)
+    X = pd.DataFrame(rng.randn(N, 4), columns=list('abcd'))
+    clean = (X['a'] > 0).astype(int)
+    y = clean.copy()
+    y.iloc[N // 2:] = 1 - y.iloc[N // 2:]  # second half is garbage
+    weight = np.concatenate([np.ones(N // 2), np.zeros(N // 2)])
+    if model_type.__name__ in BINARY_INPUT_MODELS:
+        X = (X > 0).astype(int)
+    if model_type not in imodels.CLASSIFIERS:
+        y = y.astype(float)
+    return X, y, clean, weight
+
+
+def _accuracy(model, X, clean):
+    """Agreement with the uncorrupted rule, on the half that was trusted"""
+    predictions = np.asarray(model.predict(X), dtype=float).round()
+    return (predictions[:N // 2] == clean[:N // 2]).mean()
+
+
+@pytest.mark.parametrize('model_type', WEIGHTED_MODELS,
+                         ids=[m.__name__ for m in WEIGHTED_MODELS])
+def test_sample_weight_is_not_ignored(model_type):
+    X, y, clean, weight = _data(model_type)
+    kwargs = MODEL_KWARGS.get(model_type.__name__, {})
+
+    with contextlib.redirect_stdout(io.StringIO()):
+        unweighted = model_type(**kwargs).fit(X, y)
+        weighted = model_type(**kwargs).fit(X, y, sample_weight=weight)
+
+    # zeroing out the corrupted half must not leave the model untouched
+    assert not np.array_equal(
+        np.asarray(unweighted.predict(X), dtype=float),
+        np.asarray(weighted.predict(X), dtype=float)), \
+        f'{model_type.__name__} accepts sample_weight but ignores it'
+    assert _accuracy(weighted, X, clean) >= _accuracy(unweighted, X, clean)
+
+
+def test_fpskope_selects_rules_by_weighted_precision():
+    """FPSkope mines itemsets unsupervised, so weights only reach it in scoring
+
+    It accepted sample_weight, stored it, and used it nowhere: neither its
+    itemset mining nor its rule scoring looked at it.
+    """
+    X, y, clean, weight = _data(imodels.FPSkopeClassifier)
+
+    with contextlib.redirect_stdout(io.StringIO()):
+        unweighted = imodels.FPSkopeClassifier(random_state=0).fit(X, y)
+        weighted = imodels.FPSkopeClassifier(
+            random_state=0).fit(X, y, sample_weight=weight)
+
+    assert _accuracy(weighted, X, clean) > _accuracy(unweighted, X, clean)
+
+
+@pytest.mark.parametrize('model_name',
+                         ['SkopeRulesClassifier', 'FPSkopeClassifier'])
+def test_uniform_weights_match_no_weights_in_scoring(model_name):
+    """Weighting rule scoring must not perturb the unweighted result"""
+    from imodels.util.score import _eval_rule_perf
+
+    rng = np.random.RandomState(0)
+    for _ in range(25):
+        X = pd.DataFrame(rng.randn(60, 2), columns=['a', 'b'])
+        y = np.array(rng.rand(60) > 0.5)
+        rule = f'a > {rng.randn():.2f}'
+        assert np.allclose(_eval_rule_perf(rule, X, y),
+                           _eval_rule_perf(rule, X, y, np.ones(60)))
+
+
+def test_zero_weight_samples_do_not_count_toward_a_rule():
+    """A rule covering only zero-weight samples has no weighted precision"""
+    from imodels.util.score import _eval_rule_perf
+
+    X = pd.DataFrame({'a': [1.0, 2.0, 3.0, 4.0]})
+    y = np.array([True, True, False, False])
+
+    precision, recall = _eval_rule_perf('a > 0', X, y,
+                                        np.array([0.0, 0.0, 1.0, 1.0]))
+    assert (precision, recall) == (0, 0)  # both positives were weighted out


### PR DESCRIPTION
Two contract bugs found while auditing `sample_weight` support across the model registry. The probe: corrupt half the labels, then give that half zero weight — a model that honors the weights recovers the clean rule, one that ignores them cannot.

## 1. `sample_weight` never reached rule selection

`FPSkopeClassifier` accepted `sample_weight`, stored it on `self`, and used it in neither of its two overridden methods — it mines itemsets from `X` alone, and the shared rule scorer computed **unweighted** precision and recall. Zeroing out half the data left its predictions byte-identical.

`SkopeRulesClassifier` had the same gap in scoring: weights reached its tree building via `extract_skope`, but not the precision/recall that decide which rules survive `_prune_rules`.

`score_precision_recall` and `_eval_rule_perf` now take `sample_weight`, and both models pass theirs through. **With uniform weights the weighted formula reduces exactly to the old one** — verified bit-identical on 300 random rule/data combinations, and asserted in the tests — so unweighted results are unchanged.

Effect on the probe above (accuracy against the uncorrupted rule):

| | unweighted | weighted |
|---|---|---|
| `FPSkopeClassifier` | 0.65 | **0.78** |

## 2. Wrapper models fit the estimator you handed them

`HSTree` and `DecisionTreeCCP` call `.fit()` on the object passed to `__init__`, which sklearn estimators must not do. Because shrinkage and cost-complexity pruning rewrite the tree, two wrappers sharing one estimator silently collapsed into the same model:

```python
base = DecisionTreeClassifier(max_leaf_nodes=8, random_state=0)
light = HSTreeClassifier(estimator_=base, reg_param=0.1).fit(X, y)
heavy = HSTreeClassifier(estimator_=base, reg_param=500.0).fit(X, y)
np.allclose(light.predict_proba(X), heavy.predict_proba(X))   # True -- reg_param stopped mattering
```

The second fit refit and reshrank the very tree the first was still pointing at. `HSTreeClassifier`, `HSTreeClassifierCV`, `HSTreeRegressor`, `DecisionTreeCCPClassifier` and `DecisionTreeCCPRegressor` now fit a copy, leaving the caller's estimator unfitted.

## Tests

`tests/sample_weight_test.py` parametrizes over every model advertising `sample_weight` and asserts zero-weighting the corrupted half changes the fit and does not hurt accuracy — so a model can no longer accept the argument and drop it. `tests/estimator_isolation_test.py` covers estimator isolation and refit.

13 of the new tests fail against `master` and all pass with the fix. Full suite: 861 passed, 1 skipped, on both the pinned environment and latest sklearn 1.9 / pandas 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf