### PR TITLE
Remove dead helpers and collapse the duplicated introspection methods

### DIFF
--- a/imodels/__init__.py
+++ b/imodels/__init__.py
@@ -16,8 +16,6 @@ from .rule_list.bayesian_rule_list.bayesian_rule_list import BayesianRuleListCla
 from .rule_list.fast_frugal_tree import FastFrugalTreeClassifier
 from .rule_list.greedy_rule_list import GreedyRuleListClassifier
 from .rule_list.one_r import OneRClassifier
-from .rule_set import boosted_rules
-from .rule_set.boosted_rules import *
 from .rule_set.boosted_rules import BoostedRulesClassifier, BoostedRulesRegressor
 from .rule_set.brs import BayesianRuleSetClassifier
 from .rule_set.fplasso import FPLassoRegressor, FPLassoClassifier
@@ -94,3 +92,28 @@ REGRESSORS = [
 ESTIMATORS = CLASSIFIERS + REGRESSORS
 DISCRETIZERS = [RFDiscretizer, BasicDiscretizer,
                 MDLPDiscretizer, BRLDiscretizer]
+
+# The public API. Kept explicit so that `from imodels import *` brings in the
+# models and helpers rather than whatever each submodule happened to import.
+__all__ = [
+    "AutoInterpretableClassifier", "AutoInterpretableRegressor", "BART",
+    "BRLDiscretizer", "BasicDiscretizer", "BayesianRuleListClassifier",
+    "BayesianRuleSetClassifier", "BoostedRulesClassifier",
+    "BoostedRulesRegressor", "C45TreeClassifier", "CLASSIFIERS",
+    "DISCRETIZERS", "DecisionTreeCCPClassifier", "DecisionTreeCCPRegressor",
+    "DistilledRegressor", "ESTIMATORS", "FIGSClassifier",
+    "FIGSClassifierCV", "FIGSRegressor", "FIGSRegressorCV",
+    "FPLassoClassifier", "FPLassoRegressor", "FPSkopeClassifier",
+    "FastFrugalTreeClassifier", "GreedyRuleListClassifier",
+    "GreedyTreeClassifier", "GreedyTreeRegressor",
+    "HSDecisionTreeCCPClassifierCV", "HSDecisionTreeCCPRegressorCV",
+    "HSTreeClassifier", "HSTreeClassifierCV", "HSTreeRegressor",
+    "HSTreeRegressorCV", "MDLPDiscretizer",
+    "MarginalShrinkageLinearModelRegressor", "OneRClassifier", "REGRESSORS",
+    "RFDiscretizer", "RuleFitClassifier", "RuleFitRegressor",
+    "SLIMClassifier", "SLIMRegressor", "SkopeRulesClassifier",
+    "SlipperClassifier", "StableClustering", "TaoTreeClassifier",
+    "TaoTreeRegressor", "TreeGAMClassifier", "TreeGAMRegressor",
+    "explain_classification_errors", "get_clean_dataset", "get_rules",
+    "shadow_tree",
+]

--- a/imodels/algebraic/tree_gam.py
+++ b/imodels/algebraic/tree_gam.py
@@ -16,9 +16,10 @@ import imodels
 from sklearn.base import RegressorMixin, ClassifierMixin
 from imodels.util.arguments import (check_binary_target, decode_labels,
                                     set_feature_names_in)
+from imodels.util.introspection import RuleInspectionMixin
 
 
-class TreeGAM(BaseEstimator):
+class TreeGAM(RuleInspectionMixin, BaseEstimator):
     """Tree-based GAM classifier.
     Uses cyclical boosting to fit a GAM with small trees.
     Simplified version of the explainable boosting machine described in https://github.com/interpretml/interpret
@@ -152,16 +153,6 @@ class TreeGAM(BaseEstimator):
         self.mse_val_ = self._calc_mse(X_val, y_val, sample_weight_val)
 
         return self
-
-    def get_rules(self, feature_names=None):
-        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
-        from imodels.util.get_rules import get_rules
-        return get_rules(self, feature_names=feature_names)
-
-    def apply(self, X):
-        """Return the leaf each sample reaches (see imodels.util.apply.apply_leaves)."""
-        from imodels.util.apply import apply_leaves
-        return apply_leaves(self, X)
 
     def _marginal_fit(
         self,

--- a/imodels/rule_list/rule_list.py
+++ b/imodels/rule_list/rule_list.py
@@ -1,12 +1,8 @@
 from sklearn.utils.validation import check_is_fitted
+from imodels.util.introspection import RulesMixin
 
 
-class RuleList:
-
-    def get_rules(self, feature_names=None):
-        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
-        from imodels.util.get_rules import get_rules
-        return get_rules(self, feature_names=feature_names)
+class RuleList(RulesMixin):
 
     def _get_complexity(self):
         check_is_fitted(self, ['rules_without_feature_names_'])

--- a/imodels/rule_set/boosted_rules.py
+++ b/imodels/rule_set/boosted_rules.py
@@ -3,9 +3,10 @@ from sklearn.ensemble import AdaBoostClassifier, AdaBoostRegressor
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
 from imodels.util.arguments import check_fit_arguments
+from imodels.util.introspection import RuleInspectionMixin
 
 
-class BoostedRulesClassifier(AdaBoostClassifier):
+class BoostedRulesClassifier(RuleInspectionMixin, AdaBoostClassifier):
     '''An easy-interpretable classifier optimizing simple logical rules.
 
     Params
@@ -41,16 +42,6 @@ class BoostedRulesClassifier(AdaBoostClassifier):
 
 
 
-    def get_rules(self, feature_names=None):
-        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
-        from imodels.util.get_rules import get_rules
-        return get_rules(self, feature_names=feature_names)
-
-    def apply(self, X):
-        """Return the leaf each sample reaches (see imodels.util.apply.apply_leaves)."""
-        from imodels.util.apply import apply_leaves
-        return apply_leaves(self, X)
-
     def fit(self, X, y, feature_names=None, **kwargs):
         X, y, feature_names = check_fit_arguments(self, X, y, feature_names)
         classes = self.classes_  # super().fit overwrites this with the encoded labels
@@ -63,7 +54,7 @@ class BoostedRulesClassifier(AdaBoostClassifier):
         return self
 
 
-class BoostedRulesRegressor(AdaBoostRegressor):
+class BoostedRulesRegressor(RuleInspectionMixin, AdaBoostRegressor):
     '''An easy-interpretable regressor optimizing simple logical rules.
 
     Params
@@ -96,16 +87,6 @@ class BoostedRulesRegressor(AdaBoostRegressor):
             )
             self.estimator = estimator
 
-
-    def get_rules(self, feature_names=None):
-        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
-        from imodels.util.get_rules import get_rules
-        return get_rules(self, feature_names=feature_names)
-
-    def apply(self, X):
-        """Return the leaf each sample reaches (see imodels.util.apply.apply_leaves)."""
-        from imodels.util.apply import apply_leaves
-        return apply_leaves(self, X)
 
     def fit(self, X, y, feature_names=None, **kwargs):
         X, y, feature_names = check_fit_arguments(self, X, y, feature_names)

--- a/imodels/rule_set/rule_set.py
+++ b/imodels/rule_set/rule_set.py
@@ -1,14 +1,10 @@
 import numpy as np
 import pandas as pd
 from sklearn.utils.validation import check_array, check_is_fitted
+from imodels.util.introspection import RulesMixin
 
 
-class RuleSet:
-
-    def get_rules(self, feature_names=None):
-        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
-        from imodels.util.get_rules import get_rules
-        return get_rules(self, feature_names=feature_names)
+class RuleSet(RulesMixin):
 
     def _extract_rules(self, X, y):
         pass

--- a/imodels/tree/c45_tree/c45_tree.py
+++ b/imodels/tree/c45_tree/c45_tree.py
@@ -19,6 +19,7 @@ from imodels.util.arguments import check_fit_arguments, check_predict_X, decode_
 
 from ..c45_tree.c45_utils import decision, is_numeric_feature, gain, gain_ratio, get_best_split, \
     set_as_leaf_node
+from imodels.util.introspection import RulesMixin
 
 
 def _add_label(node, label):
@@ -88,7 +89,7 @@ def _make_xml_safe_names(feature_names):
     return safe_names
 
 
-class C45TreeClassifier(BaseEstimator, ClassifierMixin):
+class C45TreeClassifier(RulesMixin, BaseEstimator, ClassifierMixin):
     """A C4.5 tree classifier.
 
     Parameters
@@ -132,11 +133,6 @@ class C45TreeClassifier(BaseEstimator, ClassifierMixin):
         # print('self.tree_', self.tree_)
         self.dom_ = minidom.parseString(self.tree_)
         return self
-
-    def get_rules(self, feature_names=None):
-        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
-        from imodels.util.get_rules import get_rules
-        return get_rules(self, feature_names=feature_names)
 
     def impute_nodes(self, X, y):
         """

--- a/imodels/tree/cart_ccp.py
+++ b/imodels/tree/cart_ccp.py
@@ -7,9 +7,10 @@ from sklearn.model_selection import cross_val_score
 
 from imodels.tree.hierarchical_shrinkage import HSTreeRegressor, HSTreeClassifier
 from imodels.util.tree import compute_tree_complexity
+from imodels.util.introspection import RuleInspectionMixin
 
 
-class DecisionTreeCCPClassifier(ClassifierMixin, BaseEstimator):
+class DecisionTreeCCPClassifier(RuleInspectionMixin, ClassifierMixin, BaseEstimator):
     def __init__(self, estimator_: BaseEstimator, desired_complexity: int = 1, complexity_measure='max_rules', *args,
                  **kwargs):
         self.desired_complexity = desired_complexity
@@ -75,20 +76,10 @@ class DecisionTreeCCPClassifier(ClassifierMixin, BaseEstimator):
         self._copy_fitted_attributes()
         return self
 
-    def get_rules(self, feature_names=None):
-        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
-        from imodels.util.get_rules import get_rules
-        return get_rules(self, feature_names=feature_names)
-
     @property
     def feature_importances_(self):
         """Mean decrease in impurity of the pruned tree, as in sklearn."""
         return self.estimator_.feature_importances_
-    def apply(self, X):
-        """Return the leaf each sample reaches (see imodels.util.apply.apply_leaves)."""
-        from imodels.util.apply import apply_leaves
-        return apply_leaves(self, X)
-
     def _get_complexity(self, BaseEstimator, complexity_measure):
         return compute_tree_complexity(BaseEstimator.tree_, complexity_measure)
 
@@ -108,7 +99,7 @@ class DecisionTreeCCPClassifier(ClassifierMixin, BaseEstimator):
             return NotImplemented
 
 
-class DecisionTreeCCPRegressor(BaseEstimator):
+class DecisionTreeCCPRegressor(RuleInspectionMixin, BaseEstimator):
 
     def __init__(self, estimator_: BaseEstimator, desired_complexity: int = 1, complexity_measure='max_rules', *args,
                  **kwargs):
@@ -183,16 +174,6 @@ class DecisionTreeCCPRegressor(BaseEstimator):
     def feature_importances_(self):
         """Mean decrease in impurity of the pruned tree, as in sklearn."""
         return self.estimator_.feature_importances_
-    def get_rules(self, feature_names=None):
-        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
-        from imodels.util.get_rules import get_rules
-        return get_rules(self, feature_names=feature_names)
-
-    def apply(self, X):
-        """Return the leaf each sample reaches (see imodels.util.apply.apply_leaves)."""
-        from imodels.util.apply import apply_leaves
-        return apply_leaves(self, X)
-
     def _get_complexity(self, BaseEstimator, complexity_measure):
         return compute_tree_complexity(BaseEstimator.tree_, self.complexity_measure)
 

--- a/imodels/tree/cart_wrapper.py
+++ b/imodels/tree/cart_wrapper.py
@@ -5,9 +5,10 @@ from sklearn.tree import DecisionTreeClassifier, export_text, DecisionTreeRegres
 from imodels.util.arguments import check_fit_arguments
 
 from imodels.util.tree import compute_tree_complexity
+from imodels.util.introspection import RulesMixin
 
 
-class GreedyTreeClassifier(DecisionTreeClassifier):
+class GreedyTreeClassifier(RulesMixin, DecisionTreeClassifier):
     """Wrapper around sklearn greedy tree classifier
     """
 
@@ -50,11 +51,6 @@ class GreedyTreeClassifier(DecisionTreeClassifier):
         return self
 
 
-    def get_rules(self, feature_names=None):
-        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
-        from imodels.util.get_rules import get_rules
-        return get_rules(self, feature_names=feature_names)
-
     def _set_complexity(self):
         """Set complexity as number of non-leaf nodes
         """
@@ -71,7 +67,7 @@ class GreedyTreeClassifier(DecisionTreeClassifier):
             return s + export_text(self, show_weights=True)
 
 
-class GreedyTreeRegressor(DecisionTreeRegressor):
+class GreedyTreeRegressor(RulesMixin, DecisionTreeRegressor):
     """Wrapper around sklearn greedy tree regressor
     """
 
@@ -107,11 +103,6 @@ class GreedyTreeRegressor(DecisionTreeRegressor):
         self._set_complexity()
         return self
 
-
-    def get_rules(self, feature_names=None):
-        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
-        from imodels.util.get_rules import get_rules
-        return get_rules(self, feature_names=feature_names)
 
     def _set_complexity(self):
         """Set complexity as number of non-leaf nodes

--- a/imodels/tree/figs.py
+++ b/imodels/tree/figs.py
@@ -19,6 +19,7 @@ from scipy.special import softmax
 from imodels.tree.viz_utils import extract_sklearn_tree_from_figs
 from imodels.util.arguments import check_fit_arguments, check_predict_X
 from imodels.util.data_util import encode_categories
+from imodels.util.introspection import RuleInspectionMixin
 
 
 class Node:
@@ -100,7 +101,7 @@ class Node:
         return self.__str__()
 
 
-class FIGS(BaseEstimator):
+class FIGS(RuleInspectionMixin, BaseEstimator):
     """FIGS (sum of trees) classifier.
     Fast Interpretable Greedy-Tree Sums (FIGS) is an algorithm for fitting concise rule-based models.
     Specifically, FIGS generalizes CART to simultaneously grow a flexible number of trees in a summation.
@@ -162,15 +163,6 @@ class FIGS(BaseEstimator):
         self.need_to_reshape = False
 
 
-    def get_rules(self, feature_names=None):
-        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
-        from imodels.util.get_rules import get_rules
-        return get_rules(self, feature_names=feature_names)
-
-    def apply(self, X):
-        """Return the leaf each sample reaches (see imodels.util.apply.apply_leaves)."""
-        from imodels.util.apply import apply_leaves
-        return apply_leaves(self, X)
     def _fit_candidate_stumps(self, X, potential_splits, y_residuals_per_tree,
                               sample_weight):
         """Re-fit the stump for every candidate split, in parallel if asked."""
@@ -843,7 +835,7 @@ class FIGSClassifier(ClassifierMixin, FIGS):
         return proba[:, 1]
 
 
-class FIGSCV(BaseEstimator):
+class FIGSCV(RuleInspectionMixin, BaseEstimator):
     def __init__(
         self,
         figs,
@@ -867,20 +859,10 @@ class FIGSCV(BaseEstimator):
         self.scoring = scoring
 
 
-    def get_rules(self, feature_names=None):
-        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
-        from imodels.util.get_rules import get_rules
-        return get_rules(self, feature_names=feature_names)
-
     @property
     def feature_importances_(self):
         """Mean decrease in impurity of the selected FIGS model."""
         return self.figs.feature_importances_
-    def apply(self, X):
-        """Return the leaf each sample reaches (see imodels.util.apply.apply_leaves)."""
-        from imodels.util.apply import apply_leaves
-        return apply_leaves(self, X)
-
     def get_params(self, deep=True):
         # defined explicitly because __init__ takes *args/**kwargs, which sklearn's
         # automatic parameter introspection rejects

--- a/imodels/tree/hierarchical_shrinkage.py
+++ b/imodels/tree/hierarchical_shrinkage.py
@@ -13,6 +13,7 @@ from sklearn.utils.validation import check_is_fitted
 from imodels.util import checks
 from imodels.util.arguments import check_fit_arguments
 from imodels.util.tree import compute_tree_complexity
+from imodels.util.introspection import RuleInspectionMixin
 
 
 def _as_arrays(X, y):
@@ -29,7 +30,7 @@ def _values_are_normalized(tree):
     return bool(np.allclose(tree.value.sum(axis=(1, 2)), 1))
 
 
-class HSTree(BaseEstimator):
+class HSTree(RuleInspectionMixin, BaseEstimator):
     def __init__(
         self,
         estimator_: BaseEstimator = None,
@@ -77,16 +78,6 @@ class HSTree(BaseEstimator):
             self.estimator_.max_leaf_nodes = max_leaf_nodes
             self.estimator_.random_state = random_state
 
-
-    def get_rules(self, feature_names=None):
-        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
-        from imodels.util.get_rules import get_rules
-        return get_rules(self, feature_names=feature_names)
-
-    def apply(self, X):
-        """Return the leaf each sample reaches (see imodels.util.apply.apply_leaves)."""
-        from imodels.util.apply import apply_leaves
-        return apply_leaves(self, X)
 
     @property
     def feature_importances_(self):

--- a/imodels/tree/tao.py
+++ b/imodels/tree/tao.py
@@ -11,9 +11,10 @@ from sklearn.utils import check_X_y
 
 from imodels.util.arguments import check_fit_arguments
 from sklearn.utils.validation import check_is_fitted
+from imodels.util.introspection import RuleInspectionMixin
 
 
-class TaoTree(BaseEstimator):
+class TaoTree(RuleInspectionMixin, BaseEstimator):
 
     def __init__(self, model_type: str = 'CART',
                  n_iters: int = 20,
@@ -370,16 +371,6 @@ class TaoTree(BaseEstimator):
                 """
 
         return num_updates
-
-    def get_rules(self, feature_names=None):
-        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
-        from imodels.util.get_rules import get_rules
-        return get_rules(self, feature_names=feature_names)
-
-    def apply(self, X):
-        """Return the leaf each sample reaches (see imodels.util.apply.apply_leaves)."""
-        from imodels.util.apply import apply_leaves
-        return apply_leaves(self, X)
 
     @property
     def feature_importances_(self):

--- a/imodels/util/arguments.py
+++ b/imodels/util/arguments.py
@@ -3,7 +3,7 @@ from inspect import signature
 import numpy as np
 import pandas as pd
 from sklearn.base import ClassifierMixin
-from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
+from sklearn.utils.validation import check_X_y, check_is_fitted
 from sklearn.utils.multiclass import check_classification_targets
 import scipy.sparse
 
@@ -109,15 +109,6 @@ def set_feature_names_in(model, X):
         model.feature_names_in_ = np.asarray(X.columns, dtype=object)
         return True
     return False
-
-
-def check_fit_X(X):
-    """Process X argument for fit and predict methods.
-    """
-    if scipy.sparse.issparse(X):
-        X = X.toarray()
-    X = check_array(X)
-    return X
 
 
 def decode_labels(model, preds):

--- a/imodels/util/automl.py
+++ b/imodels/util/automl.py
@@ -17,9 +17,10 @@ import numpy as np
 from sklearn.pipeline import Pipeline
 from imodels.util.arguments import set_feature_names_in
 from sklearn.utils.validation import check_is_fitted
+from imodels.util.introspection import RuleInspectionMixin
 
 
-class AutoInterpretableModel(BaseEstimator):
+class AutoInterpretableModel(RuleInspectionMixin, BaseEstimator):
     """Automatically fit and select a classifier that is interpretable.
     Note that all preprocessing should be done beforehand.
     This is basically a wrapper around GridSearchCV, with some preselected models.
@@ -61,19 +62,6 @@ class AutoInterpretableModel(BaseEstimator):
     def score(self, X, y):
         check_is_fitted(self, 'est_')
         return self.est_.score(X, y)
-
-    def get_rules(self, feature_names=None):
-        """Return this model's rules as a DataFrame (see imodels.get_rules).
-
-        The rules are those of the model the search selected.
-        """
-        from imodels.util.get_rules import get_rules
-        return get_rules(self, feature_names=feature_names)
-
-    def apply(self, X):
-        """Return the leaf each sample reaches (see imodels.util.apply.apply_leaves)."""
-        from imodels.util.apply import apply_leaves
-        return apply_leaves(self, X)
 
     PARAM_GRID_LINEAR_CLASSIFICATION = [
         {

--- a/imodels/util/convert.py
+++ b/imodels/util/convert.py
@@ -74,78 +74,10 @@ def tree_to_rules(tree: Union[DecisionTreeClassifier, DecisionTreeRegressor],
     return rules if len(rules) > 0 else 'True'
 
 
-def tree_to_code(clf, feature_names):
-    '''Prints a tree with a single split
-    '''
-    n_nodes = clf.tree_.node_count
-    children_left = clf.tree_.children_left
-    children_right = clf.tree_.children_right
-    feature = clf.tree_.feature
-    threshold = clf.tree_.threshold
-
-    node_depth = np.zeros(shape=n_nodes, dtype=np.int64)
-    is_leaves = np.zeros(shape=n_nodes, dtype=bool)
-    stack = [(0, 0)]  # start with the root node id (0) and its depth (0)
-    s = ''
-    while len(stack) > 0:
-        # `pop` ensures each node is only visited once
-        node_id, depth = stack.pop()
-        node_depth[node_id] = depth
-
-        # If the left and right child of a node is not the same we have a split
-        # node
-        is_split_node = children_left[node_id] != children_right[node_id]
-        # If a split node, append left and right children and depth to `stack`
-        # so we can loop through them
-        if is_split_node:
-            stack.append((children_left[node_id], depth + 1))
-            stack.append((children_right[node_id], depth + 1))
-        else:
-            is_leaves[node_id] = True
-
-    # print("The binary tree structure has {n} nodes and has "
-    #       "the following tree structure:\n".format(n=n_nodes))
-    for i in range(n_nodes):
-        if is_leaves[i]:
-            pass
-        #     print("{space}node={node} is a leaf node.".format(
-        # space=node_depth[i] * "\t", node=i))
-        else:
-            s += f"{feature_names[feature[i]]} <= {threshold[i]}"
-    return f"\033[96m{s}\033[00m\n"
-
-
 def itemsets_to_rules(itemsets: List[Tuple]) -> List[str]:
     itemsets_clean = list(filter(lambda it: it != 'null' and 'All' not in ''.join(it), itemsets))
     f = lambda itemset: ' and '.join([single_discretized_feature_to_rule(item) for item in itemset])
     return list(map(f, itemsets_clean))
-
-
-def dict_to_rule(rule, clf_feature_dict):
-    """
-    Function to accept rule dict and convert to Rule object
-
-    Parameters:
-    rule: list of dict of schema
-    [
-        {
-            'feature': int,
-            'operator': str,
-            'value': float
-        },
-    ]
-    """
-
-    output = ''
-
-    for condition in rule:
-        output += '{} {} {} and '.format(
-            clf_feature_dict[int(condition['feature'])],
-            condition['operator'],
-            condition['pivot']
-        )
-
-    return output[:-5]
 
 
 def single_discretized_feature_to_rule(feat: str) -> str:

--- a/imodels/util/introspection.py
+++ b/imodels/util/introspection.py
@@ -1,0 +1,32 @@
+"""Mixins giving models the shared introspection methods.
+
+``imodels.get_rules`` and ``imodels.util.apply.apply_leaves`` work on a model
+from the outside. These mixins expose them as methods so that ``model.get_rules()``
+also works, without every model repeating the same two-line delegation.
+
+A model mixes in only what it actually supports: ``model_introspection_test``
+asserts that a model has ``get_rules`` exactly when ``imodels.get_rules`` supports
+it, and likewise for ``apply``.
+"""
+
+
+class RulesMixin:
+    """Adds ``get_rules()`` to a model whose rules imodels.get_rules can extract."""
+
+    def get_rules(self, feature_names=None):
+        """Return this model's rules as a DataFrame (see imodels.get_rules)."""
+        from imodels.util.get_rules import get_rules
+        return get_rules(self, feature_names=feature_names)
+
+
+class LeavesMixin:
+    """Adds ``apply()`` to a model built from trees, so leaf membership is defined."""
+
+    def apply(self, X):
+        """Return the leaf each sample reaches (see imodels.util.apply.apply_leaves)."""
+        from imodels.util.apply import apply_leaves
+        return apply_leaves(self, X)
+
+
+class RuleInspectionMixin(RulesMixin, LeavesMixin):
+    """Both of the above, for tree-based models that support each."""

--- a/imodels/util/tree.py
+++ b/imodels/util/tree.py
@@ -162,20 +162,3 @@ def calculate_mean_unique_calls_in_ensemble(ensemble, X, feature_costs=None):
             feats[j] = feats[j].union(feats_est[j])
     # -1 for the -2 feature that is always present
     return np.mean([len(f) - 1 for f in feats])
-
-
-def compute_mean_llm_calls(model_name, num_prompts, model=None, X=None):
-    if model_name == "manual_tree":
-        return calculate_mean_depth_of_points_in_tree(model.tree_)
-    elif model_name == "manual_hstree":
-        return calculate_mean_depth_of_points_in_tree(model.estimator_.tree_)
-    elif model_name == "manual_gbdt":
-        return calculate_mean_unique_calls_in_ensemble(model, X)
-    elif model_name == "manual_tree_cv":
-        return calculate_mean_depth_of_points_in_tree(model.best_estimator_.tree_)
-    elif model_name in ["manual_single_prompt"]:
-        return 1
-    elif model_name in ["manual_ensemble", "manual_boosting"]:
-        return num_prompts
-    else:
-        return num_prompts

--- a/imodels/util/tree_interaction_utils.py
+++ b/imodels/util/tree_interaction_utils.py
@@ -1,8 +1,4 @@
-import itertools
-from typing import Set, Tuple
-
 import numpy as np
-import pandas as pd
 
 
 def make_rj(n=300, p=50):
@@ -62,60 +58,3 @@ def make_vp(n=100, p=100):
     y = effects + interactions + np.random.normal(scale=0.14, size=n)
 
     return X, y
-
-
-def get_gt(dataset_name):
-    important_features = []
-    interactions = []
-    if dataset_name == "friedman1":
-        important_features = [0, 1, 2, 3, 4]
-        interactions = [(0, 1)]
-    elif dataset_name == "radchenko_james":
-        important_features = [0, 1, 2, 3, 4]
-        interactions = [(0, 1), (0, 2)]
-    elif dataset_name == "vo_pati":
-        important_features = [0, 1, 2, 3, 4]
-        interactions = [(0, 1), (1, 2), (2, 3)]
-
-    return set(important_features), set(interactions)
-
-
-def get_important_features(importance, k):
-    return set(np.argsort(importance)[0:k])
-
-
-def get_interacting_features(interaction, k):
-    scores_list = []
-    for ind_1, ind_2 in itertools.combinations(range(interaction.shape[0]), 2):
-        scores_list.append([interaction[ind_1, ind_2], ind_1, ind_2])
-    df = pd.DataFrame(scores_list)
-    df = df.sort_values(0, ascending=False)
-    interactions = []
-    for i in range(k):
-        interactions.append((df.iloc[i, 1], df.iloc[i, 2]))
-    return set(interactions)
-
-
-def interaction_fpr(i_gt: Set[Tuple], i_hat: Set[Tuple], p: int):
-    if len(i_gt) == 0:
-        return
-    n_pairs = 0.5 * p * (p - 1)
-    n_non_interacting_pairs = (n_pairs - len(i_gt))
-    return len(i_hat.difference(i_gt)) / n_non_interacting_pairs
-
-
-def interaction_tpr(i_gt: Set[Tuple], i_hat: Set[Tuple], p: int):
-    if len(i_gt) == 0:
-        return
-    n_interactions = len(i_gt)
-    return len(i_hat.intersection(i_gt)) / n_interactions
-
-
-def interaction_f1(i_gt: Set[Tuple], i_hat: Set[Tuple], p: int):
-    if len(i_gt) == 0:
-        return
-    recall = len(i_gt.intersection(i_hat)) / len(i_gt)
-    precision = interaction_tpr(i_hat, i_gt, p)
-    if recall + precision == 0:
-        return 0
-    return 2 * ((precision * recall) / (precision + recall))


### PR DESCRIPTION
Third cleanup pass: **-300 lines, +84**, no behavior change. Stacked on #291 (base `cleanup`); both retarget to `master` as they merge.

## Dead private helpers

`check_fit_X`, `tree_to_code`, `dict_to_rule`, `compute_mean_llm_calls`, and five of the seven functions in `tree_interaction_utils` are defined but never called — not by the library, the tests, the notebooks, or the docs — and none are reachable as `imodels.X`. Only `make_rj`/`make_vp` in that module are used, by `data_util`.

These are unexported internal helpers, which is why they're going. The two large unreferenced modules from #291 are still left alone as you asked.

## `get_rules`/`apply` were copy-pasted 24 times

The identical two-line delegation appeared verbatim in **14 classes** for `get_rules` and **10** for `apply`:

```python
def get_rules(self, feature_names=None):
    """Return this model's rules as a DataFrame (see imodels.get_rules)."""
    from imodels.util.get_rules import get_rules
    return get_rules(self, feature_names=feature_names)
```

They now come from `RulesMixin` / `LeavesMixin` in a new `imodels/util/introspection.py`.

Two mixins rather than one: five classes (`RuleList`, `RuleSet`, `C45TreeClassifier`, `GreedyTree{Classifier,Regressor}`) have `get_rules` but not `apply`, and a single combined mixin would have silently handed them an `apply` they don't support. `model_introspection_test` pins that a model exposes each method exactly when the underlying function supports it, so that would have been a real regression.

Verified across all 51 estimator classes that the set exposing each method is byte-for-byte the same before and after.

## The package namespace was leaking

`imodels/__init__.py` had:

```python
from .rule_set import boosted_rules
from .rule_set.boosted_rules import *
from .rule_set.boosted_rules import BoostedRulesClassifier, BoostedRulesRegressor
```

So `from imodels import *` also bound `AdaBoostClassifier`, `AdaBoostRegressor`, `DecisionTreeClassifier`, `DecisionTreeRegressor`, `check_fit_arguments` and the `boosted_rules` module object — names that either belong to sklearn or are internal. The star import contributed no model the following line didn't already import explicitly, so it's gone.

This is precisely what let `brs_test` use `np` without importing it (fixed in #291).

`__all__` now states the 53 public names explicitly, so the API is declared rather than being a side effect of what each submodule happened to import. Star-import still yields exactly those 53; submodules (`imodels.tree`, `imodels.util`, …) remain reachable as attributes, they're just no longer bound by `import *`.

`pyflakes imodels/` is now clean apart from `brl_util.py`'s `from numpy import *` and the bartpy internals, both explained in #291.

## Test plan
- [x] `pytest tests` — 912 pass on sklearn 1.5.2/py3.10, 895 on sklearn 1.9/py3.12
- [x] All 51 estimator classes expose the same `get_rules`/`apply` as before (diffed programmatically)
- [x] `from imodels import *` yields the same 53 models and helpers; the 7 names dropped are sklearn classes, an internal helper, and a module object
- [x] Predictions unchanged for all 35 registered models except BART, which is nondeterministic run to run regardless

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PWG8LboAM9TsyHCxRi2Bk