### PR TITLE
Bump version to 3.0.0 and rebuild the docs

### DIFF
--- a/docs/algebraic/gam_multitask.html
+++ b/docs/algebraic/gam_multitask.html
@@ -23,27 +23,18 @@
 </summary>
 <pre><code class="python">from copy import deepcopy
 import numpy as np
-import pandas as pd
 from sklearn.base import BaseEstimator
-from sklearn.linear_model import ElasticNetCV, LinearRegression, RidgeCV, LassoCV, LogisticRegressionCV
-from sklearn.tree import DecisionTreeRegressor
+from sklearn.linear_model import ElasticNetCV, RidgeCV, LassoCV, LogisticRegressionCV
 from sklearn.utils.validation import check_is_fitted
 from sklearn.utils import check_array
 from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_X_y
 from sklearn.utils.validation import _check_sample_weight
-from sklearn.ensemble import GradientBoostingClassifier, GradientBoostingRegressor, AdaBoostClassifier, AdaBoostRegressor
-from sklearn.model_selection import train_test_split
-from sklearn.metrics import accuracy_score, roc_auc_score
 from tqdm import tqdm
 from sklearn.multioutput import MultiOutputRegressor, MultiOutputClassifier
-from collections import defaultdict
-import pandas as pd
-import json
 from sklearn.preprocessing import StandardScaler
 from imodels.util.transforms import CorrelationScreenTransformer
 
-import imodels
 from interpret.glassbox import ExplainableBoostingClassifier, ExplainableBoostingRegressor
 
 from sklearn.base import RegressorMixin, ClassifierMixin
@@ -54,6 +45,9 @@ from sklearn.base import RegressorMixin, ClassifierMixin
 # merge ebms: https://github.com/interpretml/interpret/blob/develop/python/interpret-core/interpret/glassbox/_ebm/_merge_ebms.py#L280
 # eval_terms: https://interpret.ml/docs/python/api/ExplainableBoostingRegressor.html#interpret.glassbox.ExplainableBoostingRegressor.eval_terms
 
+DEFAULT_EBM_KWARGS = {&#39;n_jobs&#39;: 1, &#39;max_rounds&#39;: 5000}
+
+
 class MultiTaskGAM(BaseEstimator):
     &#34;&#34;&#34;EBM-based GAM that shares curves for predicting different outputs.
     - If only one target is given, we fit an EBM to predict each covariate
@@ -63,7 +57,7 @@ class MultiTaskGAM(BaseEstimator):
 
     def __init__(
         self,
-        ebm_kwargs={&#39;n_jobs&#39;: 1, &#39;max_rounds&#39;: 5000, },
+        ebm_kwargs=None,
         multitask=True,
         interactions=0.95,
         linear_penalty=&#39;ridge&#39;,
@@ -115,10 +109,6 @@ class MultiTaskGAM(BaseEstimator):
         self.use_correlation_screening_for_features = use_correlation_screening_for_features
         self.fit_linear_frac = fit_linear_frac
 
-        # override ebm_kwargs
-        ebm_kwargs[&#39;random_state&#39;] = random_state
-        ebm_kwargs[&#39;interactions&#39;] = interactions
-
     def fit(self, X, y, sample_weight=None):
         X, y = check_X_y(X, y, accept_sparse=False, multi_output=True)
         self.n_outputs_ = 1 if len(y.shape) == 1 else y.shape[1]
@@ -146,9 +136,9 @@ class MultiTaskGAM(BaseEstimator):
         # just fit ebm normally
         if not self.multitask:
             if isinstance(self, ClassifierMixin):
-                self.ebm_ = ExplainableBoostingClassifier(**self.ebm_kwargs)
+                self.ebm_ = ExplainableBoostingClassifier(**self._ebm_kwargs())
             else:
-                self.ebm_ = ExplainableBoostingRegressor(**self.ebm_kwargs)
+                self.ebm_ = ExplainableBoostingRegressor(**self._ebm_kwargs())
 
             # fit
             if self.n_outputs_ &gt; 1:
@@ -218,11 +208,24 @@ class MultiTaskGAM(BaseEstimator):
 
         return self
 
+    def _ebm_kwargs(self):
+        &#34;&#34;&#34;Constructor kwargs for the internal EBMs.
+
+        random_state and interactions are applied here rather than in __init__,
+        so that neither the caller&#39;s dict nor the shared default is mutated and
+        get_params() keeps returning exactly what was passed in.
+        &#34;&#34;&#34;
+        kwargs = dict(DEFAULT_EBM_KWARGS if self.ebm_kwargs is None
+                      else self.ebm_kwargs)
+        kwargs[&#39;random_state&#39;] = self.random_state
+        kwargs[&#39;interactions&#39;] = self.interactions
+        return kwargs
+
     def _initialize_ebm_internal(self, y):
         if self.use_internal_classifiers and len(np.unique(y)) == 2:
-            return ExplainableBoostingClassifier(**self.ebm_kwargs)
+            return ExplainableBoostingClassifier(**self._ebm_kwargs())
         else:
-            return ExplainableBoostingRegressor(**self.ebm_kwargs)
+            return ExplainableBoostingRegressor(**self._ebm_kwargs())
 
     def _split_data(self, num_samples):
         &#39;&#39;&#39;Split data into EBM and linear model data
@@ -343,7 +346,7 @@ class MultiTaskGAMClassifier(MultiTaskGAM, ClassifierMixin):
 <dl>
 <dt id="imodels.algebraic.gam_multitask.MultiTaskGAM"><code class="flex name class">
 <span>class <span class="ident">MultiTaskGAM</span></span>
-<span>(</span><span>ebm_kwargs={'n_jobs': 1, 'max_rounds': 5000}, multitask=True, interactions=0.95, linear_penalty='ridge', onehot_prior=False, renormalize_features=False, use_normalize_feature_targets=False, use_internal_classifiers=False, fit_target_curves=True, use_correlation_screening_for_features=False, use_single_task_with_reweighting=False, fit_linear_frac: float = None, random_state=42)</span>
+<span>(</span><span>ebm_kwargs=None, multitask=True, interactions=0.95, linear_penalty='ridge', onehot_prior=False, renormalize_features=False, use_normalize_feature_targets=False, use_internal_classifiers=False, fit_target_curves=True, use_correlation_screening_for_features=False, use_single_task_with_reweighting=False, fit_linear_frac: float = None, random_state=42)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>EBM-based GAM that shares curves for predicting different outputs.
@@ -384,7 +387,7 @@ If not None, the fraction of features to use for the linear model (the rest are 
 
     def __init__(
         self,
-        ebm_kwargs={&#39;n_jobs&#39;: 1, &#39;max_rounds&#39;: 5000, },
+        ebm_kwargs=None,
         multitask=True,
         interactions=0.95,
         linear_penalty=&#39;ridge&#39;,
@@ -436,10 +439,6 @@ If not None, the fraction of features to use for the linear model (the rest are 
         self.use_correlation_screening_for_features = use_correlation_screening_for_features
         self.fit_linear_frac = fit_linear_frac
 
-        # override ebm_kwargs
-        ebm_kwargs[&#39;random_state&#39;] = random_state
-        ebm_kwargs[&#39;interactions&#39;] = interactions
-
     def fit(self, X, y, sample_weight=None):
         X, y = check_X_y(X, y, accept_sparse=False, multi_output=True)
         self.n_outputs_ = 1 if len(y.shape) == 1 else y.shape[1]
@@ -467,9 +466,9 @@ If not None, the fraction of features to use for the linear model (the rest are 
         # just fit ebm normally
         if not self.multitask:
             if isinstance(self, ClassifierMixin):
-                self.ebm_ = ExplainableBoostingClassifier(**self.ebm_kwargs)
+                self.ebm_ = ExplainableBoostingClassifier(**self._ebm_kwargs())
             else:
-                self.ebm_ = ExplainableBoostingRegressor(**self.ebm_kwargs)
+                self.ebm_ = ExplainableBoostingRegressor(**self._ebm_kwargs())
 
             # fit
             if self.n_outputs_ &gt; 1:
@@ -539,11 +538,24 @@ If not None, the fraction of features to use for the linear model (the rest are 
 
         return self
 
+    def _ebm_kwargs(self):
+        &#34;&#34;&#34;Constructor kwargs for the internal EBMs.
+
+        random_state and interactions are applied here rather than in __init__,
+        so that neither the caller&#39;s dict nor the shared default is mutated and
+        get_params() keeps returning exactly what was passed in.
+        &#34;&#34;&#34;
+        kwargs = dict(DEFAULT_EBM_KWARGS if self.ebm_kwargs is None
+                      else self.ebm_kwargs)
+        kwargs[&#39;random_state&#39;] = self.random_state
+        kwargs[&#39;interactions&#39;] = self.interactions
+        return kwargs
+
     def _initialize_ebm_internal(self, y):
         if self.use_internal_classifiers and len(np.unique(y)) == 2:
-            return ExplainableBoostingClassifier(**self.ebm_kwargs)
+            return ExplainableBoostingClassifier(**self._ebm_kwargs())
         else:
-            return ExplainableBoostingRegressor(**self.ebm_kwargs)
+            return ExplainableBoostingRegressor(**self._ebm_kwargs())
 
     def _split_data(self, num_samples):
         &#39;&#39;&#39;Split data into EBM and linear model data
@@ -694,9 +706,9 @@ If not None, the fraction of features to use for the linear model (the rest are 
     # just fit ebm normally
     if not self.multitask:
         if isinstance(self, ClassifierMixin):
-            self.ebm_ = ExplainableBoostingClassifier(**self.ebm_kwargs)
+            self.ebm_ = ExplainableBoostingClassifier(**self._ebm_kwargs())
         else:
-            self.ebm_ = ExplainableBoostingRegressor(**self.ebm_kwargs)
+            self.ebm_ = ExplainableBoostingRegressor(**self._ebm_kwargs())
 
         # fit
         if self.n_outputs_ &gt; 1:
@@ -923,7 +935,7 @@ default=<code>sklearn.utils.metadata_routing.UNCHANGED</code></dt>
 </dd>
 <dt id="imodels.algebraic.gam_multitask.MultiTaskGAMClassifier"><code class="flex name class">
 <span>class <span class="ident">MultiTaskGAMClassifier</span></span>
-<span>(</span><span>ebm_kwargs={'n_jobs': 1, 'max_rounds': 5000}, multitask=True, interactions=0.95, linear_penalty='ridge', onehot_prior=False, renormalize_features=False, use_normalize_feature_targets=False, use_internal_classifiers=False, fit_target_curves=True, use_correlation_screening_for_features=False, use_single_task_with_reweighting=False, fit_linear_frac: float = None, random_state=42)</span>
+<span>(</span><span>ebm_kwargs=None, multitask=True, interactions=0.95, linear_penalty='ridge', onehot_prior=False, renormalize_features=False, use_normalize_feature_targets=False, use_internal_classifiers=False, fit_target_curves=True, use_correlation_screening_for_features=False, use_single_task_with_reweighting=False, fit_linear_frac: float = None, random_state=42)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>EBM-based GAM that shares curves for predicting different outputs.
@@ -1075,7 +1087,7 @@ default=<code>sklearn.utils.metadata_routing.UNCHANGED</code></dt>
 </dd>
 <dt id="imodels.algebraic.gam_multitask.MultiTaskGAMRegressor"><code class="flex name class">
 <span>class <span class="ident">MultiTaskGAMRegressor</span></span>
-<span>(</span><span>ebm_kwargs={'n_jobs': 1, 'max_rounds': 5000}, multitask=True, interactions=0.95, linear_penalty='ridge', onehot_prior=False, renormalize_features=False, use_normalize_feature_targets=False, use_internal_classifiers=False, fit_target_curves=True, use_correlation_screening_for_features=False, use_single_task_with_reweighting=False, fit_linear_frac: float = None, random_state=42)</span>
+<span>(</span><span>ebm_kwargs=None, multitask=True, interactions=0.95, linear_penalty='ridge', onehot_prior=False, renormalize_features=False, use_normalize_feature_targets=False, use_internal_classifiers=False, fit_target_curves=True, use_correlation_screening_for_features=False, use_single_task_with_reweighting=False, fit_linear_frac: float = None, random_state=42)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>EBM-based GAM that shares curves for predicting different outputs.

--- a/docs/algebraic/gam_shap.html
+++ b/docs/algebraic/gam_shap.html
@@ -21,14 +21,8 @@
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">from copy import deepcopy
-from interpret.glassbox import ExplainableBoostingClassifier, ExplainableBoostingRegressor
-from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin, defaultdict
-from sklearn.datasets import load_diabetes
-from sklearn.utils import resample
-from sklearn.datasets import load_iris
-from sklearn.model_selection import train_test_split
-from sklearn.metrics import accuracy_score, r2_score
+<pre><code class="python">from interpret.glassbox import ExplainableBoostingClassifier, ExplainableBoostingRegressor
+from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 import numpy as np
 
 
@@ -130,15 +124,15 @@ class ShapGAM(BaseEstimator):
             # return preds
 
             # averaging the predictions across all models for each feature
-            preds = np.zeros(len(X_test))
-            for ex_num in range(len(X_test)):
-                for feat_num in range(X_train.shape[1]):
+            preds = np.zeros(len(X))
+            for ex_num in range(len(X)):
+                for feat_num in range(X.shape[1]):
                     feat_count = 0
                     pred_feat = 0
                     for ebm, feature_subset in zip(self.models, self.feature_subsets):
                         if feat_num in feature_subset:
                             expl_local = ebm.explain_local(
-                                X_test[ex_num, feature_subset])
+                                X[ex_num, feature_subset])
                             feat_num_in_subset = np.where(
                                 feature_subset == feat_num)[0][0]
                             pred_feat += expl_local.data(
@@ -168,45 +162,7 @@ class ShapGAMRegressor(ShapGAM, RegressorMixin):
 
 
 class ShapGAMClassifier(ShapGAM, ClassifierMixin):
-    ...
-
-
-if __name__ == &#39;__main__&#39;:
-
-    # Load data
-    # X, y = load_iris(return_X_y=True)
-    # X, y =
-
-    # make binary classification
-    # X = X[y &lt; 2]
-    # y = y[y &lt; 2]
-
-    # load regression data
-    X, y = load_diabetes(return_X_y=True)
-
-    # normalize y
-    y = (y - y.mean()) / y.std()
-
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.3, random_state=42)
-
-    # Create and fit ensemble EBM
-    # ebm_ensemble = ExplainableBoostingRegressor(
-    # interactions=0, random_state=42)
-    ebm_ensemble = ShapGAMRegressor(
-        n_estimators=20,
-        # feature_fraction=0.9,
-        feature_fraction=&#39;uniform&#39;,
-        random_state=42, ebm_kwargs={&#39;interactions&#39;: 0})
-    ebm_ensemble.fit(X_train, y_train)
-
-    # Evaluate
-    y_pred = ebm_ensemble.predict(X_test)
-    # accuracy = accuracy_score(y_test, y_pred)
-    # print(f&#34;Ensemble EBM Accuracy: {accuracy}&#34;)
-
-    r2 = r2_score(y_test, y_pred)
-    print(f&#34;Ensemble EBM R^2: {r2}&#34;)</code></pre>
+    ...</code></pre>
 </details>
 </section>
 <section>
@@ -366,15 +322,15 @@ array([3, 3, 3])
             # return preds
 
             # averaging the predictions across all models for each feature
-            preds = np.zeros(len(X_test))
-            for ex_num in range(len(X_test)):
-                for feat_num in range(X_train.shape[1]):
+            preds = np.zeros(len(X))
+            for ex_num in range(len(X)):
+                for feat_num in range(X.shape[1]):
                     feat_count = 0
                     pred_feat = 0
                     for ebm, feature_subset in zip(self.models, self.feature_subsets):
                         if feat_num in feature_subset:
                             expl_local = ebm.explain_local(
-                                X_test[ex_num, feature_subset])
+                                X[ex_num, feature_subset])
                             feat_num_in_subset = np.where(
                                 feature_subset == feat_num)[0][0]
                             pred_feat += expl_local.data(
@@ -505,15 +461,15 @@ contained subobjects that are estimators.</dd>
         # return preds
 
         # averaging the predictions across all models for each feature
-        preds = np.zeros(len(X_test))
-        for ex_num in range(len(X_test)):
-            for feat_num in range(X_train.shape[1]):
+        preds = np.zeros(len(X))
+        for ex_num in range(len(X)):
+            for feat_num in range(X.shape[1]):
                 feat_count = 0
                 pred_feat = 0
                 for ebm, feature_subset in zip(self.models, self.feature_subsets):
                     if feat_num in feature_subset:
                         expl_local = ebm.explain_local(
-                            X_test[ex_num, feature_subset])
+                            X[ex_num, feature_subset])
                         feat_num_in_subset = np.where(
                             feature_subset == feat_num)[0][0]
                         pred_feat += expl_local.data(

--- a/docs/algebraic/marginal_shrinkage_linear_model.html
+++ b/docs/algebraic/marginal_shrinkage_linear_model.html
@@ -23,21 +23,15 @@
 </summary>
 <pre><code class="python">from copy import deepcopy
 import numpy as np
-import pandas as pd
 from sklearn.base import BaseEstimator
-from sklearn.linear_model import LinearRegression, RidgeCV, Ridge, ElasticNet, ElasticNetCV
-from sklearn.tree import DecisionTreeRegressor
+from sklearn.linear_model import RidgeCV, ElasticNet, ElasticNetCV
 from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_X_y, check_array, _check_sample_weight
-from imodels.util.arguments import set_feature_names_in
-from sklearn.model_selection import train_test_split
-from sklearn.metrics import accuracy_score, roc_auc_score
-from tqdm import tqdm
+from imodels.util.arguments import check_predict_X, set_feature_names_in
 from sklearn.preprocessing import StandardScaler
-from collections import defaultdict
-import imodels
 
 from sklearn.base import RegressorMixin, ClassifierMixin
+from sklearn.utils.validation import check_is_fitted
 
 
 class MarginalShrinkageLinearModel(BaseEstimator):
@@ -208,10 +202,14 @@ class MarginalShrinkageLinearModel(BaseEstimator):
             )
 
     def predict_proba(self, X):
+        check_is_fitted(self, &#39;est_main_&#39;)
+        check_predict_X(self, X)
         X = self.scalar_X_.transform(X)
         return self.est_main_.predict_proba(X)
 
     def predict(self, X):
+        check_is_fitted(self, &#39;est_main_&#39;)
+        check_predict_X(self, X)
         X = self.scalar_X_.transform(X)
         pred = self.est_main_.predict(X)
         return self.scalar_y_.inverse_transform(pred.reshape(-1, 1)).squeeze()
@@ -293,98 +291,7 @@ class MarginalLinearClassifier(MarginalLinearModel, ClassifierMixin):
 #     m.fit(X_train, y_train)
 #     print(m.coef_)
 #     print(m.predict(X_test))
-#     print(m.score(X_test, y_test))
-
-if __name__ == &#34;__main__&#34;:
-    # X, y, feature_names = imodels.get_clean_dataset(&#34;heart&#34;)
-    X, y, feature_names = imodels.get_clean_dataset(
-        **imodels.util.data_util.DSET_KWARGS[&#34;california_housing&#34;]
-    )
-
-    # scale the data
-    X = StandardScaler().fit_transform(X)
-    y = StandardScaler().fit_transform(y.reshape(-1, 1)).squeeze()
-
-    print(&#34;shapes&#34;, X.shape, y.shape, &#34;nunique&#34;, np.unique(y).size)
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, random_state=42, test_size=0.2
-    )
-
-    coefs = []
-    alphas = (0.1, 1, 10, 100, 1000, 10000)  # (0.1, 1, 10, 100, 1000, 10000)
-    # alphas = 10000
-    kwargs = dict(
-        random_state=42,
-        alphas=alphas,
-    )
-    results = defaultdict(list)
-    for m in [
-        # MarginalShrinkageLinearModelRegressor(**kwargs),
-        # MarginalShrinkageLinearModelRegressor(
-        #     est_marginal_name=None, **kwargs),
-        # MarginalShrinkageLinearModelRegressor(
-        #     est_main_name=None,
-        #     **kwargs,
-        # ),
-        # MarginalShrinkageLinearModelRegressor(
-        #     est_marginal_name=&#34;ridge&#34;,
-        #     est_main_name=&#34;ridge&#34;,
-        #     marginal_sign_constraint=True,
-        #     **kwargs,
-        # ),
-        # MarginalShrinkageLinearModelRegressor(
-        #     est_marginal_name=None, est_main_name=&#34;lasso&#34;, **kwargs
-        # ),
-        # MarginalShrinkageLinearModelRegressor(
-        #     est_marginal_name=&#34;ridge&#34;,
-        #     est_main_name=&#34;lasso&#34;,
-        #     marginal_sign_constraint=True,
-        #     **kwargs,
-        # ),
-        MarginalLinearRegressor(alpha=1.0),
-        RidgeCV(alphas=alphas, fit_intercept=False),
-    ]:
-        results[&#34;model_name&#34;].append(str(m))
-        m.fit(X_train, y_train)
-
-        # check roc auc score
-        if isinstance(m, ClassifierMixin):
-            results[&#34;train_roc&#34;].append(
-                roc_auc_score(y_train, m.predict_proba(X_train)[:, 1])
-            )
-            results[&#34;test_roc&#34;].append(
-                roc_auc_score(y_test, m.predict_proba(X_test)[:, 1])
-            )
-            results[&#34;acc_train&#34;].append(
-                accuracy_score(y_train, m.predict(X_train)))
-            results[&#34;acc_test&#34;].append(
-                accuracy_score(y_test, m.predict(X_test)))
-        else:
-            y_pred = m.predict(X_test)
-            results[&#34;train_mse&#34;].append(
-                np.mean((y_train - m.predict(X_train)) ** 2))
-            results[&#34;test_mse&#34;].append(np.mean((y_test - y_pred) ** 2))
-            results[&#34;train_r2&#34;].append(m.score(X_train, y_train))
-            results[&#34;test_r2&#34;].append(m.score(X_test, y_test))
-
-        if isinstance(m, MarginalShrinkageLinearModelRegressor):
-            lin = m.est_main_
-        else:
-            lin = m
-
-        coefs.append(deepcopy(lin.coef_))
-        print(&#34;alpha best&#34;, lin.alpha_)
-
-    # diffs = pd.DataFrame({str(i): coefs[i] for i in range(len(coefs))})
-    # diffs[&#34;diff 0 - 1&#34;] = diffs[&#34;0&#34;] - diffs[&#34;1&#34;]
-    # diffs[&#34;diff 1 - 2&#34;] = diffs[&#34;1&#34;] - diffs[&#34;2&#34;]
-    # print(diffs)
-
-    # don&#39;t round strings
-    with pd.option_context(
-        &#34;display.max_rows&#34;, None, &#34;display.max_columns&#34;, None, &#34;display.width&#34;, 1000
-    ):
-        print(pd.DataFrame(results).round(3))</code></pre>
+#     print(m.score(X_test, y_test))</code></pre>
 </details>
 </section>
 <section>
@@ -1081,10 +988,14 @@ Random seed</p></div>
             )
 
     def predict_proba(self, X):
+        check_is_fitted(self, &#39;est_main_&#39;)
+        check_predict_X(self, X)
         X = self.scalar_X_.transform(X)
         return self.est_main_.predict_proba(X)
 
     def predict(self, X):
+        check_is_fitted(self, &#39;est_main_&#39;)
+        check_predict_X(self, X)
         X = self.scalar_X_.transform(X)
         pred = self.est_main_.predict(X)
         return self.scalar_y_.inverse_transform(pred.reshape(-1, 1)).squeeze()</code></pre>
@@ -1149,6 +1060,8 @@ Random seed</p></div>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def predict(self, X):
+    check_is_fitted(self, &#39;est_main_&#39;)
+    check_predict_X(self, X)
     X = self.scalar_X_.transform(X)
     pred = self.est_main_.predict(X)
     return self.scalar_y_.inverse_transform(pred.reshape(-1, 1)).squeeze()</code></pre>
@@ -1164,6 +1077,8 @@ Random seed</p></div>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def predict_proba(self, X):
+    check_is_fitted(self, &#39;est_main_&#39;)
+    check_predict_X(self, X)
     X = self.scalar_X_.transform(X)
     return self.est_main_.predict_proba(X)</code></pre>
 </details>

--- a/docs/algebraic/ridge_multi.html
+++ b/docs/algebraic/ridge_multi.html
@@ -33,8 +33,6 @@ These functions help to predict many outputs using ridge regression efficiently.
 import time
 import numpy as np
 from tqdm import tqdm
-import logging
-import joblib
 import itertools as itools
 from imodels.algebraic.ridge_multi_utils import mult_diag, _z_score, ridge_logger, _counter
 from sklearn.utils.extmath import randomized_svd
@@ -600,98 +598,7 @@ def boostrap_ridge_with_lowrank(
     return wt_hybrid, corrs_test, corrs_tune, valinds
 
 
-    ###########################################################
-if __name__ == &#39;__main__&#39;:
-    # sample data for ridge regression
-    np.random.seed(0)
-
-    # set logging to debug
-    logging.basicConfig(level=logging.DEBUG)
-
-    # params = joblib.load(&#39;example_params.joblib&#39;)
-    params = joblib.load(&#39;/home/chansingh/fmri/example_params_full.joblib&#39;)
-    print(params.keys())
-
-    X_train = params[&#39;features_train_delayed&#39;]
-    y_train = params[&#39;resp_train&#39;]
-    X_test = params[&#39;features_test_delayed&#39;]
-    y_test = params[&#39;resp_test&#39;]
-    alphas = params[&#39;alphas&#39;]
-    # nboots=params[&#39;nboots&#39;],
-    nboots = 10
-    chunklen = params[&#39;chunklen&#39;]
-    nchunks = params[&#39;nchunks&#39;]
-    singcutoff = params[&#39;singcutoff&#39;]
-    single_alpha = params[&#39;single_alpha&#39;]
-
-    # wt_hybrid, corrs_test, corrs_tune, valinds = boostrap_ridge_with_lowrank(
-    #     X_train, y_train, X_test, y_test,
-    #     alphas_ridge=alphas,
-    #     alphas_lowrank=alphas,
-    #     ranks=[100],
-    #     nboots=nboots, chunklen=chunklen, nchunks=nchunks)
-
-    print(&#39;alphas&#39;, alphas)
-
-    # baseline call (with decrease_alpha=1)
-    t0 = time.time()
-    wt_ridge, corrs_test, alphas_best, corrs_tune, valinds = bootstrap_ridge(
-        X_train, y_train, X_test, y_test,
-        alphas=alphas,
-        nboots=nboots,
-        chunklen=params[&#39;chunklen&#39;], nchunks=params[&#39;nchunks&#39;],
-        singcutoff=params[&#39;singcutoff&#39;], single_alpha=params[&#39;single_alpha&#39;],
-        decrease_alpha=1
-    )
-    print(&#39;time elapsed&#39;, time.time()-t0)
-
-    pred_test = X_test @ wt_ridge
-    corrs_test = np.array([np.corrcoef(y_test[:, ii], pred_test[:, ii].ravel())[0, 1]
-                           for ii in range(y_test.shape[1])])
-    print(&#39;mean test corrs&#39;, corrs_test.mean())
-    pred_train = X_train @ wt_ridge
-    corrs_train = np.array([np.corrcoef(y_train[:, ii], pred_train[:, ii].ravel())[0, 1]
-                            for ii in range(y_train.shape[1])])
-    print(&#39;mean train corrs&#39;, corrs_train.mean())
-
-    # # call 2
-    # t0 = time.time()
-    # wt_lowrank, meanbootcorrs = bootstrap_low_rank_ridge(
-    #     X_train, y_train, alphas=alphas[::2], ranks=[25, 100], nboots=nboots, chunklen=chunklen, nchunks=nchunks)
-    # print(&#39;time elapsed&#39;, time.time()-t0)
-    # pred_train = X_train @ wt_lowrank
-
-    # pred_test = X_test @ wt_lowrank
-    # corrs_test = np.array([np.corrcoef(y_test[:, ii], pred_test[:, ii].ravel())[0, 1]
-    #                        for ii in range(y_test.shape[1])])
-    # print(&#39;mean test corrs&#39;, corrs_test.mean())
-    # pred_train = X_train @ wt_lowrank
-    # corrs_train = np.array([np.corrcoef(y_train[:, ii], pred_train[:, ii].ravel())[0, 1]
-    #                         for ii in range(y_train.shape[1])])
-    # print(&#39;mean train corrs&#39;, corrs_train.mean())
-
-    # # select weights between wt and wt_lowrank based on bootstrap results
-    # try:
-    #     meanbootcorrs_ridge = corrs_tune.mean(2).max(axis=0)
-    #     meanbootcorrs_lowrank = meanbootcorrs.max(axis=0)
-    #     wt_hybrid = np.zeros_like(wt_ridge)
-    #     for i in range(y_train.shape[1]):
-    #         if meanbootcorrs_ridge[i] &gt; meanbootcorrs_lowrank[i]:
-    #             wt_hybrid[:, i] = wt_ridge[:, i]
-    #         else:
-    #             wt_hybrid[:, i] = wt_lowrank[:, i]
-
-    #     pred_test = X_test @ wt_hybrid
-    #     corrs_test = np.array([np.corrcoef(y_test[:, ii], pred_test[:, ii].ravel())[0, 1]
-    #                            for ii in range(y_test.shape[1])])
-    #     print(&#39;mean test corrs&#39;, corrs_test.mean())
-    #     pred_train = X_train @ wt_hybrid
-    #     corrs_train = np.array([np.corrcoef(y_train[:, ii], pred_train[:, ii].ravel())[0, 1]
-    #                             for ii in range(y_train.shape[1])])
-    #     print(&#39;mean train corrs&#39;, corrs_train.mean())
-    # except Exception as e:
-    #     print(e)
-    #     breakpoint()</code></pre>
+    ###########################################################</code></pre>
 </details>
 </section>
 <section>

--- a/docs/algebraic/ridge_multi_utils.html
+++ b/docs/algebraic/ridge_multi_utils.html
@@ -21,13 +21,9 @@
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">from sklearn.linear_model import Ridge
-import time
-import numpy as np
-from tqdm import tqdm
+<pre><code class="python">import time
 import logging
 import random
-import joblib
 import itertools as itools
 
 

--- a/docs/algebraic/slim.html
+++ b/docs/algebraic/slim.html
@@ -42,7 +42,28 @@ from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.linear_model import LinearRegression, Lasso, LogisticRegression
 from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
-from imodels.util.arguments import set_feature_names_in
+from imodels.util.arguments import check_predict_X, set_feature_names_in
+
+def _warn_if_rounding_collapsed(coef, rounded):
+    &#34;&#34;&#34;Warn when rounding to integers has destroyed the fitted model.
+
+    SLIM&#39;s coefficients are integers, so a feature whose natural coefficient is
+    much smaller than 1 rounds to zero. On data whose columns are on very
+    different scales that silently removes most of the model: on breast_cancer,
+    raw features give a below-chance classifier while standardized ones reach
+    0.99 AUC.
+    &#34;&#34;&#34;
+    nonzero_before = int(np.count_nonzero(coef))
+    nonzero_after = int(np.count_nonzero(rounded))
+    if nonzero_before and nonzero_after * 2 &lt; nonzero_before:
+        warnings.warn(
+            f&#34;Rounding coefficients to integers left {nonzero_after} of &#34;
+            f&#34;{nonzero_before} nonzero, so most of the fitted model was lost. &#34;
+            &#34;SLIM uses integer coefficients, so features on very different &#34;
+            &#34;scales collapse when rounded; scale X first (for example with &#34;
+            &#34;sklearn.preprocessing.StandardScaler).&#34;
+        )
+
 
 class SLIMRegressor(RegressorMixin, BaseEstimator):
     &#39;&#39;&#39;Sparse integer linear model
@@ -108,16 +129,15 @@ class SLIMRegressor(RegressorMixin, BaseEstimator):
     def _fit_backup(self, X, y, sample_weight):
         m = Lasso(alpha=self.alpha)
         m.fit(X, y, sample_weight=sample_weight)
-        self.model_.coef_ = np.round(m.coef_).astype(int)
+        rounded = np.round(m.coef_).astype(int)
+        _warn_if_rounding_collapsed(m.coef_, rounded)
+        self.model_.coef_ = rounded
         self.model_.intercept_ = m.intercept_
 
     def predict(self, X):
         check_is_fitted(self)
+        check_predict_X(self, X)
         X = check_array(X)
-        # ensure input feature count matches training
-        if hasattr(self, &#39;n_features_in_&#39;) and X.shape[1] != self.n_features_in_:
-            raise ValueError(&#34;X has %d features, but %s is expecting %d features as input&#34; %
-                             (X.shape[1], self.__class__.__name__, self.n_features_in_))
         return self.model_.predict(X)
 
 
@@ -189,25 +209,21 @@ class SLIMClassifier(ClassifierMixin, BaseEstimator):
     def _fit_backup(self, X, y, sample_weight=None):
         m = LogisticRegression(C=1 / self.alpha)
         m.fit(X, y, sample_weight=sample_weight)
-        self.model_.coef_ = np.round(m.coef_).astype(int)
+        rounded = np.round(m.coef_).astype(int)
+        _warn_if_rounding_collapsed(m.coef_, rounded)
+        self.model_.coef_ = rounded
         self.model_.intercept_ = m.intercept_
 
     def predict(self, X):
         check_is_fitted(self)
+        check_predict_X(self, X)
         X = check_array(X)
-        # ensure input feature count matches training
-        if hasattr(self, &#39;n_features_in_&#39;) and X.shape[1] != self.n_features_in_:
-            raise ValueError(&#34;X has %d features, but %s is expecting %d features as input&#34; %
-                             (X.shape[1], self.__class__.__name__, self.n_features_in_))
         return self.model_.predict(X)
 
     def predict_proba(self, X):
         check_is_fitted(self)
+        check_predict_X(self, X)
         X = check_array(X)
-        # ensure input feature count matches training
-        if hasattr(self, &#39;n_features_in_&#39;) and X.shape[1] != self.n_features_in_:
-            raise ValueError(&#34;X has %d features, but %s is expecting %d features as input&#34; %
-                             (X.shape[1], self.__class__.__name__, self.n_features_in_))
         return self.model_.predict_proba(X)</code></pre>
 </details>
 </section>
@@ -330,25 +346,21 @@ weight for sparsity penalty</p></div>
     def _fit_backup(self, X, y, sample_weight=None):
         m = LogisticRegression(C=1 / self.alpha)
         m.fit(X, y, sample_weight=sample_weight)
-        self.model_.coef_ = np.round(m.coef_).astype(int)
+        rounded = np.round(m.coef_).astype(int)
+        _warn_if_rounding_collapsed(m.coef_, rounded)
+        self.model_.coef_ = rounded
         self.model_.intercept_ = m.intercept_
 
     def predict(self, X):
         check_is_fitted(self)
+        check_predict_X(self, X)
         X = check_array(X)
-        # ensure input feature count matches training
-        if hasattr(self, &#39;n_features_in_&#39;) and X.shape[1] != self.n_features_in_:
-            raise ValueError(&#34;X has %d features, but %s is expecting %d features as input&#34; %
-                             (X.shape[1], self.__class__.__name__, self.n_features_in_))
         return self.model_.predict(X)
 
     def predict_proba(self, X):
         check_is_fitted(self)
+        check_predict_X(self, X)
         X = check_array(X)
-        # ensure input feature count matches training
-        if hasattr(self, &#39;n_features_in_&#39;) and X.shape[1] != self.n_features_in_:
-            raise ValueError(&#34;X has %d features, but %s is expecting %d features as input&#34; %
-                             (X.shape[1], self.__class__.__name__, self.n_features_in_))
         return self.model_.predict_proba(X)</code></pre>
 </details>
 <h3>Ancestors</h3>
@@ -439,11 +451,8 @@ weight for each individual sample</p></div>
 </summary>
 <pre><code class="python">def predict(self, X):
     check_is_fitted(self)
+    check_predict_X(self, X)
     X = check_array(X)
-    # ensure input feature count matches training
-    if hasattr(self, &#39;n_features_in_&#39;) and X.shape[1] != self.n_features_in_:
-        raise ValueError(&#34;X has %d features, but %s is expecting %d features as input&#34; %
-                         (X.shape[1], self.__class__.__name__, self.n_features_in_))
     return self.model_.predict(X)</code></pre>
 </details>
 </dd>
@@ -458,11 +467,8 @@ weight for each individual sample</p></div>
 </summary>
 <pre><code class="python">def predict_proba(self, X):
     check_is_fitted(self)
+    check_predict_X(self, X)
     X = check_array(X)
-    # ensure input feature count matches training
-    if hasattr(self, &#39;n_features_in_&#39;) and X.shape[1] != self.n_features_in_:
-        raise ValueError(&#34;X has %d features, but %s is expecting %d features as input&#34; %
-                         (X.shape[1], self.__class__.__name__, self.n_features_in_))
     return self.model_.predict_proba(X)</code></pre>
 </details>
 </dd>
@@ -734,16 +740,15 @@ weight for sparsity penalty</p></div>
     def _fit_backup(self, X, y, sample_weight):
         m = Lasso(alpha=self.alpha)
         m.fit(X, y, sample_weight=sample_weight)
-        self.model_.coef_ = np.round(m.coef_).astype(int)
+        rounded = np.round(m.coef_).astype(int)
+        _warn_if_rounding_collapsed(m.coef_, rounded)
+        self.model_.coef_ = rounded
         self.model_.intercept_ = m.intercept_
 
     def predict(self, X):
         check_is_fitted(self)
+        check_predict_X(self, X)
         X = check_array(X)
-        # ensure input feature count matches training
-        if hasattr(self, &#39;n_features_in_&#39;) and X.shape[1] != self.n_features_in_:
-            raise ValueError(&#34;X has %d features, but %s is expecting %d features as input&#34; %
-                             (X.shape[1], self.__class__.__name__, self.n_features_in_))
         return self.model_.predict(X)</code></pre>
 </details>
 <h3>Ancestors</h3>
@@ -831,11 +836,8 @@ weight for each individual sample</p></div>
 </summary>
 <pre><code class="python">def predict(self, X):
     check_is_fitted(self)
+    check_predict_X(self, X)
     X = check_array(X)
-    # ensure input feature count matches training
-    if hasattr(self, &#39;n_features_in_&#39;) and X.shape[1] != self.n_features_in_:
-        raise ValueError(&#34;X has %d features, but %s is expecting %d features as input&#34; %
-                         (X.shape[1], self.__class__.__name__, self.n_features_in_))
     return self.model_.predict(X)</code></pre>
 </details>
 </dd>

--- a/docs/algebraic/tree_gam.html
+++ b/docs/algebraic/tree_gam.html
@@ -23,7 +23,6 @@
 </summary>
 <pre><code class="python">from copy import deepcopy
 import numpy as np
-import pandas as pd
 from sklearn.base import BaseEstimator
 from sklearn.linear_model import ElasticNetCV, LinearRegression, RidgeCV
 from sklearn.tree import DecisionTreeRegressor
@@ -32,15 +31,13 @@ from sklearn.utils import check_array
 from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_X_y
 from sklearn.utils.validation import _check_sample_weight
-from sklearn.ensemble import GradientBoostingClassifier, GradientBoostingRegressor
+from sklearn.ensemble import GradientBoostingRegressor
 from sklearn.model_selection import train_test_split
-from sklearn.metrics import accuracy_score, roc_auc_score
-from tqdm import tqdm
 
 import imodels
 
 from sklearn.base import RegressorMixin, ClassifierMixin
-from imodels.util.arguments import (check_binary_target, decode_labels,
+from imodels.util.arguments import (check_binary_target, check_predict_X, decode_labels,
                                     set_feature_names_in)
 
 
@@ -340,6 +337,7 @@ class TreeGAM(BaseEstimator):
         marginal_only: bool
             If True, only use the marginal effects.
         &#34;&#34;&#34;
+        check_predict_X(self, X)
         X = check_array(X, accept_sparse=False, dtype=None)
         check_is_fitted(self)
         probs1 = np.ones(X.shape[0]) * self.bias_
@@ -396,45 +394,7 @@ class TreeGAMRegressor(TreeGAM, RegressorMixin):
 
 
 class TreeGAMClassifier(TreeGAM, ClassifierMixin):
-    ...
-
-
-if __name__ == &#34;__main__&#34;:
-    X, y, feature_names = imodels.get_clean_dataset(&#34;heart&#34;)
-    X, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
-    gam = TreeGAMClassifier(
-        boosting_strategy=&#34;cyclic&#34;,
-        random_state=42,
-        learning_rate=0.1,
-        max_leaf_nodes=3,
-        # select_linear_marginal=True,
-        # fit_linear_marginal=&#34;NNLS&#34;,
-        # n_boosting_rounds_marginal=3,
-        # decay_rate_towards_marginal=0,
-        fit_posthoc_tree_coefs=&#34;elasticnet&#34;,
-        n_boosting_rounds=100,
-    )
-    gam.fit(X, y_train)
-
-    # check roc auc score
-    y_pred = gam.predict_proba(X_test)[:, 1]
-    # print(
-    #     &#34;train roc:&#34;,
-    #     roc_auc_score(y_train, gam.predict_proba(X)[:, 1]).round(3),
-    # )
-    print(&#34;test roc:&#34;, roc_auc_score(y_test, y_pred).round(3))
-    print(&#34;test acc:&#34;, accuracy_score(y_test, gam.predict(X_test)).round(3))
-    print(&#39;\t(imb:&#39;, np.mean(y_test).round(3), &#39;)&#39;)
-    # print(
-    #     &#34;accs&#34;,
-    #     accuracy_score(y_train, gam.predict(X)).round(3),
-    #     accuracy_score(y_test, gam.predict(X_test)).round(3),
-    #     &#34;imb&#34;,
-    #     np.mean(y_train).round(3),
-    #     np.mean(y_test).round(3),
-    # )
-
-    # # print(gam.estimators_)</code></pre>
+    ...</code></pre>
 </details>
 </section>
 <section>
@@ -792,6 +752,7 @@ Random seed.</p></div>
         marginal_only: bool
             If True, only use the marginal effects.
         &#34;&#34;&#34;
+        check_predict_X(self, X)
         X = check_array(X, accept_sparse=False, dtype=None)
         check_is_fitted(self)
         probs1 = np.ones(X.shape[0]) * self.bias_
@@ -988,6 +949,7 @@ If True, only use the marginal effects.</p></div>
     marginal_only: bool
         If True, only use the marginal effects.
     &#34;&#34;&#34;
+    check_predict_X(self, X)
     X = check_array(X, accept_sparse=False, dtype=None)
     check_is_fitted(self)
     probs1 = np.ones(X.shape[0]) * self.bias_

--- a/docs/algebraic/tree_gam_minimal.html
+++ b/docs/algebraic/tree_gam_minimal.html
@@ -30,8 +30,6 @@ from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_X_y, check_is_fitted, _check_sample_weight
 from sklearn.model_selection import train_test_split
 from sklearn.base import RegressorMixin, ClassifierMixin
-from sklearn.metrics import accuracy_score, roc_auc_score
-import imodels
 
 
 class TreeGAMMinimal(BaseEstimator):
@@ -198,40 +196,7 @@ class TreeGAMMinimalRegressor(TreeGAMMinimal, RegressorMixin):
 
 
 class TreeGAMMinimalClassifier(TreeGAMMinimal, ClassifierMixin):
-    ...
-
-
-if __name__ == &#34;__main__&#34;:
-    X, y, feature_names = imodels.get_clean_dataset(&#34;heart&#34;)
-    X, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
-    gam = TreeGAMMinimalClassifier(
-        boosting_strategy=&#34;cyclic&#34;,
-        random_state=42,
-        learning_rate=0.1,
-        max_leaf_nodes=3,
-        n_boosting_rounds=100,
-    )
-    gam.fit(X, y_train)
-
-    # check roc auc score
-    y_pred = gam.predict_proba(X_test)[:, 1]
-    # print(
-    #     &#34;train roc:&#34;,
-    #     roc_auc_score(y_train, gam.predict_proba(X)[:, 1]).round(3),
-    # )
-    print(f&#34;test roc: {roc_auc_score(y_test, y_pred):.3f}&#34;)
-    print(f&#34;test acc {accuracy_score(y_test, gam.predict(X_test)):.3f}&#34;)
-    print(&#39;\t(imb:&#39;, np.mean(y_test).round(3), &#39;)&#39;)
-    # print(
-    #     &#34;accs&#34;,
-    #     accuracy_score(y_train, gam.predict(X)).round(3),
-    #     accuracy_score(y_test, gam.predict(X_test)).round(3),
-    #     &#34;imb&#34;,
-    #     np.mean(y_train).round(3),
-    #     np.mean(y_test).round(3),
-    # )
-
-    # # print(gam.estimators_)</code></pre>
+    ...</code></pre>
 </details>
 </section>
 <section>

--- a/docs/clustering/stableclustering.html
+++ b/docs/clustering/stableclustering.html
@@ -25,12 +25,9 @@
 import numpy as np
 from sklearn.base import BaseEstimator, ClusterMixin
 from sklearn.cluster import KMeans
-from sklearn.decomposition import NMF
 from sklearn.metrics import rand_score, adjusted_rand_score
-import sklearn.datasets
 from sklearn.utils.validation import check_is_fitted
 from tqdm import tqdm
-import matplotlib.pyplot as plt
 
 
 class StableClustering(BaseEstimator, ClusterMixin):
@@ -115,23 +112,7 @@ class StableClustering(BaseEstimator, ClusterMixin):
             distances_[cluster_assignments != i] = np.inf
             closest_points = np.argsort(distances_)[:n_closest]
             preds[closest_points] = i
-        return preds
-
-
-if __name__ == &#39;__main__&#39;:
-    # sample sklearn datraset
-    X_simple = sklearn.datasets.load_iris().data
-
-    stable_clustering = StableClustering(
-        k_values=[3, 4, 5, 6, 7, 8, 9, 10, 12, 15], n_repetitions=10,
-        algorithm=&#34;k-means&#34;,
-        # algorithm=&#34;nmf&#34;,
-        metric=&#34;adjusted_rand&#34;)
-    stable_clustering.fit(X_simple)
-    print(stable_clustering.scores_)  # Dictionary of scores for each k
-
-    plt.plot(list(stable_clustering.scores_.keys()), list(
-        stable_clustering.scores_.values()), &#39;.-&#39;)</code></pre>
+        return preds</code></pre>
 </details>
 </section>
 <section>

--- a/docs/discretization/mdlp.html
+++ b/docs/discretization/mdlp.html
@@ -45,7 +45,7 @@ from imodels.util.metrics import entropy, cut_point_information_gain
 
 
 class MDLPDiscretizer(object):
-    def __init__(self, dataset, class_label, out_path_data=None, out_path_bins=None, features=None):
+    def __init__(self, dataset=None, class_label=None, out_path_data=None, out_path_bins=None, features=None):
         &#39;&#39;&#39;
         initializes discretizer object:
             saves raw copy of data and creates self._data with only features to discretize and class
@@ -59,12 +59,20 @@ class MDLPDiscretizer(object):
         Params
         ------
         dataset
-            pandas dataframe with data to discretize
+            pandas dataframe with data to discretize. If None, the cut points
+            are computed later by calling fit(X, y).
         class_label
             name of the column containing class in input dataframe
         features
             if !None, features that the user wants to discretize specifically
         &#39;&#39;&#39;
+        self._out_path_data = out_path_data
+        self._out_path_bins = out_path_bins
+        self._requested_features = features
+
+        if dataset is None:  # defer the work to fit
+            self._class_name = class_label
+            return
 
         if not isinstance(dataset, pd.core.frame.DataFrame):  # class needs a pandas dataframe
             raise AttributeError(&#39;input dataset should be a pandas data frame&#39;)
@@ -231,7 +239,7 @@ class MDLPDiscretizer(object):
             return
         # determine whether to cut and where
         cut_candidate = self._best_cut_point(data=data_partition, feature=feature)
-        if cut_candidate == None:
+        if cut_candidate is None:
             return
         decision = self.MDLPC_criterion(data=data_partition, feature=feature, cut_point=cut_candidate)
 
@@ -261,6 +269,61 @@ class MDLPDiscretizer(object):
             self._single_feature_accepted_cutpoints(feature=attr)
         return
 
+    def _bin_labels(self, attr):
+        &#39;&#39;&#39;Names of the bins a feature is cut into (a feature with no accepted
+        cut point stays in one catch-all bin).
+        &#39;&#39;&#39;
+        if len(self._cuts[attr]) == 0:
+            return [&#39;All&#39;]
+        cuts = [-np.inf] + self._cuts[attr] + [np.inf]
+        return [&#39;%s_to_%s&#39; % (str(cuts[i]), str(cuts[i + 1]))
+                for i in range(len(cuts) - 1)]
+
+    def _bin_column(self, attr, column):
+        &#39;&#39;&#39;Applies this feature&#39;s cut points to any column of its values.&#39;&#39;&#39;
+        if len(self._cuts[attr]) == 0:
+            return &#39;All&#39;
+        cuts = [-np.inf] + self._cuts[attr] + [np.inf]
+        return pd.cut(x=np.asarray(column), bins=cuts, right=False,
+                      labels=self._bin_labels(attr), precision=6,
+                      include_lowest=True)
+
+    def fit(self, X, y):
+        &#39;&#39;&#39;Learns cut points for the numeric columns of X, in the sklearn style.
+
+        Equivalent to constructing with a dataset, but lets the same fitted
+        discretizer be applied to new data with transform.
+        &#39;&#39;&#39;
+        X = pd.DataFrame(X).copy()
+        X.columns = [str(c) for c in X.columns]
+        class_label = self._class_name if self._class_name is not None else &#39;y&#39;
+        while class_label in X.columns:  # don&#39;t collide with a real feature
+            class_label += &#39;_&#39;
+        X[class_label] = np.asarray(y)
+        MDLPDiscretizer.__init__(
+            self, dataset=X, class_label=class_label,
+            out_path_data=self._out_path_data,
+            out_path_bins=self._out_path_bins,
+            features=self._requested_features)
+        return self
+
+    def transform(self, X):
+        &#39;&#39;&#39;Bins X with the cut points found by fit. Columns that were not
+        discretized are passed through unchanged.
+        &#39;&#39;&#39;
+        if not hasattr(self, &#39;_cuts&#39;):
+            raise ValueError(
+                &#39;This MDLPDiscretizer is not fitted yet. Call fit before transform.&#39;)
+        X = pd.DataFrame(X).copy()
+        X.columns = [str(c) for c in X.columns]
+        for attr in self._features:
+            if attr in X.columns:
+                X[attr] = self._bin_column(attr, X[attr])
+        return X
+
+    def fit_transform(self, X, y):
+        return self.fit(X, y).transform(X)
+
     def _apply_cutpoints(self, out_data_path=None, out_bins_path=None):
         &#39;&#39;&#39;
         Discretizes data by applying bins according to self._cuts. Saves a new, discretized file, and a description of
@@ -271,16 +334,9 @@ class MDLPDiscretizer(object):
         &#39;&#39;&#39;
         bin_label_collection = {}
         for attr in self._features:
-            if len(self._cuts[attr]) == 0:
-                self._data[attr] = &#39;All&#39;
-                bin_label_collection[attr] = [&#39;All&#39;]
-            else:
-                cuts = [-np.inf] + self._cuts[attr] + [np.inf]
-                start_bin_indices = range(0, len(cuts) - 1)
-                bin_labels = [&#39;%s_to_%s&#39; % (str(cuts[i]), str(cuts[i + 1])) for i in start_bin_indices]
-                bin_label_collection[attr] = bin_labels
-                self._data[attr] = pd.cut(x=self._data[attr].values, bins=cuts, right=False, labels=bin_labels,
-                                          precision=6, include_lowest=True)
+            bin_label_collection[attr] = self._bin_labels(attr)
+            self._data[attr] = self._bin_column(attr, self._data[attr])
+        self.bin_labels_ = bin_label_collection
 
         # reconstitute full data, now discretized
         if self._ignored_features:
@@ -313,6 +369,10 @@ class BRLDiscretizer:
         # check which features are numeric (to be discretized)
         self.discretized_features = []
 
+        # _encode_strings indexes positionally, so a DataFrame has to be
+        # unwrapped here the same way transform does
+        if isinstance(X, (pd.DataFrame, pd.Series)):
+            X = X.values
         X_str_disc = self._encode_strings(X)
 
         for fi in range(X_str_disc.shape[1]):
@@ -337,7 +397,11 @@ class BRLDiscretizer:
             self.discretized_X = X_str_and_num_disc
         else:
             self.discretizer = None
-            return
+        return self
+
+    def fit_transform(self, X, y, undiscretized_features=[], return_onehot=True):
+        return self.fit(X, y, undiscretized_features).transform(
+            X, return_onehot=return_onehot)
 
     def discretize(self, X, y):
         &#39;&#39;&#39;Discretize the features specified in self.discretized_features
@@ -347,7 +411,9 @@ class BRLDiscretizer:
         D = pd.DataFrame(np.hstack((X, np.expand_dims(y, axis=1))), columns=list(self.feature_labels) + [&#34;y&#34;])
         self.discretizer = MDLPDiscretizer(dataset=D, class_label=&#34;y&#34;, features=self.discretized_features)
 
-        cat_data = pd.DataFrame(np.zeros_like(X))
+        # object dtype: the columns are filled with bin-label strings, which
+        # pandas refuses to write into the float frame np.zeros_like would give
+        cat_data = pd.DataFrame(np.zeros(np.shape(X), dtype=object))
         for i in range(len(self.feature_labels)):
             label = self.feature_labels[i]
             if label in self.discretized_features:
@@ -455,6 +521,10 @@ class BRLDiscretizer:
         # check which features are numeric (to be discretized)
         self.discretized_features = []
 
+        # _encode_strings indexes positionally, so a DataFrame has to be
+        # unwrapped here the same way transform does
+        if isinstance(X, (pd.DataFrame, pd.Series)):
+            X = X.values
         X_str_disc = self._encode_strings(X)
 
         for fi in range(X_str_disc.shape[1]):
@@ -479,7 +549,11 @@ class BRLDiscretizer:
             self.discretized_X = X_str_and_num_disc
         else:
             self.discretizer = None
-            return
+        return self
+
+    def fit_transform(self, X, y, undiscretized_features=[], return_onehot=True):
+        return self.fit(X, y, undiscretized_features).transform(
+            X, return_onehot=return_onehot)
 
     def discretize(self, X, y):
         &#39;&#39;&#39;Discretize the features specified in self.discretized_features
@@ -489,7 +563,9 @@ class BRLDiscretizer:
         D = pd.DataFrame(np.hstack((X, np.expand_dims(y, axis=1))), columns=list(self.feature_labels) + [&#34;y&#34;])
         self.discretizer = MDLPDiscretizer(dataset=D, class_label=&#34;y&#34;, features=self.discretized_features)
 
-        cat_data = pd.DataFrame(np.zeros_like(X))
+        # object dtype: the columns are filled with bin-label strings, which
+        # pandas refuses to write into the float frame np.zeros_like would give
+        cat_data = pd.DataFrame(np.zeros(np.shape(X), dtype=object))
         for i in range(len(self.feature_labels)):
             label = self.feature_labels[i]
             if label in self.discretized_features:
@@ -612,7 +688,9 @@ def onehot_df(self):
     D = pd.DataFrame(np.hstack((X, np.expand_dims(y, axis=1))), columns=list(self.feature_labels) + [&#34;y&#34;])
     self.discretizer = MDLPDiscretizer(dataset=D, class_label=&#34;y&#34;, features=self.discretized_features)
 
-    cat_data = pd.DataFrame(np.zeros_like(X))
+    # object dtype: the columns are filled with bin-label strings, which
+    # pandas refuses to write into the float frame np.zeros_like would give
+    cat_data = pd.DataFrame(np.zeros(np.shape(X), dtype=object))
     for i in range(len(self.feature_labels)):
         label = self.feature_labels[i]
         if label in self.discretized_features:
@@ -638,6 +716,10 @@ def onehot_df(self):
     # check which features are numeric (to be discretized)
     self.discretized_features = []
 
+    # _encode_strings indexes positionally, so a DataFrame has to be
+    # unwrapped here the same way transform does
+    if isinstance(X, (pd.DataFrame, pd.Series)):
+        X = X.values
     X_str_disc = self._encode_strings(X)
 
     for fi in range(X_str_disc.shape[1]):
@@ -662,7 +744,21 @@ def onehot_df(self):
         self.discretized_X = X_str_and_num_disc
     else:
         self.discretizer = None
-        return</code></pre>
+    return self</code></pre>
+</details>
+</dd>
+<dt id="imodels.discretization.mdlp.BRLDiscretizer.fit_transform"><code class="name flex">
+<span>def <span class="ident">fit_transform</span></span>(<span>self, X, y, undiscretized_features=[], return_onehot=True)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def fit_transform(self, X, y, undiscretized_features=[], return_onehot=True):
+    return self.fit(X, y, undiscretized_features).transform(
+        X, return_onehot=return_onehot)</code></pre>
 </details>
 </dd>
 <dt id="imodels.discretization.mdlp.BRLDiscretizer.get_onehot_df"><code class="name flex">
@@ -726,7 +822,7 @@ def onehot_df(self):
 </dd>
 <dt id="imodels.discretization.mdlp.MDLPDiscretizer"><code class="flex name class">
 <span>class <span class="ident">MDLPDiscretizer</span></span>
-<span>(</span><span>dataset, class_label, out_path_data=None, out_path_bins=None, features=None)</span>
+<span>(</span><span>dataset=None, class_label=None, out_path_data=None, out_path_bins=None, features=None)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>initializes discretizer object:
@@ -739,7 +835,8 @@ self._data = partition of data with only features of interest and class
 self._cuts = dictionary with cut points for each feature</p>
 <h2 id="params">Params</h2>
 <p>dataset
-pandas dataframe with data to discretize
+pandas dataframe with data to discretize. If None, the cut points
+are computed later by calling fit(X, y).
 class_label
 name of the column containing class in input dataframe
 features
@@ -749,7 +846,7 @@ if !None, features that the user wants to discretize specifically</p></div>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">class MDLPDiscretizer(object):
-    def __init__(self, dataset, class_label, out_path_data=None, out_path_bins=None, features=None):
+    def __init__(self, dataset=None, class_label=None, out_path_data=None, out_path_bins=None, features=None):
         &#39;&#39;&#39;
         initializes discretizer object:
             saves raw copy of data and creates self._data with only features to discretize and class
@@ -763,12 +860,20 @@ if !None, features that the user wants to discretize specifically</p></div>
         Params
         ------
         dataset
-            pandas dataframe with data to discretize
+            pandas dataframe with data to discretize. If None, the cut points
+            are computed later by calling fit(X, y).
         class_label
             name of the column containing class in input dataframe
         features
             if !None, features that the user wants to discretize specifically
         &#39;&#39;&#39;
+        self._out_path_data = out_path_data
+        self._out_path_bins = out_path_bins
+        self._requested_features = features
+
+        if dataset is None:  # defer the work to fit
+            self._class_name = class_label
+            return
 
         if not isinstance(dataset, pd.core.frame.DataFrame):  # class needs a pandas dataframe
             raise AttributeError(&#39;input dataset should be a pandas data frame&#39;)
@@ -935,7 +1040,7 @@ if !None, features that the user wants to discretize specifically</p></div>
             return
         # determine whether to cut and where
         cut_candidate = self._best_cut_point(data=data_partition, feature=feature)
-        if cut_candidate == None:
+        if cut_candidate is None:
             return
         decision = self.MDLPC_criterion(data=data_partition, feature=feature, cut_point=cut_candidate)
 
@@ -965,6 +1070,61 @@ if !None, features that the user wants to discretize specifically</p></div>
             self._single_feature_accepted_cutpoints(feature=attr)
         return
 
+    def _bin_labels(self, attr):
+        &#39;&#39;&#39;Names of the bins a feature is cut into (a feature with no accepted
+        cut point stays in one catch-all bin).
+        &#39;&#39;&#39;
+        if len(self._cuts[attr]) == 0:
+            return [&#39;All&#39;]
+        cuts = [-np.inf] + self._cuts[attr] + [np.inf]
+        return [&#39;%s_to_%s&#39; % (str(cuts[i]), str(cuts[i + 1]))
+                for i in range(len(cuts) - 1)]
+
+    def _bin_column(self, attr, column):
+        &#39;&#39;&#39;Applies this feature&#39;s cut points to any column of its values.&#39;&#39;&#39;
+        if len(self._cuts[attr]) == 0:
+            return &#39;All&#39;
+        cuts = [-np.inf] + self._cuts[attr] + [np.inf]
+        return pd.cut(x=np.asarray(column), bins=cuts, right=False,
+                      labels=self._bin_labels(attr), precision=6,
+                      include_lowest=True)
+
+    def fit(self, X, y):
+        &#39;&#39;&#39;Learns cut points for the numeric columns of X, in the sklearn style.
+
+        Equivalent to constructing with a dataset, but lets the same fitted
+        discretizer be applied to new data with transform.
+        &#39;&#39;&#39;
+        X = pd.DataFrame(X).copy()
+        X.columns = [str(c) for c in X.columns]
+        class_label = self._class_name if self._class_name is not None else &#39;y&#39;
+        while class_label in X.columns:  # don&#39;t collide with a real feature
+            class_label += &#39;_&#39;
+        X[class_label] = np.asarray(y)
+        MDLPDiscretizer.__init__(
+            self, dataset=X, class_label=class_label,
+            out_path_data=self._out_path_data,
+            out_path_bins=self._out_path_bins,
+            features=self._requested_features)
+        return self
+
+    def transform(self, X):
+        &#39;&#39;&#39;Bins X with the cut points found by fit. Columns that were not
+        discretized are passed through unchanged.
+        &#39;&#39;&#39;
+        if not hasattr(self, &#39;_cuts&#39;):
+            raise ValueError(
+                &#39;This MDLPDiscretizer is not fitted yet. Call fit before transform.&#39;)
+        X = pd.DataFrame(X).copy()
+        X.columns = [str(c) for c in X.columns]
+        for attr in self._features:
+            if attr in X.columns:
+                X[attr] = self._bin_column(attr, X[attr])
+        return X
+
+    def fit_transform(self, X, y):
+        return self.fit(X, y).transform(X)
+
     def _apply_cutpoints(self, out_data_path=None, out_bins_path=None):
         &#39;&#39;&#39;
         Discretizes data by applying bins according to self._cuts. Saves a new, discretized file, and a description of
@@ -975,16 +1135,9 @@ if !None, features that the user wants to discretize specifically</p></div>
         &#39;&#39;&#39;
         bin_label_collection = {}
         for attr in self._features:
-            if len(self._cuts[attr]) == 0:
-                self._data[attr] = &#39;All&#39;
-                bin_label_collection[attr] = [&#39;All&#39;]
-            else:
-                cuts = [-np.inf] + self._cuts[attr] + [np.inf]
-                start_bin_indices = range(0, len(cuts) - 1)
-                bin_labels = [&#39;%s_to_%s&#39; % (str(cuts[i]), str(cuts[i + 1])) for i in start_bin_indices]
-                bin_label_collection[attr] = bin_labels
-                self._data[attr] = pd.cut(x=self._data[attr].values, bins=cuts, right=False, labels=bin_labels,
-                                          precision=6, include_lowest=True)
+            bin_label_collection[attr] = self._bin_labels(attr)
+            self._data[attr] = self._bin_column(attr, self._data[attr])
+        self.bin_labels_ = bin_label_collection
 
         # reconstitute full data, now discretized
         if self._ignored_features:
@@ -1055,6 +1208,75 @@ if !None, features that the user wants to discretize specifically</p></div>
         return False</code></pre>
 </details>
 </dd>
+<dt id="imodels.discretization.mdlp.MDLPDiscretizer.fit"><code class="name flex">
+<span>def <span class="ident">fit</span></span>(<span>self, X, y)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Learns cut points for the numeric columns of X, in the sklearn style.</p>
+<p>Equivalent to constructing with a dataset, but lets the same fitted
+discretizer be applied to new data with transform.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def fit(self, X, y):
+    &#39;&#39;&#39;Learns cut points for the numeric columns of X, in the sklearn style.
+
+    Equivalent to constructing with a dataset, but lets the same fitted
+    discretizer be applied to new data with transform.
+    &#39;&#39;&#39;
+    X = pd.DataFrame(X).copy()
+    X.columns = [str(c) for c in X.columns]
+    class_label = self._class_name if self._class_name is not None else &#39;y&#39;
+    while class_label in X.columns:  # don&#39;t collide with a real feature
+        class_label += &#39;_&#39;
+    X[class_label] = np.asarray(y)
+    MDLPDiscretizer.__init__(
+        self, dataset=X, class_label=class_label,
+        out_path_data=self._out_path_data,
+        out_path_bins=self._out_path_bins,
+        features=self._requested_features)
+    return self</code></pre>
+</details>
+</dd>
+<dt id="imodels.discretization.mdlp.MDLPDiscretizer.fit_transform"><code class="name flex">
+<span>def <span class="ident">fit_transform</span></span>(<span>self, X, y)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def fit_transform(self, X, y):
+    return self.fit(X, y).transform(X)</code></pre>
+</details>
+</dd>
+<dt id="imodels.discretization.mdlp.MDLPDiscretizer.transform"><code class="name flex">
+<span>def <span class="ident">transform</span></span>(<span>self, X)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Bins X with the cut points found by fit. Columns that were not
+discretized are passed through unchanged.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def transform(self, X):
+    &#39;&#39;&#39;Bins X with the cut points found by fit. Columns that were not
+    discretized are passed through unchanged.
+    &#39;&#39;&#39;
+    if not hasattr(self, &#39;_cuts&#39;):
+        raise ValueError(
+            &#39;This MDLPDiscretizer is not fitted yet. Call fit before transform.&#39;)
+    X = pd.DataFrame(X).copy()
+    X.columns = [str(c) for c in X.columns]
+    for attr in self._features:
+        if attr in X.columns:
+            X[attr] = self._bin_column(attr, X[attr])
+    return X</code></pre>
+</details>
+</dd>
 </dl>
 </dd>
 </dl>
@@ -1081,6 +1303,7 @@ if !None, features that the user wants to discretize specifically</p></div>
 <li><code><a title="imodels.discretization.mdlp.BRLDiscretizer.data" href="#imodels.discretization.mdlp.BRLDiscretizer.data">data</a></code></li>
 <li><code><a title="imodels.discretization.mdlp.BRLDiscretizer.discretize" href="#imodels.discretization.mdlp.BRLDiscretizer.discretize">discretize</a></code></li>
 <li><code><a title="imodels.discretization.mdlp.BRLDiscretizer.fit" href="#imodels.discretization.mdlp.BRLDiscretizer.fit">fit</a></code></li>
+<li><code><a title="imodels.discretization.mdlp.BRLDiscretizer.fit_transform" href="#imodels.discretization.mdlp.BRLDiscretizer.fit_transform">fit_transform</a></code></li>
 <li><code><a title="imodels.discretization.mdlp.BRLDiscretizer.get_onehot_df" href="#imodels.discretization.mdlp.BRLDiscretizer.get_onehot_df">get_onehot_df</a></code></li>
 <li><code><a title="imodels.discretization.mdlp.BRLDiscretizer.onehot_df" href="#imodels.discretization.mdlp.BRLDiscretizer.onehot_df">onehot_df</a></code></li>
 <li><code><a title="imodels.discretization.mdlp.BRLDiscretizer.transform" href="#imodels.discretization.mdlp.BRLDiscretizer.transform">transform</a></code></li>
@@ -1090,6 +1313,9 @@ if !None, features that the user wants to discretize specifically</p></div>
 <h4><code><a title="imodels.discretization.mdlp.MDLPDiscretizer" href="#imodels.discretization.mdlp.MDLPDiscretizer">MDLPDiscretizer</a></code></h4>
 <ul class="">
 <li><code><a title="imodels.discretization.mdlp.MDLPDiscretizer.MDLPC_criterion" href="#imodels.discretization.mdlp.MDLPDiscretizer.MDLPC_criterion">MDLPC_criterion</a></code></li>
+<li><code><a title="imodels.discretization.mdlp.MDLPDiscretizer.fit" href="#imodels.discretization.mdlp.MDLPDiscretizer.fit">fit</a></code></li>
+<li><code><a title="imodels.discretization.mdlp.MDLPDiscretizer.fit_transform" href="#imodels.discretization.mdlp.MDLPDiscretizer.fit_transform">fit_transform</a></code></li>
+<li><code><a title="imodels.discretization.mdlp.MDLPDiscretizer.transform" href="#imodels.discretization.mdlp.MDLPDiscretizer.transform">transform</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/experimental/bartpy/diagnostics/diagnostics.html
+++ b/docs/experimental/bartpy/diagnostics/diagnostics.html
@@ -21,21 +21,13 @@
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">import numpy as np
-import pandas as pd
-from imodels import FIGSRegressor
-from matplotlib import pyplot as plt
-from sklearn import datasets, model_selection
-from sklearn.ensemble import GradientBoostingRegressor
-from sklearn.metrics import mean_squared_error
+<pre><code class="python">from matplotlib import pyplot as plt
 
-from imodels.util.tree_interaction_utils import get_interacting_features
 from ..diagnostics.residuals import plot_qq, plot_homoscedasticity_diagnostics
-from ..diagnostics.sampling import plot_tree_mutation_acceptance_rate, plot_tree_likelihood, plot_tree_probs
+from ..diagnostics.sampling import plot_tree_mutation_acceptance_rate
 from ..diagnostics.sigma import plot_sigma_convergence
 from ..diagnostics.trees import plot_tree_depth
-from ..initializers.sklearntreeinitializer import SklearnTreeInitializer
-from ..sklearnmodel import SklearnModel, BART
+from ..sklearnmodel import SklearnModel
 
 
 def plot_diagnostics(model: SklearnModel):
@@ -49,71 +41,7 @@ def plot_diagnostics(model: SklearnModel):
     # plot_tree_likelihood(model, ax6)
     # plot_tree_probs(model, ax7)
 
-    plt.show()
-
-
-if __name__ == &#39;__main__&#39;:
-
-    n = 100
-    n_trees = 1
-    # X, y = datasets.make_friedman1(n)
-    x_1 = np.random.choice([2, 3, 5, 7, 8], size=n)
-    x_2 = np.random.choice([1, 2, 3, 4], size=n)
-    X = pd.DataFrame([x_1, x_2]).T
-
-
-    def _f(x):
-        x_1 = x[0]
-        x_2 = x[1]
-
-        if np.logical_and(x_1 &lt;= 5, x_2 in [1, 3]):
-            return 8
-        elif np.logical_and(x_1 &gt; 5, x_2 in [1, 3]):
-            return 2
-        elif np.logical_and(x_1 &lt;= 3, x_2 in [2, 4]):
-            return 1
-        elif np.logical_and(3 &lt; x_1 &lt;= 7, x_2 in [2, 4]):
-            return 5
-        elif np.logical_and(x_1 &gt; 7, x_2 in [2, 4]):
-            return 8
-
-
-    y = np.array([_f(X.iloc[i, :]) for i in range(n)]) + np.random.normal(size=n, scale=0.1)
-
-    X_train, X_test, y_train, y_test = model_selection.train_test_split(
-        X, y, test_size=0.3, random_state=4)
-
-    bart_zero = BART(classification=False, store_acceptance_trace=True, n_trees=n_trees, n_samples=10000, n_burn=100,
-                     n_chains=5,
-                     thin=1)
-    bart_zero.fit(X_train, y_train)
-
-    # bart_figs = BART(classification=False, store_acceptance_trace=True, n_trees=n_trees, n_samples=1000, n_burn=100,
-    #                  n_chains=5,
-    #                  thin=1, initializer=SklearnTreeInitializer(tree_=figs))
-    #
-    # bart_figs.fit(X_train, y_train)
-
-    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 10))
-    fig, ax = plt.subplots(1)
-    bart_preds = bart_zero.predict(X_test)
-    # bart_figs_preds = bart_figs.predict(X_test)
-    # figs_preds = figs.predict(X_test)
-    # # print(f&#34;figs: {mean_squared_error(figs_preds, y_test)}&#34;)
-    # bfigs_preds = bart_figs.predict(X_test)
-    # print(f&#34;bfigs: {mean_squared_error(bfigs_preds, y_test)}&#34;)
-
-    # plot_tree_depth(bart_sgb, ax1, f&#34;CART initialization {np.round(mean_squared_error(bart_sgb_preds, y_test), 4)}&#34;)
-    plot_tree_depth(bart_zero, ax, f&#34;BART initialization (MSE: {np.round(mean_squared_error(bart_preds, y_test), 4)})&#34;)
-    # plot_tree_depth(bart_figs, ax2,
-    #                 f&#34;FIGS initialization (MSE: {np.round(mean_squared_error(bart_figs_preds, y_test), 4)}&#34;
-    #                 f&#34;, FIGS MSE: {np.round(mean_squared_error(figs_preds, y_test), 2)})&#34;, x_label=True)
-    # plt.title(f&#34;Bayesian tree with different initialization of Friedman 1 dataset n={n}&#34;)
-
-    plt.show()
-
-    # y_hat = bart.predict(X)
-    # plot_diagnostics(bart)</code></pre>
+    plt.show()</code></pre>
 </details>
 </section>
 <section>

--- a/docs/experimental/bartpy/diagnostics/motivation.html
+++ b/docs/experimental/bartpy/diagnostics/motivation.html
@@ -27,16 +27,14 @@ import os
 from functools import partial
 
 import numpy as np
-import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib import cm
 from tqdm import tqdm
-from sklearn import model_selection, datasets
+from sklearn import model_selection
 from sklearn.metrics import mean_squared_error
 
 from imodels import get_clean_dataset
 from imodels.experimental.bartpy.model import Model
-from imodels.experimental.bartpy.tree import Tree
 from ..sklearnmodel import BART, SklearnModel
 
 ART_PATH = &#34;/accounts/campus/omer_ronen/projects/tree_shrink/imodels/art&#34;
@@ -213,11 +211,7 @@ def main():
             plt.suptitle(title)
 
             plt.savefig(os.path.join(ART_PATH, &#34;functional&#34;, f&#34;{d[0]}_samples_{n_samples}.png&#34;))
-            plt.close()
-
-
-if __name__ == &#39;__main__&#39;:
-    main()</code></pre>
+            plt.close()</code></pre>
 </details>
 </section>
 <section>

--- a/docs/experimental/bartpy/initializers/sklearntreeinitializer.html
+++ b/docs/experimental/bartpy/initializers/sklearntreeinitializer.html
@@ -21,13 +21,12 @@
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">from typing import Tuple, List
+<pre><code class="python">from typing import Tuple
 from operator import gt, le
 
 import numpy as np
 from sklearn.ensemble import GradientBoostingRegressor, RandomForestRegressor
 from imodels.tree.figs import FIGSRegressor, Node, FIGSRegressorCV
-from sklearn.exceptions import NotFittedError
 from sklearn.tree import DecisionTreeRegressor
 
 from ..data import make_bartpy_data

--- a/docs/experimental/bartpy/model.html
+++ b/docs/experimental/bartpy/model.html
@@ -21,7 +21,7 @@
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">from copy import deepcopy, copy
+<pre><code class="python">from copy import deepcopy
 from typing import List, Generator, Optional
 from imodels.util.checks import check_is_fitted
 

--- a/docs/experimental/bartpy/node.html
+++ b/docs/experimental/bartpy/node.html
@@ -21,7 +21,7 @@
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">from typing import Union, Tuple
+<pre><code class="python">from typing import Tuple
 
 from .data import Data
 from .split import Split, SplitCondition

--- a/docs/experimental/bartpy/samplers/leafnode.html
+++ b/docs/experimental/bartpy/samplers/leafnode.html
@@ -21,9 +21,7 @@
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">import numpy as np
-
-from ..model import Model
+<pre><code class="python">from ..model import Model
 from ..node import LeafNode
 from ..samplers.sampler import Sampler
 from ..samplers.scalar import NormalScalarSampler

--- a/docs/experimental/bartpy/samplers/modelsampler.html
+++ b/docs/experimental/bartpy/samplers/modelsampler.html
@@ -26,7 +26,6 @@ from collections import defaultdict
 from typing import List, Mapping, Union, Any, Type
 
 import numpy as np
-from tqdm import tqdm
 
 from ..model import Model
 from ..samplers.sampler import Sampler

--- a/docs/experimental/bartpy/samplers/oblivioustrees/proposer.html
+++ b/docs/experimental/bartpy/samplers/oblivioustrees/proposer.html
@@ -22,9 +22,8 @@
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">from operator import le, gt
-from typing import Callable, List, Mapping, Optional, Tuple
+from typing import List, Optional, Tuple
 
-import numpy as np
 
 from ...errors import NoSplittableVariableException, NoPrunableNodeException
 from ...mutation import TreeMutation, GrowMutation, PruneMutation

--- a/docs/experimental/bartpy/samplers/schedule.html
+++ b/docs/experimental/bartpy/samplers/schedule.html
@@ -23,8 +23,6 @@
 </summary>
 <pre><code class="python">from typing import Callable, Generator, Text, Tuple
 
-import numpy as np
-import pandas as pd
 
 from ..model import Model
 from ..samplers.leafnode import LeafNodeSampler

--- a/docs/experimental/bartpy/sklearnmodel.html
+++ b/docs/experimental/bartpy/sklearnmodel.html
@@ -25,7 +25,6 @@
 from copy import deepcopy
 from typing import List, Callable, Mapping, Union, Optional
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import scipy.stats
@@ -33,9 +32,8 @@ from joblib import Parallel, delayed
 from sklearn.base import RegressorMixin, BaseEstimator
 from sklearn.metrics import mean_squared_error
 from sklearn.model_selection import cross_val_score
-from sklearn.tree import DecisionTreeClassifier
 from sklearn import datasets, model_selection
-from imodels.util.arguments import set_feature_names_in
+from imodels.util.arguments import check_predict_X, set_feature_names_in
 
 from .data import Data
 from .initializers.initializer import Initializer
@@ -269,6 +267,11 @@ class SklearnModel(BaseEstimator, RegressorMixin):
             self with trained parameter values
         &#34;&#34;&#34;
         set_feature_names_in(self, X)
+        # X/y may arrive as plain lists, which the model code indexes as arrays
+        if not hasattr(X, &#39;shape&#39;) and not hasattr(X, &#39;values&#39;):
+            X = np.asarray(X)
+        if not hasattr(y, &#39;shape&#39;) and not hasattr(y, &#39;values&#39;):
+            y = np.asarray(y)
         self.n_features_in_ = np.asarray(X).shape[1]
         self.model = self._construct_model(X, y)
         self.extract = Parallel(n_jobs=self.n_jobs)(self.f_delayed_chains(X, y))
@@ -382,12 +385,15 @@ class SklearnModel(BaseEstimator, RegressorMixin):
             raise ValueError(
                 &#34;In sample predictions only possible if model.store_in_sample_predictions is `True`.  Either set the parameter to True or pass a non-None X parameter&#34;)
         else:
+            check_predict_X(self, X)
             predictions = self._out_of_sample_predict(X)
             if self.classification:
                 return np.round(predictions, 0)
             return predictions
 
     def predict_proba(self, X: np.ndarray = None) -&gt; np.ndarray:
+        if X is not None:
+            check_predict_X(self, X)
         preds = self._out_of_sample_predict(X)
         return np.stack([preds, 1 - preds], axis=1)
 
@@ -488,6 +494,9 @@ class SklearnModel(BaseEstimator, RegressorMixin):
         return total_var - within_chain_var
 
     def _out_of_sample_predict(self, X):
+        # the samples index X by (row, column), so a plain list will not do
+        if X is not None and not hasattr(X, &#39;shape&#39;) and not hasattr(X, &#39;values&#39;):
+            X = np.asarray(X)
         samples = self._model_samples
         predictions_transformed = [x.predict(X) for x in samples]
         predictions = self.data.y.unnormalize_y(np.mean(predictions_transformed, axis=0))
@@ -797,11 +806,7 @@ def main():
     # # plt.show()
     # #
     # # plt.close()
-    #
-
-
-if __name__ == &#39;__main__&#39;:
-    main()</code></pre>
+    #</code></pre>
 </details>
 </section>
 <section>
@@ -1872,6 +1877,11 @@ set to <code>-1</code> to use all cores</dd>
             self with trained parameter values
         &#34;&#34;&#34;
         set_feature_names_in(self, X)
+        # X/y may arrive as plain lists, which the model code indexes as arrays
+        if not hasattr(X, &#39;shape&#39;) and not hasattr(X, &#39;values&#39;):
+            X = np.asarray(X)
+        if not hasattr(y, &#39;shape&#39;) and not hasattr(y, &#39;values&#39;):
+            y = np.asarray(y)
         self.n_features_in_ = np.asarray(X).shape[1]
         self.model = self._construct_model(X, y)
         self.extract = Parallel(n_jobs=self.n_jobs)(self.f_delayed_chains(X, y))
@@ -1985,12 +1995,15 @@ set to <code>-1</code> to use all cores</dd>
             raise ValueError(
                 &#34;In sample predictions only possible if model.store_in_sample_predictions is `True`.  Either set the parameter to True or pass a non-None X parameter&#34;)
         else:
+            check_predict_X(self, X)
             predictions = self._out_of_sample_predict(X)
             if self.classification:
                 return np.round(predictions, 0)
             return predictions
 
     def predict_proba(self, X: np.ndarray = None) -&gt; np.ndarray:
+        if X is not None:
+            check_predict_X(self, X)
         preds = self._out_of_sample_predict(X)
         return np.stack([preds, 1 - preds], axis=1)
 
@@ -2091,6 +2104,9 @@ set to <code>-1</code> to use all cores</dd>
         return total_var - within_chain_var
 
     def _out_of_sample_predict(self, X):
+        # the samples index X by (row, column), so a plain list will not do
+        if X is not None and not hasattr(X, &#39;shape&#39;) and not hasattr(X, &#39;values&#39;):
+            X = np.asarray(X)
         samples = self._model_samples
         predictions_transformed = [x.predict(X) for x in samples]
         predictions = self.data.y.unnormalize_y(np.mean(predictions_transformed, axis=0))
@@ -2558,6 +2574,11 @@ e.g. when calculating a null distribution for feature importance</p>
         self with trained parameter values
     &#34;&#34;&#34;
     set_feature_names_in(self, X)
+    # X/y may arrive as plain lists, which the model code indexes as arrays
+    if not hasattr(X, &#39;shape&#39;) and not hasattr(X, &#39;values&#39;):
+        X = np.asarray(X)
+    if not hasattr(y, &#39;shape&#39;) and not hasattr(y, &#39;values&#39;):
+        y = np.asarray(y)
     self.n_features_in_ = np.asarray(X).shape[1]
     self.model = self._construct_model(X, y)
     self.extract = Parallel(n_jobs=self.n_jobs)(self.f_delayed_chains(X, y))
@@ -2723,6 +2744,7 @@ If X is None, will predict based on training covariates</p>
         raise ValueError(
             &#34;In sample predictions only possible if model.store_in_sample_predictions is `True`.  Either set the parameter to True or pass a non-None X parameter&#34;)
     else:
+        check_predict_X(self, X)
         predictions = self._out_of_sample_predict(X)
         if self.classification:
             return np.round(predictions, 0)
@@ -2756,6 +2778,8 @@ If X is None, will predict based on training covariates</p>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def predict_proba(self, X: np.ndarray = None) -&gt; np.ndarray:
+    if X is not None:
+        check_predict_X(self, X)
     preds = self._out_of_sample_predict(X)
     return np.stack([preds, 1 - preds], axis=1)</code></pre>
 </details>

--- a/docs/experimental/bartpy/split.html
+++ b/docs/experimental/bartpy/split.html
@@ -21,8 +21,7 @@
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">from copy import deepcopy
-from typing import List, Optional
+<pre><code class="python">from typing import Optional
 
 import numpy as np
 

--- a/docs/experimental/bartpy/splitcondition.html
+++ b/docs/experimental/bartpy/splitcondition.html
@@ -22,7 +22,7 @@
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">from operator import le, gt
-from typing import Callable, List, Optional, Union
+from typing import Callable, List
 
 import numpy as np
 

--- a/docs/experimental/figs_ensembles.html
+++ b/docs/experimental/figs_ensembles.html
@@ -25,11 +25,9 @@
 
 import numpy as np
 from matplotlib import pyplot as plt
-from sklearn import datasets
 from sklearn import tree
 from sklearn.base import BaseEstimator
 from sklearn.linear_model import RidgeCV, RidgeClassifierCV
-from sklearn.model_selection import train_test_split
 from sklearn.tree import plot_tree
 from sklearn.utils import check_X_y
 
@@ -151,15 +149,6 @@ class FIGSExt(BaseEstimator):
         &#34;&#34;&#34;
         self.prediction_task = &#39;regression&#39;
 
-    def _init_decision_function(self):
-        &#34;&#34;&#34;Sets decision function based on prediction_task
-        &#34;&#34;&#34;
-        # used by sklearn GridSearchCV, BaggingClassifier
-        if self.prediction_task == &#39;classification&#39;:
-            def decision_function(x): return self.predict_proba(x)[:, 1]
-        elif self.prediction_task == &#39;regression&#39;:
-            decision_function = self.predict
-
     def _construct_node_linear(self, X, y, idxs, tree_num=0, sample_weight=None):
         &#34;&#34;&#34;This can be made a lot faster
         Assumes there are at least 5 points in node
@@ -452,8 +441,8 @@ class FIGSExt(BaseEstimator):
             X_feats = self._extract_tree_predictions(X)
             return self.weighted_model_.predict(X_feats)
         preds = np.zeros(X.shape[0])
-        for tree in self.trees_:
-            preds += self._predict_tree(tree, X)
+        for figs_tree in self.trees_:
+            preds += self._predict_tree(figs_tree, X)
         if self.prediction_task == &#39;regression&#39;:
             return preds
         elif self.prediction_task == &#39;classification&#39;:
@@ -470,8 +459,8 @@ class FIGSExt(BaseEstimator):
             return np.vstack((1 - probs, probs)).transpose()
         else:
             preds = np.zeros(X.shape[0])
-            for tree in self.trees_:
-                preds += self._predict_tree(tree, X)
+            for figs_tree in self.trees_:
+                preds += self._predict_tree(figs_tree, X)
             # constrain to range of probabilities
             preds = np.clip(preds, a_min=0., a_max=1.)
             return np.vstack((1 - preds, preds)).transpose()
@@ -517,27 +506,17 @@ class FIGSExt(BaseEstimator):
     def plot(self, cols=2, feature_names=None, filename=None, label=&#34;all&#34;,
              impurity=False, tree_number=None, dpi=150, fig_size=None):
         is_single_tree = len(self.trees_) &lt; 2 or tree_number is not None
-        n_cols = int(cols)
-        n_rows = int(np.ceil(len(self.trees_) / n_cols))
-        # if is_single_tree:
-        #     fig, ax = plt.subplots(1)
-        # else:
-        #     fig, axs = plt.subplots(n_rows, n_cols)
         n_plots = int(len(self.trees_)) if tree_number is None else 1
-        fig, axs = plt.subplots(n_plots, dpi=dpi)
+        n_cols = 1 if is_single_tree else max(1, min(int(cols), n_plots))
+        n_rows = int(np.ceil(n_plots / n_cols))
+        fig, axs = plt.subplots(n_rows, n_cols, dpi=dpi, squeeze=False)
         if fig_size is not None:
             fig.set_size_inches(fig_size, fig_size)
-        criterion = &#34;squared_error&#34; if self.prediction_task == &#34;regression&#34; else &#34;gini&#34;
+        for ax in axs.flat[n_plots:]:
+            ax.axis(&#34;off&#34;)
         n_classes = 1 if self.prediction_task == &#39;regression&#39; else 2
-        ax_size = int(len(self.trees_))  # n_cols * n_rows
         for i in range(n_plots):
-            r = i // n_cols
-            c = i % n_cols
-            if not is_single_tree:
-                # ax = axs[r, c]
-                ax = axs[i]
-            else:
-                ax = axs
+            ax = axs.flat[i]
             try:
                 dt = extract_sklearn_tree_from_figs(
                     self, i if tree_number is None else tree_number, n_classes)
@@ -561,26 +540,7 @@ class FIGSExtRegressor(FIGSExt):
 
 class FIGSExtClassifier(FIGSExt):
     def _init_prediction_task(self):
-        self.prediction_task = &#39;classification&#39;
-
-
-if __name__ == &#39;__main__&#39;:
-    np.random.seed(13)
-    # X, y = datasets.load_breast_cancer(return_X_y=True)  # binary classification
-    X, y = datasets.load_diabetes(return_X_y=True)  # regression
-    # X = np.random.randn(500, 10)
-    # y = (X[:, 0] &gt; 0).astype(float) + (X[:, 1] &gt; 1).astype(float)
-
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.33, random_state=42
-    )
-    print(&#39;X.shape&#39;, X.shape)
-    print(&#39;ys&#39;, np.unique(y_train), &#39;\n\n&#39;)
-
-    m = FIGSExtClassifier(max_rules=50)
-    m.fit(X_train, y_train)
-    print(m.predict_proba(X_train))
-    m.plot(2, tree_number=0)</code></pre>
+        self.prediction_task = &#39;classification&#39;</code></pre>
 </details>
 </section>
 <section>
@@ -651,15 +611,6 @@ tree-growing phase</p></div>
         &#34;&#34;&#34;
         self.prediction_task = &#39;regression&#39;
 
-    def _init_decision_function(self):
-        &#34;&#34;&#34;Sets decision function based on prediction_task
-        &#34;&#34;&#34;
-        # used by sklearn GridSearchCV, BaggingClassifier
-        if self.prediction_task == &#39;classification&#39;:
-            def decision_function(x): return self.predict_proba(x)[:, 1]
-        elif self.prediction_task == &#39;regression&#39;:
-            decision_function = self.predict
-
     def _construct_node_linear(self, X, y, idxs, tree_num=0, sample_weight=None):
         &#34;&#34;&#34;This can be made a lot faster
         Assumes there are at least 5 points in node
@@ -952,8 +903,8 @@ tree-growing phase</p></div>
             X_feats = self._extract_tree_predictions(X)
             return self.weighted_model_.predict(X_feats)
         preds = np.zeros(X.shape[0])
-        for tree in self.trees_:
-            preds += self._predict_tree(tree, X)
+        for figs_tree in self.trees_:
+            preds += self._predict_tree(figs_tree, X)
         if self.prediction_task == &#39;regression&#39;:
             return preds
         elif self.prediction_task == &#39;classification&#39;:
@@ -970,8 +921,8 @@ tree-growing phase</p></div>
             return np.vstack((1 - probs, probs)).transpose()
         else:
             preds = np.zeros(X.shape[0])
-            for tree in self.trees_:
-                preds += self._predict_tree(tree, X)
+            for figs_tree in self.trees_:
+                preds += self._predict_tree(figs_tree, X)
             # constrain to range of probabilities
             preds = np.clip(preds, a_min=0., a_max=1.)
             return np.vstack((1 - preds, preds)).transpose()
@@ -1017,27 +968,17 @@ tree-growing phase</p></div>
     def plot(self, cols=2, feature_names=None, filename=None, label=&#34;all&#34;,
              impurity=False, tree_number=None, dpi=150, fig_size=None):
         is_single_tree = len(self.trees_) &lt; 2 or tree_number is not None
-        n_cols = int(cols)
-        n_rows = int(np.ceil(len(self.trees_) / n_cols))
-        # if is_single_tree:
-        #     fig, ax = plt.subplots(1)
-        # else:
-        #     fig, axs = plt.subplots(n_rows, n_cols)
         n_plots = int(len(self.trees_)) if tree_number is None else 1
-        fig, axs = plt.subplots(n_plots, dpi=dpi)
+        n_cols = 1 if is_single_tree else max(1, min(int(cols), n_plots))
+        n_rows = int(np.ceil(n_plots / n_cols))
+        fig, axs = plt.subplots(n_rows, n_cols, dpi=dpi, squeeze=False)
         if fig_size is not None:
             fig.set_size_inches(fig_size, fig_size)
-        criterion = &#34;squared_error&#34; if self.prediction_task == &#34;regression&#34; else &#34;gini&#34;
+        for ax in axs.flat[n_plots:]:
+            ax.axis(&#34;off&#34;)
         n_classes = 1 if self.prediction_task == &#39;regression&#39; else 2
-        ax_size = int(len(self.trees_))  # n_cols * n_rows
         for i in range(n_plots):
-            r = i // n_cols
-            c = i % n_cols
-            if not is_single_tree:
-                # ax = axs[r, c]
-                ax = axs[i]
-            else:
-                ax = axs
+            ax = axs.flat[i]
             try:
                 dt = extract_sklearn_tree_from_figs(
                     self, i if tree_number is None else tree_number, n_classes)
@@ -1274,27 +1215,17 @@ are ignored while searching for a split in each node.</p></div>
 <pre><code class="python">def plot(self, cols=2, feature_names=None, filename=None, label=&#34;all&#34;,
          impurity=False, tree_number=None, dpi=150, fig_size=None):
     is_single_tree = len(self.trees_) &lt; 2 or tree_number is not None
-    n_cols = int(cols)
-    n_rows = int(np.ceil(len(self.trees_) / n_cols))
-    # if is_single_tree:
-    #     fig, ax = plt.subplots(1)
-    # else:
-    #     fig, axs = plt.subplots(n_rows, n_cols)
     n_plots = int(len(self.trees_)) if tree_number is None else 1
-    fig, axs = plt.subplots(n_plots, dpi=dpi)
+    n_cols = 1 if is_single_tree else max(1, min(int(cols), n_plots))
+    n_rows = int(np.ceil(n_plots / n_cols))
+    fig, axs = plt.subplots(n_rows, n_cols, dpi=dpi, squeeze=False)
     if fig_size is not None:
         fig.set_size_inches(fig_size, fig_size)
-    criterion = &#34;squared_error&#34; if self.prediction_task == &#34;regression&#34; else &#34;gini&#34;
+    for ax in axs.flat[n_plots:]:
+        ax.axis(&#34;off&#34;)
     n_classes = 1 if self.prediction_task == &#39;regression&#39; else 2
-    ax_size = int(len(self.trees_))  # n_cols * n_rows
     for i in range(n_plots):
-        r = i // n_cols
-        c = i % n_cols
-        if not is_single_tree:
-            # ax = axs[r, c]
-            ax = axs[i]
-        else:
-            ax = axs
+        ax = axs.flat[i]
         try:
             dt = extract_sklearn_tree_from_figs(
                 self, i if tree_number is None else tree_number, n_classes)
@@ -1325,8 +1256,8 @@ are ignored while searching for a split in each node.</p></div>
         X_feats = self._extract_tree_predictions(X)
         return self.weighted_model_.predict(X_feats)
     preds = np.zeros(X.shape[0])
-    for tree in self.trees_:
-        preds += self._predict_tree(tree, X)
+    for figs_tree in self.trees_:
+        preds += self._predict_tree(figs_tree, X)
     if self.prediction_task == &#39;regression&#39;:
         return preds
     elif self.prediction_task == &#39;classification&#39;:
@@ -1353,8 +1284,8 @@ are ignored while searching for a split in each node.</p></div>
         return np.vstack((1 - probs, probs)).transpose()
     else:
         preds = np.zeros(X.shape[0])
-        for tree in self.trees_:
-            preds += self._predict_tree(tree, X)
+        for figs_tree in self.trees_:
+            preds += self._predict_tree(figs_tree, X)
         # constrain to range of probabilities
         preds = np.clip(preds, a_min=0., a_max=1.)
         return np.vstack((1 - preds, preds)).transpose()</code></pre>

--- a/docs/experimental/figs_shrinkage.html
+++ b/docs/experimental/figs_shrinkage.html
@@ -25,12 +25,8 @@
 from typing import List
 
 import numpy as np
-from sklearn import datasets
 from sklearn.base import BaseEstimator
-from sklearn.metrics import r2_score
 from sklearn.model_selection import cross_val_score
-from sklearn.model_selection import train_test_split
-from sklearn.tree import DecisionTreeRegressor
 
 from imodels.util import checks
 
@@ -166,48 +162,7 @@ class HSFIGSRegressorCV(HSFIGSRegressor):
             cv_scores = cross_val_score(est, X, y, cv=self.cv, scoring=self.scoring)
             self.scores_.append(np.mean(cv_scores))
         self.reg_param = self.reg_param_list[np.argmax(self.scores_)]
-        super().fit(X=X, y=y)
-
-
-if __name__ == &#39;__main__&#39;:
-    np.random.seed(15)
-    # X, y = datasets.fetch_california_housing(return_X_y=True)  # regression
-    # X, y = datasets.load_breast_cancer(return_X_y=True)  # binary classification
-    X, y = datasets.load_diabetes(return_X_y=True)  # regression
-    # X = np.random.randn(500, 10)
-    # y = (X[:, 0] &gt; 0).astype(float) + (X[:, 1] &gt; 1).astype(float)
-
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.33, random_state=10
-    )
-    print(&#39;X.shape&#39;, X.shape)
-    print(&#39;ys&#39;, np.unique(y_train))
-
-    # m = HSTree(estimator_=DecisionTreeClassifier(), reg_param=0.1)
-    # m = DecisionTreeClassifier(max_leaf_nodes = 20,random_state=1, max_features=None)
-    m = DecisionTreeRegressor(random_state=42, max_leaf_nodes=20)
-    # print(&#39;best alpha&#39;, m.reg_param)
-    m.fit(X_train, y_train)
-    # m.predict_proba(X_train)  # just run this
-    print(&#39;score&#39;, r2_score(y_test, m.predict(X_test)))
-    print(&#39;running again....&#39;)
-
-    # x = DecisionTreeRegressor(random_state = 42, ccp_alpha = 0.3)
-    # x.fit(X_train,y_train)
-
-    # m = HSTree(estimator_=DecisionTreeRegressor(random_state=42, max_features=None), reg_param=10)
-    # m = HSTree(estimator_=DecisionTreeClassifier(random_state=42, max_features=None), reg_param=0)
-    m = HSFIGSClassifierCV(estimator_=DecisionTreeRegressor(max_leaf_nodes=10, random_state=1),
-                           shrinkage_scheme_=&#39;node_based&#39;,
-                           reg_param_list=[0.1, 1, 2, 5, 10, 25, 50, 100, 500])
-    # m = ShrunkTreeCV(estimator_=DecisionTreeClassifier())
-
-    # m = HSTreeClassifier(estimator_ = GradientBoostingClassifier(random_state = 10),reg_param = 5)
-    m.fit(X_train, y_train)
-    print(&#39;best alpha&#39;, m.reg_param)
-    # m.predict_proba(X_train)  # just run this
-    # print(&#39;score&#39;, m.score(X_test, y_test))
-    print(&#39;score&#39;, r2_score(y_test, m.predict(X_test)))</code></pre>
+        super().fit(X=X, y=y)</code></pre>
 </details>
 </section>
 <section>

--- a/docs/experimental/tree_gam_simple.html
+++ b/docs/experimental/tree_gam_simple.html
@@ -23,7 +23,6 @@
 </summary>
 <pre><code class="python">from copy import deepcopy
 import numpy as np
-import pandas as pd
 from sklearn.base import BaseEstimator
 from sklearn.tree import DecisionTreeRegressor
 from sklearn.utils.validation import check_is_fitted
@@ -32,10 +31,7 @@ from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_X_y
 from sklearn.utils.validation import _check_sample_weight
 from sklearn.model_selection import train_test_split
-from sklearn.metrics import accuracy_score, roc_auc_score
-from tqdm import tqdm
 
-import imodels
 
 from sklearn.base import RegressorMixin, ClassifierMixin
 
@@ -202,30 +198,7 @@ class TreeGAMSimpleRegressor(TreeGAMSimple, RegressorMixin):
 
 
 class TreeGAMSimpleClassifier(TreeGAMSimple, ClassifierMixin):
-    ...
-
-
-if __name__ == &#34;__main__&#34;:
-    X, y, feature_names = imodels.get_clean_dataset(&#34;heart&#34;)
-    X, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
-    gam = TreeGAMSimpleClassifier(
-        boosting_strategy=&#34;cyclic&#34;,
-        random_state=42,
-        learning_rate=0.1,
-        max_leaf_nodes=3,
-        n_boosting_rounds=100,
-    )
-    gam.fit(X, y_train)
-
-    # check roc auc score
-    y_pred = gam.predict_proba(X_test)[:, 1]
-    print(
-        &#34;train roc:&#34;,
-        roc_auc_score(y_train, gam.predict_proba(X)[:, 1]).round(3),
-    )
-    print(&#34;test roc:&#34;, roc_auc_score(y_test, y_pred).round(3))
-    print(&#34;test acc:&#34;, accuracy_score(y_test, gam.predict(X_test)).round(3))
-    print(&#39;\t(imb:&#39;, np.mean(y_test).round(3), &#39;)&#39;)</code></pre>
+    ...</code></pre>
 </details>
 </section>
 <section>

--- a/docs/importance/mdi_plus.html
+++ b/docs/importance/mdi_plus.html
@@ -362,7 +362,7 @@ class TreeMDIPlus:
                 if len(scoring_fns) &gt; 1:
                     msg = &#34;scoring_fn={} should return one value for each feature.&#34;.format(fn_name)
                 else:
-                    msg = &#34;scoring_fns should return one value for each feature.&#34;.format(fn_name)
+                    msg = &#34;scoring_fns should return one value for each feature.&#34;
                 raise ValueError(&#34;Unexpected dimensions. {}&#34;.format(msg))
             scores = scores.ravel()
             all_scores[fn_name] = scores
@@ -999,7 +999,7 @@ variance in the transformers.</dd>
                 if len(scoring_fns) &gt; 1:
                     msg = &#34;scoring_fn={} should return one value for each feature.&#34;.format(fn_name)
                 else:
-                    msg = &#34;scoring_fns should return one value for each feature.&#34;.format(fn_name)
+                    msg = &#34;scoring_fns should return one value for each feature.&#34;
                 raise ValueError(&#34;Unexpected dimensions. {}&#34;.format(msg))
             scores = scores.ravel()
             all_scores[fn_name] = scores

--- a/docs/importance/rf_plus.html
+++ b/docs/importance/rf_plus.html
@@ -21,7 +21,7 @@
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">import copy, pprint, warnings
+<pre><code class="python">import copy
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, RegressorMixin, ClassifierMixin
@@ -30,14 +30,12 @@ from sklearn.utils.validation import check_is_fitted
 from sklearn.metrics import r2_score, roc_auc_score, log_loss
 from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier
 from sklearn.preprocessing import OneHotEncoder
-from sklearn.model_selection import train_test_split
 from imodels.importance.block_transformers import MDIPlusDefaultTransformer, TreeTransformer, \
     CompositeTransformer, IdentityTransformer
 from imodels.importance.ppms import PartialPredictionModelBase, GlmClassifierPPM, \
     RidgeRegressorPPM, LogisticClassifierPPM
 from imodels.importance.mdi_plus import ForestMDIPlus, \
     _get_default_sample_split, _validate_sample_split, _get_sample_split_data
-import imodels
 
 class _RandomForestPlus(BaseEstimator):
     &#34;&#34;&#34;
@@ -490,31 +488,7 @@ def _neg_log_loss(y_true, y_pred):
     -------
     Scalar quantity, measuring the negative log-loss value.
     &#34;&#34;&#34;
-    return -log_loss(y_true, y_pred)
-
-
-if __name__ == &#34;__main__&#34;:
-    
-
-    #Suppress specific warning
-    # warnings.filterwarnings(&#34;ignore&#34;, message=&#34;pkg_resources is deprecated&#34;)
-    
-    X, y,f = imodels.get_clean_dataset(&#34;california_housing&#34;)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.6, random_state=1)
-
-    pprint.pprint(f&#34;Shape: {X_train.shape}&#34;)
-
-    rf = RandomForestRegressor(n_estimators=3,min_samples_leaf=5,max_features=0.33,random_state=1)
-    rf.fit(X_train, y_train)
-    
-    rf_plus = RandomForestPlusRegressor(rf_model=copy.deepcopy(rf))
-    rf_plus.fit(X_train, y_train)
-
-    pprint.pprint(f&#34;RF r2_score: {r2_score(y_test,rf.predict(X_test))}&#34;)
-
-    pprint.pprint(f&#34;RF+ r2_score: {r2_score(y_test,rf_plus.predict(X_test))}&#34;)
-
-   </code></pre>
+    return -log_loss(y_true, y_pred)</code></pre>
 </details>
 </section>
 <section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -124,7 +124,7 @@ Prediction is made by looking at the value in the appropriate leaf of the tree
 </tr>
 <tr>
 <td style="text-align: left;">Fast-and-frugal tree</td>
-<td><a href="https://csinva.io/imodels/rule_list/fast_frugal_tree.html">FastFrugalTreeClassifier</a></td>
+<td><a href="https://csinva.io/imodels/rule_list/fast_frugal_tree.html">🗂️</a> <a href="https://github.com/fasttrees/fasttrees">🔗</a></td>
 <td></td>
 </tr>
 <tr>
@@ -190,7 +190,7 @@ Prediction is made by looking at the value in the appropriate leaf of the tree
 </tbody>
 </table>
 <h2 id="demo-notebooks">Demo notebooks</h2>
-<p>Demos are contained in the <a href="notebooks">notebooks</a> folder. (The standalone Colab notebook has been retired; please refer to the demos below, which are kept up to date with the package.)</p>
+<p>Demos are contained in the <a href="notebooks">notebooks</a> folder</p>
 <details>
 <summary><a href="https://github.com/csinva/imodels/blob/master/notebooks/imodels_demo.ipynb">Quickstart demo</a></summary>
 Shows how to fit, predict, and visualize with different interpretable models
@@ -258,177 +258,106 @@ Bayesian rule lists and greedy rule lists differ in how they select rules; bayes
 <summary>Ex. FPSkope vs. SkopeRules</summary>
 FPSkope and SkopeRules differ only in the way they generate candidate rules: FPSkope uses FPgrowth whereas SkopeRules extracts rules from decision trees.
 </details>
-<h2 id="support-for-different-tasks">Support for different tasks</h2>
-<p>Different models support different machine-learning tasks. Current support for different models is given below (each of these models can be imported directly from imodels (e.g. <code>from <a title="imodels" href="#imodels">imodels</a> import RuleFitClassifier</code>):</p>
-<p>All of these models follow the standard sklearn estimator API, which is checked for every model in <a href="tests/model_api_test.py">tests/model_api_test.py</a>: <code>fit</code> returns the estimator, <code>predict</code> returns labels drawn from <code>classes_</code> (strings included), <code>predict_proba</code> returns an <code>(n_samples, n_classes)</code> matrix whose rows sum to 1, DataFrame input sets <code>feature_names_in_</code>,, models can be <code>clone</code>d and configured with <code>get_params</code>/<code>set_params</code>, and every model works inside sklearn pipelines and grid searches.</p>
-<table>
-<thead>
-<tr>
-<th style="text-align: left;">Model</th>
-<th style="text-align: center;">Binary classification</th>
-<th style="text-align: center;">Regression</th>
-<th>Notes</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td style="text-align: left;">Rulefit rule set</td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/rule_set/rule_fit.html#imodels.rule_set.rule_fit.RuleFitClassifier">RuleFitClassifier</a></td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/rule_set/rule_fit.html#imodels.rule_set.rule_fit.RuleFitRegressor">RuleFitRegressor</a></td>
-<td></td>
-</tr>
-<tr>
-<td style="text-align: left;">Skope rule set</td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/rule_set/skope_rules.html#imodels.rule_set.skope_rules.SkopeRulesClassifier">SkopeRulesClassifier</a></td>
-<td style="text-align: center;"></td>
-<td></td>
-</tr>
-<tr>
-<td style="text-align: left;">FPSkope rule set</td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/rule_set/fpskope.html#imodels.rule_set.fpskope.FPSkopeClassifier">FPSkopeClassifier</a></td>
-<td style="text-align: center;"></td>
-<td>Like Skope, but generates candidate rules with FPGrowth; requires discretized features</td>
-</tr>
-<tr>
-<td style="text-align: left;">Rulefit rule set (XGBoost)</td>
-<td style="text-align: center;">pass <code>tree_generator=XGBClassifier(...)</code> to <code>RuleFitClassifier</code></td>
-<td style="text-align: center;">pass <code>tree_generator=XGBRegressor(...)</code> to <code>RuleFitRegressor</code></td>
-<td>Requires <a href="https://pypi.org/project/xgboost/">xgboost</a></td>
-</tr>
-<tr>
-<td style="text-align: left;">FPLasso rule set</td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/rule_set/fplasso.html#imodels.rule_set.fplasso.FPLassoClassifier">FPLassoClassifier</a></td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/rule_set/fplasso.html#imodels.rule_set.fplasso.FPLassoRegressor">FPLassoRegressor</a></td>
-<td>Lasso over rules mined with FPGrowth; requires discretized features</td>
-</tr>
-<tr>
-<td style="text-align: left;">Boosted rule set</td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/rule_set/boosted_rules.html#imodels.rule_set.boosted_rules.BoostedRulesClassifier">BoostedRulesClassifier</a></td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/rule_set/boosted_rules.html#imodels.rule_set.boosted_rules.BoostedRulesRegressor">BoostedRulesRegressor</a></td>
-<td></td>
-</tr>
-<tr>
-<td style="text-align: left;">SLIPPER rule set</td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/rule_set/slipper.html#imodels.rule_set.slipper.SlipperClassifier">SlipperClassifier</a></td>
-<td style="text-align: center;"></td>
-<td></td>
-</tr>
-<tr>
-<td style="text-align: left;">Bayesian rule set</td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/rule_set/brs.html#imodels.rule_set.brs.BayesianRuleSetClassifier">BayesianRuleSetClassifier</a></td>
-<td style="text-align: center;"></td>
-<td>Fails for large problems</td>
-</tr>
-<tr>
-<td style="text-align: left;">Bayesian rule list</td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/rule_list/bayesian_rule_list/bayesian_rule_list.html#imodels.rule_list.bayesian_rule_list.bayesian_rule_list.BayesianRuleListClassifier">BayesianRuleListClassifier</a></td>
-<td style="text-align: center;"></td>
-<td></td>
-</tr>
-<tr>
-<td style="text-align: left;">Greedy rule list</td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/rule_list/greedy_rule_list.html#imodels.rule_list.greedy_rule_list.GreedyRuleListClassifier">GreedyRuleListClassifier</a></td>
-<td style="text-align: center;"></td>
-<td></td>
-</tr>
-<tr>
-<td style="text-align: left;">OneR rule list</td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/rule_list/one_r.html#imodels.rule_list.one_r.OneRClassifier">OneRClassifier</a></td>
-<td style="text-align: center;"></td>
-<td></td>
-</tr>
-<tr>
-<td style="text-align: left;">Greedy rule tree (CART)</td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/tree/cart_wrapper.html#imodels.tree.cart_wrapper.GreedyTreeClassifier">GreedyTreeClassifier</a></td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/tree/cart_wrapper.html#imodels.tree.cart_wrapper.GreedyTreeRegressor">GreedyTreeRegressor</a></td>
-<td></td>
-</tr>
-<tr>
-<td style="text-align: left;">C4.5 rule tree</td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/tree/c45_tree/c45_tree.html#imodels.tree.c45_tree.c45_tree.C45TreeClassifier">C45TreeClassifier</a></td>
-<td style="text-align: center;"></td>
-<td></td>
-</tr>
-<tr>
-<td style="text-align: left;">CCP-pruned rule tree</td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/tree/cart_ccp.html#imodels.tree.cart_ccp.DecisionTreeCCPClassifier">DecisionTreeCCPClassifier</a></td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/tree/cart_ccp.html#imodels.tree.cart_ccp.DecisionTreeCCPRegressor">DecisionTreeCCPRegressor</a></td>
-<td>Prunes a tree to a target complexity via cost-complexity pruning</td>
-</tr>
-<tr>
-<td style="text-align: left;">TAO rule tree</td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/tree/tao.html#imodels.tree.tao.TaoTreeClassifier">TaoTreeClassifier</a></td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/tree/tao.html#imodels.tree.tao.TaoTreeRegressor">TaoTreeRegressor</a></td>
-<td></td>
-</tr>
-<tr>
-<td style="text-align: left;">Sparse integer linear model</td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/algebraic/slim.html#imodels.algebraic.slim.SLIMClassifier">SLIMClassifier</a></td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/algebraic/slim.html#imodels.algebraic.slim.SLIMRegressor">SLIMRegressor</a></td>
-<td>Requires extra dependencies for speed</td>
-</tr>
-<tr>
-<td style="text-align: left;">Tree GAM</td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/algebraic/tree_gam.html">TreeGAMClassifier</a></td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/algebraic/tree_gam.html">TreeGAMRegressor</a></td>
-<td></td>
-</tr>
-<tr>
-<td style="text-align: left;">Greedy tree sums (FIGS)</td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/tree/figs.html#imodels.tree.figs.FIGSClassifier">FIGSClassifier</a></td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/tree/figs.html#imodels.tree.figs.FIGSRegressor">FIGSRegressor</a></td>
-<td></td>
-</tr>
-<tr>
-<td style="text-align: left;">Hierarchical shrinkage</td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/tree/hierarchical_shrinkage.html#imodels.tree.hierarchical_shrinkage.HSTreeClassifierCV">HSTreeClassifierCV</a></td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/tree/hierarchical_shrinkage.html#imodels.tree.hierarchical_shrinkage.HSTreeRegressorCV">HSTreeRegressorCV</a></td>
-<td>Wraps any sklearn tree-based model</td>
-</tr>
-<tr>
-<td style="text-align: left;">Marginal shrinkage<br/>linear model</td>
-<td style="text-align: center;"></td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/algebraic/marginal_shrinkage_linear_model.html">MarginalShrinkageLinearModelRegressor</a></td>
-<td>Linear model shrunk towards its marginal effects</td>
-</tr>
-<tr>
-<td style="text-align: left;">BART</td>
-<td style="text-align: center;"></td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/experimental/bartpy/index.html">BART</a></td>
-<td>Bayesian additive regression trees (slow)</td>
-</tr>
-<tr>
-<td style="text-align: left;">Distillation</td>
-<td style="text-align: center;"></td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/util/distillation.html#imodels.util.distillation.DistilledRegressor">DistilledRegressor</a></td>
-<td>Wraps any sklearn-compatible models</td>
-</tr>
-<tr>
-<td style="text-align: left;">AutoML model</td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/util/automl.html">AutoInterpretableClassifier️</a></td>
-<td style="text-align: center;"><a href="https://csinva.io/imodels/util/automl.html">AutoInterpretableRegressor️</a></td>
-<td></td>
-</tr>
-</tbody>
-</table>
-<p><strong>Multiclass.</strong> These classifiers handle more than two classes: <code>FIGSClassifier</code>,
+<details>
+<summary><h3>Support for different tasks</h3></summary>
+Different models support different machine-learning tasks. Current support for different models is given below (each of these models can be imported directly from imodels (e.g. <code>from <a title="imodels" href="#imodels">imodels</a> import RuleFitClassifier</code>):
+All of these models follow the standard sklearn estimator API, which is checked for every model in [tests/model_api_test.py](tests/model_api_test.py): <code>fit</code> returns the estimator, <code>predict</code> returns labels drawn from <code>classes\_</code> (strings included), <code>predict\_proba</code> returns an <code>(n\_samples, n\_classes)</code> matrix whose rows sum to 1, DataFrame input sets <code>feature\_names\_in\_</code>,, models can be <code>clone</code>d and configured with <code>get\_params</code>/<code>set\_params</code>, and every model works inside sklearn pipelines and grid searches.
+| Model
+|
+Binary classification
+|
+Regression
+| Notes |
+| :-------------------------- | :----------------------------------------------------------: | :----------------------------------------------------------: | --------------------------- |
+| Rulefit rule set
+| [RuleFitClassifier](https://csinva.io/imodels/rule_set/rule_fit.html#imodels.rule_set.rule_fit.RuleFitClassifier) | [RuleFitRegressor](https://csinva.io/imodels/rule_set/rule_fit.html#imodels.rule_set.rule_fit.RuleFitRegressor) |
+|
+| Skope rule set
+| [SkopeRulesClassifier](https://csinva.io/imodels/rule_set/skope_rules.html#imodels.rule_set.skope_rules.SkopeRulesClassifier) |
+|
+|
+| FPSkope rule set
+| [FPSkopeClassifier](https://csinva.io/imodels/rule_set/fpskope.html#imodels.rule_set.fpskope.FPSkopeClassifier) |
+| Like Skope, but generates candidate rules with FPGrowth; requires discretized features |
+| Rulefit rule set (XGBoost)
+| pass `tree_generator=XGBClassifier(...)` to <code>RuleFitClassifier</code> | pass `tree_generator=XGBRegressor(...)` to <code>RuleFitRegressor</code> | Requires [xgboost](https://pypi.org/project/xgboost/) |
+| FPLasso rule set
+| [FPLassoClassifier](https://csinva.io/imodels/rule_set/fplasso.html#imodels.rule_set.fplasso.FPLassoClassifier) | [FPLassoRegressor](https://csinva.io/imodels/rule_set/fplasso.html#imodels.rule_set.fplasso.FPLassoRegressor) | Lasso over rules mined with FPGrowth; requires discretized features |
+| Boosted rule set
+| [BoostedRulesClassifier](https://csinva.io/imodels/rule_set/boosted_rules.html#imodels.rule_set.boosted_rules.BoostedRulesClassifier) | [BoostedRulesRegressor](https://csinva.io/imodels/rule_set/boosted_rules.html#imodels.rule_set.boosted_rules.BoostedRulesRegressor) |
+|
+| SLIPPER rule set
+| [SlipperClassifier](https://csinva.io/imodels/rule_set/slipper.html#imodels.rule_set.slipper.SlipperClassifier) |
+|
+|
+| Bayesian rule set
+| [BayesianRuleSetClassifier](https://csinva.io/imodels/rule_set/brs.html#imodels.rule_set.brs.BayesianRuleSetClassifier) |
+| Fails for large problems |
+| Bayesian rule list
+| [BayesianRuleListClassifier](https://csinva.io/imodels/rule_list/bayesian_rule_list/bayesian_rule_list.html#imodels.rule_list.bayesian_rule_list.bayesian_rule_list.BayesianRuleListClassifier) |
+|
+|
+| Greedy rule list
+| [GreedyRuleListClassifier](https://csinva.io/imodels/rule_list/greedy_rule_list.html#imodels.rule_list.greedy_rule_list.GreedyRuleListClassifier) |
+|
+|
+| OneR rule list
+| [OneRClassifier](https://csinva.io/imodels/rule_list/one_r.html#imodels.rule_list.one_r.OneRClassifier) |
+|
+|
+| Greedy rule tree (CART)
+| [GreedyTreeClassifier](https://csinva.io/imodels/tree/cart_wrapper.html#imodels.tree.cart_wrapper.GreedyTreeClassifier) |
+[GreedyTreeRegressor](https://csinva.io/imodels/tree/cart_wrapper.html#imodels.tree.cart_wrapper.GreedyTreeRegressor)
+|
+|
+| C4.5 rule tree
+| [C45TreeClassifier](https://csinva.io/imodels/tree/c45_tree/c45_tree.html#imodels.tree.c45_tree.c45_tree.C45TreeClassifier) |
+|
+|
+| CCP-pruned rule tree
+| [DecisionTreeCCPClassifier](https://csinva.io/imodels/tree/cart_ccp.html#imodels.tree.cart_ccp.DecisionTreeCCPClassifier) | [DecisionTreeCCPRegressor](https://csinva.io/imodels/tree/cart_ccp.html#imodels.tree.cart_ccp.DecisionTreeCCPRegressor) | Prunes a tree to a target complexity via cost-complexity pruning |
+| TAO rule tree
+| [TaoTreeClassifier](https://csinva.io/imodels/tree/tao.html#imodels.tree.tao.TaoTreeClassifier) |
+[TaoTreeRegressor](https://csinva.io/imodels/tree/tao.html#imodels.tree.tao.TaoTreeRegressor)
+|
+|
+| Sparse integer linear model | [SLIMClassifier](https://csinva.io/imodels/algebraic/slim.html#imodels.algebraic.slim.SLIMClassifier) | [SLIMRegressor](https://csinva.io/imodels/algebraic/slim.html#imodels.algebraic.slim.SLIMRegressor) | Requires extra dependencies for speed |
+| Tree GAM | [TreeGAMClassifier](https://csinva.io/imodels/algebraic/tree_gam.html) | [TreeGAMRegressor](https://csinva.io/imodels/algebraic/tree_gam.html) | |
+| Greedy tree sums (FIGS) | [FIGSClassifier](https://csinva.io/imodels/tree/figs.html#imodels.tree.figs.FIGSClassifier) | [FIGSRegressor](https://csinva.io/imodels/tree/figs.html#imodels.tree.figs.FIGSRegressor) |
+|
+| Hierarchical shrinkage | [HSTreeClassifierCV](https://csinva.io/imodels/tree/hierarchical_shrinkage.html#imodels.tree.hierarchical_shrinkage.HSTreeClassifierCV) | [HSTreeRegressorCV](https://csinva.io/imodels/tree/hierarchical_shrinkage.html#imodels.tree.hierarchical_shrinkage.HSTreeRegressorCV) | Wraps any sklearn tree-based model |
+| Marginal shrinkage<br/>linear model |
+| [MarginalShrinkageLinearModelRegressor](https://csinva.io/imodels/algebraic/marginal_shrinkage_linear_model.html) | Linear model shrunk towards its marginal effects |
+| BART |
+| [BART](https://csinva.io/imodels/experimental/bartpy/index.html) | Bayesian additive regression trees (slow) |
+| Distillation |
+| [DistilledRegressor](https://csinva.io/imodels/util/distillation.html#imodels.util.distillation.DistilledRegressor) | Wraps any sklearn-compatible models |
+| AutoML model | [AutoInterpretableClassifier️](https://csinva.io/imodels/util/automl.html)
+| [AutoInterpretableRegressor️](https://csinva.io/imodels/util/automl.html) | |
+**Feature scaling.** Most models here work on raw features. <code>SLIMClassifier</code> and
+<code>SLIMRegressor</code> are the exception: their coefficients are integers, so features
+on very different scales collapse to zero when rounded. Standardize X before
+fitting them (they warn if rounding has removed most of the model).
+**Multiclass.** These classifiers handle more than two classes: <code>FIGSClassifier</code>,
 <code>GreedyTreeClassifier</code>, <code>HSTreeClassifier</code>, <code>TaoTreeClassifier</code>,
 <code>BoostedRulesClassifier</code>, <code>SLIMClassifier</code>, <code>C45TreeClassifier</code>,
 <code>DecisionTreeCCPClassifier</code> and the <code>CV</code> variants. The rule-set and rule-list models are binary-only and raise a
 clear error if given a multiclass target, rather than silently treating it as
-binary.</p>
-<p><strong>Categorical features.</strong> <code>FIGS</code> takes them directly — pass the column names and
-it one-hot encodes them internally, remembering them for <code>predict</code>:</p>
+binary.
+**Categorical features.** <code>FIGS</code> takes them directly — pass the column names and
+it one-hot encodes them internally, remembering them for <code>predict</code>:
 <pre><code class="language-python">model = FIGSClassifier().fit(X, y, categorical_features=['pet', 'city'])
 model.predict(X)
 </code></pre>
-<p>Other models expect numeric input, so encode categorical columns first (e.g. with
+Other models expect numeric input, so encode categorical columns first (e.g. with
 <code>sklearn.preprocessing.OneHotEncoder</code>, or one of the
-<a href="https://csinva.io/imodels/discretization/index.html">discretizers</a> for numeric
-columns that a rule model needs binarized).</p>
-<h3 id="plotting-trees-with-dtreeviz">Plotting trees with dtreeviz</h3>
-<p>Tree-based models can be drawn with <a href="https://github.com/parrt/dtreeviz">dtreeviz</a>.
-<code>shadow_tree</code> builds the <code>ShadowDecTree</code> it needs from any imodels tree model:</p>
+[discretizers](https://csinva.io/imodels/discretization/index.html) for numeric
+columns that a rule model needs binarized).
+</details>
+<details>
+<summary><h3>Plotting trees with dtreeviz</h3></summary>
+Tree-based models can be drawn with [dtreeviz](https://github.com/parrt/dtreeviz).
+<code>shadow\_tree</code> builds the <code>ShadowDecTree</code> it needs from any imodels tree model:
 <pre><code class="language-python">import dtreeviz
 from imodels import FIGSClassifier, shadow_tree
 
@@ -436,12 +365,14 @@ model = FIGSClassifier(max_rules=6).fit(X, y)
 viz = dtreeviz.trees.DTreeVizAPI(shadow_tree(model, X, y))
 viz.view()
 </code></pre>
-<p>For a model made of several trees (FIGS, boosted rules), pass <code>tree_num</code> to pick
+For a model made of several trees (FIGS, boosted rules), pass <code>tree\_num</code> to pick
 one. Feature and class names default to those the model was fitted with.
-dtreeviz is not a dependency and is imported only when this is called.</p>
-<h3 id="inspecting-the-rules-a-model-learned">Inspecting the rules a model learned</h3>
-<p>Every rule-based model exposes its rules the same way, as a <code>pandas</code> DataFrame with
-one row per rule, via <code>get_rules()</code>:</p>
+dtreeviz is not a dependency and is imported only when this is called.
+</details>
+<details>
+<summary><h3>Inspecting the rules a model learned</h3></summary>
+Every rule-based model exposes its rules the same way, as a <code>pandas</code> DataFrame with
+one row per rule, via <code>get\_rules()</code>:
 <pre><code class="language-python">from imodels import FIGSClassifier
 
 model = FIGSClassifier(max_rules=4).fit(X_train, y_train, feature_names=feature_names)
@@ -456,20 +387,22 @@ model.get_rules()
 5   PainNeck2 &lt;= 0.5 and AlteredMentalStatus2 &gt; 0.5       0.048     2
 6                                   PainNeck2 &gt; 0.5       0.058     2
 </code></pre>
-<p>Two columns are always present: <code>rule</code>, the condition as a string, and <code>prediction</code>,
+Two columns are always present: <code>rule</code>, the condition as a string, and <code>prediction</code>,
 what that rule predicts. Models add their own columns on top — <code>coef</code>, <code>support</code> and
 <code><a title="imodels.importance" href="importance/index.html">imodels.importance</a></code> for RuleFit, <code><a title="imodels.tree" href="tree/index.html">imodels.tree</a></code> for models made of several trees, and <code>weight</code> for
 boosted ensembles, which combine their trees by weighted vote. Where a model is
 additive, as FIGS is, <code>prediction</code> is that tree's contribution, so the contributions
-of the matching rules sum to the model's output.</p>
-<p>This works across rule sets, rule lists and tree-based models (RuleFit, SkopeRules,
+of the matching rules sum to the model's output.
+This works across rule sets, rule lists and tree-based models (RuleFit, SkopeRules,
 SLIPPER, greedy and Bayesian rule lists, FIGS, CART, C4.5, TAO, boosted rules, and
 hierarchical shrinkage, including the <code>CV</code> variants). It is also available as a
-function, <code>imodels.get_rules(model)</code>, and takes an optional <code>feature_names</code> argument
-to rename the features. Models that aren't rule-based raise a clear error.</p>
-<h3 id="shap-values-for-shrunk-trees">SHAP values for shrunk trees</h3>
-<p><code>shap.TreeExplainer</code> dispatches on the model class, so it doesn't recognize the
-imodels wrapper. Pass the shrunk estimator it wraps:</p>
+function, <code>imodels.get\_rules(model)</code>, and takes an optional <code>feature\_names</code> argument
+to rename the features. Models that aren't rule-based raise a clear error.
+</details>
+<details>
+<summary><h3>SHAP values for shrunk trees</h3></summary>
+<code>shap.TreeExplainer</code> dispatches on the model class, so it doesn't recognize the
+imodels wrapper. Pass the shrunk estimator it wraps:
 <pre><code class="language-python">import shap
 from imodels import HSTreeClassifier
 
@@ -477,16 +410,17 @@ model = HSTreeClassifier(DecisionTreeClassifier(max_leaf_nodes=8), reg_param=50)
 explainer = shap.TreeExplainer(model.estimator_)   # not model itself
 shap_values = explainer.shap_values(X)
 </code></pre>
-<p>Hierarchical shrinkage rewrites the node values of that tree in place, so the
+Hierarchical shrinkage rewrites the node values of that tree in place, so the
 explainer sees the shrunk model: the SHAP values differ from the unshrunk tree's
-and sum, with the expected value, to <code>model.predict_proba(X)</code>. This reproduces
-the SHAP summary plots in the <a href="https://arxiv.org/abs/2202.00858">paper</a>.</p>
-<p>Tree-based models expose <code>feature_importances_</code> (mean decrease in impurity), the
-same measure sklearn's tree models report, so they can be compared directly.</p>
-<p>Tree-based models also expose <code>apply(X)</code>, which reports which leaf each sample
+and sum, with the expected value, to <code>model.predict\_proba(X)</code>. This reproduces
+the SHAP summary plots in the [paper](https://arxiv.org/abs/2202.00858).
+Tree-based models expose <code>feature\_importances\_</code> (mean decrease in impurity), the
+same measure sklearn's tree models report, so they can be compared directly.
+Tree-based models also expose <code>apply(X)</code>, which reports which leaf each sample
 falls into, using the same node numbering as scikit-learn. A single tree returns
 one index per sample; a model made of several trees (FIGS, boosted rules) returns
-one column per tree, like <code>RandomForest.apply</code>.</p>
+one column per tree, like <code>RandomForest.apply</code>.
+</details>
 <h3 id="extras">Extras</h3>
 <details>
 <summary><a href="https://csinva.io/imodels/util/data_util.html#imodels.util.data_util.get_clean_dataset">Data-wrangling functions</a> for working with popular tabular datasets (e.g. compas).</summary>
@@ -764,11 +698,7 @@ DISCRETIZERS = [RFDiscretizer, BasicDiscretizer,
 <li><a href="#installation">Installation</a></li>
 <li><a href="#supported-models">Supported models</a></li>
 <li><a href="#demo-notebooks">Demo notebooks</a></li>
-<li><a href="#whats-the-difference-between-the-models">What's the difference between the models?</a></li>
-<li><a href="#support-for-different-tasks">Support for different tasks</a><ul>
-<li><a href="#plotting-trees-with-dtreeviz">Plotting trees with dtreeviz</a></li>
-<li><a href="#inspecting-the-rules-a-model-learned">Inspecting the rules a model learned</a></li>
-<li><a href="#shap-values-for-shrunk-trees">SHAP values for shrunk trees</a></li>
+<li><a href="#whats-the-difference-between-the-models">What's the difference between the models?</a><ul>
 <li><a href="#extras">Extras</a></li>
 </ul>
 </li>

--- a/docs/rule_list/bayesian_rule_list/bayesian_rule_list.html
+++ b/docs/rule_list/bayesian_rule_list/bayesian_rule_list.html
@@ -26,7 +26,7 @@ import pandas as pd
 import random
 from collections import Counter, defaultdict
 from sklearn.base import BaseEstimator, ClassifierMixin
-from sklearn.utils.multiclass import check_classification_targets, unique_labels
+from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
 
 from imodels.rule_list.bayesian_rule_list.brl_util import (
@@ -35,7 +35,8 @@ from imodels.rule_list.bayesian_rule_list.brl_util import (
 from imodels.rule_list.rule_list import RuleList
 from imodels.util.convert import itemsets_to_rules
 from imodels.util.extract import extract_fpgrowth
-from imodels.util.arguments import decode_labels, set_feature_names_in
+from imodels.util.arguments import (check_predict_X, decode_labels,
+                                    set_feature_names_in)
 from imodels.util.rule import get_feature_dict, replace_feature_name, Rule
 
 
@@ -305,6 +306,7 @@ class BayesianRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
             order, as they appear in the attribute `classes_`.
         &#34;&#34;&#34;
         check_is_fitted(self)
+        check_predict_X(self, X)
         X = check_array(X)
 
         D = pd.DataFrame(X, columns=self.feature_placeholders)
@@ -332,6 +334,7 @@ class BayesianRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
             Class labels for samples in X.
         &#34;&#34;&#34;
         check_is_fitted(self)
+        check_predict_X(self, X)
         X = check_array(X)
 
         return decode_labels(self, 1 * (self.predict_proba(X)[:, 1] &gt;= threshold))</code></pre>
@@ -648,6 +651,7 @@ rule lists, trying to optimize for compactness and predictive performance.</p>
             order, as they appear in the attribute `classes_`.
         &#34;&#34;&#34;
         check_is_fitted(self)
+        check_predict_X(self, X)
         X = check_array(X)
 
         D = pd.DataFrame(X, columns=self.feature_placeholders)
@@ -675,6 +679,7 @@ rule lists, trying to optimize for compactness and predictive performance.</p>
             Class labels for samples in X.
         &#34;&#34;&#34;
         check_is_fitted(self)
+        check_predict_X(self, X)
         X = check_array(X)
 
         return decode_labels(self, 1 * (self.predict_proba(X)[:, 1] &gt;= threshold))</code></pre>
@@ -870,6 +875,7 @@ classifier; lower it to trade precision for recall.</dd>
         Class labels for samples in X.
     &#34;&#34;&#34;
     check_is_fitted(self)
+    check_predict_X(self, X)
     X = check_array(X)
 
     return decode_labels(self, 1 * (self.predict_proba(X)[:, 1] &gt;= threshold))</code></pre>
@@ -911,6 +917,7 @@ order, as they appear in the attribute <code>classes_</code>.</dd>
         order, as they appear in the attribute `classes_`.
     &#34;&#34;&#34;
     check_is_fitted(self)
+    check_predict_X(self, X)
     X = check_array(X)
 
     D = pd.DataFrame(X, columns=self.feature_placeholders)

--- a/docs/rule_list/fast_frugal_tree.html
+++ b/docs/rule_list/fast_frugal_tree.html
@@ -57,7 +57,7 @@ from sklearn.utils.validation import check_array, check_is_fitted
 
 from imodels.rule_list.rule_list import RuleList
 from imodels.util.arguments import (check_binary_target, check_fit_arguments,
-                                    decode_labels)
+                                    check_predict_X, decode_labels)
 
 
 class FastFrugalTreeClassifier(BaseEstimator, RuleList, ClassifierMixin):
@@ -166,7 +166,7 @@ class FastFrugalTreeClassifier(BaseEstimator, RuleList, ClassifierMixin):
 
     def predict_proba(self, X):
         check_is_fitted(self)
-        X = check_array(X)
+        X = check_array(check_predict_X(self, X))
 
         probs = np.zeros(X.shape[0])
         undecided = np.ones(X.shape[0], dtype=bool)
@@ -349,7 +349,7 @@ works on it.</dd>
 
     def predict_proba(self, X):
         check_is_fitted(self)
-        X = check_array(X)
+        X = check_array(check_predict_X(self, X))
 
         probs = np.zeros(X.shape[0])
         undecided = np.ones(X.shape[0], dtype=bool)
@@ -453,7 +453,7 @@ works on it.</dd>
 </summary>
 <pre><code class="python">def predict_proba(self, X):
     check_is_fitted(self)
-    X = check_array(X)
+    X = check_array(check_predict_X(self, X))
 
     probs = np.zeros(X.shape[0])
     undecided = np.ones(X.shape[0], dtype=bool)

--- a/docs/rule_list/greedy_rule_list.html
+++ b/docs/rule_list/greedy_rule_list.html
@@ -39,7 +39,8 @@ from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.utils.validation import check_array, check_is_fitted
 from sklearn.tree import DecisionTreeClassifier
 from imodels.rule_list.rule_list import RuleList
-from imodels.util.arguments import check_binary_target, check_fit_arguments, decode_labels
+from imodels.util.arguments import (check_binary_target, check_fit_arguments,
+                                    check_predict_X, decode_labels)
 
 
 class GreedyRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
@@ -151,7 +152,7 @@ class GreedyRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
 
     def predict_proba(self, X):
         check_is_fitted(self)
-        X = check_array(X)
+        X = check_array(check_predict_X(self, X))
         n = X.shape[0]
         probs = np.zeros(n)
         for i in range(n):
@@ -170,7 +171,7 @@ class GreedyRuleListClassifier(BaseEstimator, RuleList, ClassifierMixin):
 
     def predict(self, X):
         check_is_fitted(self)
-        X = check_array(X)
+        X = check_array(check_predict_X(self, X))
         return decode_labels(self, np.argmax(self.predict_proba(X), axis=1))
 
 
@@ -519,7 +520,7 @@ Criterion used to split
 
     def predict_proba(self, X):
         check_is_fitted(self)
-        X = check_array(X)
+        X = check_array(check_predict_X(self, X))
         n = X.shape[0]
         probs = np.zeros(n)
         for i in range(n):
@@ -538,7 +539,7 @@ Criterion used to split
 
     def predict(self, X):
         check_is_fitted(self)
-        X = check_array(X)
+        X = check_array(check_predict_X(self, X))
         return decode_labels(self, np.argmax(self.predict_proba(X), axis=1))
 
 
@@ -858,7 +859,7 @@ the depth of the current layer (used to recurse)</p></div>
 </summary>
 <pre><code class="python">def predict(self, X):
     check_is_fitted(self)
-    X = check_array(X)
+    X = check_array(check_predict_X(self, X))
     return decode_labels(self, np.argmax(self.predict_proba(X), axis=1))</code></pre>
 </details>
 </dd>
@@ -873,7 +874,7 @@ the depth of the current layer (used to recurse)</p></div>
 </summary>
 <pre><code class="python">def predict_proba(self, X):
     check_is_fitted(self)
-    X = check_array(X)
+    X = check_array(check_predict_X(self, X))
     n = X.shape[0]
     probs = np.zeros(n)
     for i in range(n):

--- a/docs/rule_list/one_r.html
+++ b/docs/rule_list/one_r.html
@@ -29,23 +29,15 @@ It works by building a greedy rule list using only one feature at a time, and th
 the rule list with the highest accuracy
 &#39;&#39;&#39;
 
-import math
 import numpy as np
-from copy import deepcopy
-from sklearn.base import BaseEstimator
-from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
-from sklearn.utils.multiclass import check_classification_targets, unique_labels
-from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
 
 from imodels import GreedyRuleListClassifier
-from imodels.rule_list.rule_list import RuleList
 from imodels.util.arguments import check_binary_target, check_fit_arguments
 
 
 class OneRClassifier(GreedyRuleListClassifier):
     def __init__(self, max_depth=5, class_weight=None, criterion=&#39;gini&#39;):
         self.max_depth = max_depth
-        self.feature_names_ = None
         self.class_weight = class_weight
         self.criterion = criterion
         self._estimator_type = &#39;classifier&#39;
@@ -142,7 +134,6 @@ Criterion used to split
 <pre><code class="python">class OneRClassifier(GreedyRuleListClassifier):
     def __init__(self, max_depth=5, class_weight=None, criterion=&#39;gini&#39;):
         self.max_depth = max_depth
-        self.feature_names_ = None
         self.class_weight = class_weight
         self.criterion = criterion
         self._estimator_type = &#39;classifier&#39;

--- a/docs/rule_set/boosted_rules.html
+++ b/docs/rule_set/boosted_rules.html
@@ -21,24 +21,10 @@
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">from copy import deepcopy
-from functools import partial
-
-import numpy as np
-import sklearn
-from sklearn.ensemble import AdaBoostClassifier, AdaBoostRegressor
-from sklearn.base import BaseEstimator, ClassifierMixin, MetaEstimatorMixin
-from sklearn.model_selection import train_test_split
-from sklearn.preprocessing import normalize
+<pre><code class="python">from sklearn.ensemble import AdaBoostClassifier, AdaBoostRegressor
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
-from sklearn.utils.multiclass import check_classification_targets, unique_labels
-from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
 
-from imodels.rule_set.rule_set import RuleSet
-from imodels.rule_set.slipper_util import SlipperBaseEstimator
 from imodels.util.arguments import check_fit_arguments
-from imodels.util.convert import tree_to_code, tree_to_rules, dict_to_rule
-from imodels.util.rule import Rule, get_feature_dict, replace_feature_name
 
 
 class BoostedRulesClassifier(AdaBoostClassifier):
@@ -150,19 +136,7 @@ class BoostedRulesRegressor(AdaBoostRegressor):
         if names_in is not None:  # super().fit strips this when passed a plain array
             self.feature_names_in_ = names_in
         self.complexity_ = len(self.estimators_)
-        return self
-
-
-if __name__ == &#39;__main__&#39;:
-    np.random.seed(13)
-    X, Y = sklearn.datasets.load_breast_cancer(as_frame=True, return_X_y=True)
-    model = BoostedRulesClassifier(estimator=DecisionTreeClassifier)
-    X_train, X_test, y_train, y_test = train_test_split(X, Y, test_size = 0.3)
-    model.fit(X_train, y_train, feature_names=X_train.columns)
-    y_pred = model.predict(X_test)
-    acc = model.score(X_test, y_test)
-    print(&#39;acc&#39;, acc, &#39;complexity&#39;, model.complexity_)
-    print(model)</code></pre>
+        return self</code></pre>
 </details>
 </section>
 <section>

--- a/docs/rule_set/brs.html
+++ b/docs/rule_set/brs.html
@@ -27,9 +27,7 @@
 
 import itertools
 import operator
-import os
 import warnings
-from os.path import join as oj
 from bisect import bisect_left
 from collections import defaultdict
 from copy import deepcopy
@@ -40,12 +38,10 @@ import numpy as np
 import pandas as pd
 from mlxtend.frequent_patterns import fpgrowth
 from numpy.random import random
-from pandas import read_csv
 from scipy.sparse import csc_matrix
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.ensemble import RandomForestClassifier
-from sklearn.utils.multiclass import check_classification_targets
-from sklearn.utils.validation import check_X_y, check_is_fitted
+from sklearn.utils.validation import check_is_fitted
 
 from imodels.rule_set.rule_set import RuleSet
 from imodels.util.arguments import check_fit_arguments
@@ -540,46 +536,7 @@ def _extract_rules(tree, feature_names):
         for node in _recurse(left, right, child):
             rule.append(node)
         rules.append(rule)
-    return rules
-
-
-if __name__ == &#39;__main__&#39;:
-    test_dir = os.path.dirname(os.path.abspath(__file__))
-
-    df = read_csv(oj(test_dir, &#39;../../tests/test_data&#39;, &#39;tictactoe_X.txt&#39;), header=0, sep=&#34; &#34;)
-    Y = np.loadtxt(open(oj(test_dir, &#39;../../tests/test_data&#39;, &#39;tictactoe_Y.txt&#39;), &#34;rb&#34;), delimiter=&#34; &#34;)
-
-    lenY = len(Y)
-    idxs_train = sample(range(lenY), int(0.50 * lenY))
-    idxs_test = [i for i in range(lenY) if i not in idxs_train]
-    y_test = Y[idxs_test]
-    model = BayesianRuleSetClassifier(n_rules=100,
-                                      supp=5,
-                                      maxlen=3,
-                                      num_iterations=100,
-                                      num_chains=2,
-                                      alpha_pos=500, beta_pos=1,
-                                      alpha_neg=500, beta_neg=1,
-                                      alpha_l=None, beta_l=None)
-
-    # fit and check accuracy
-    np.random.seed(13)
-    # random.seed(13)
-    model.fit(df.iloc[idxs_train], Y[idxs_train])
-    y_pred = model.predict(df.iloc[idxs_test])
-    acc1 = np.mean(y_pred == y_test)
-    assert acc1 &gt; 0.8
-
-    # try fitting np version
-    np.random.seed(13)
-    # random.seed(13)
-    model.fit(df.iloc[idxs_train].values, Y[idxs_train])
-    y_pred = model.predict(df.iloc[idxs_test].values)
-    y_test = Y[idxs_test]
-    acc2 = np.mean(y_pred == y_test)
-    assert acc2 &gt; 0.8
-
-    # assert np.abs(acc1 - acc2) &lt; 0.05 # todo: fix seeding</code></pre>
+    return rules</code></pre>
 </details>
 </section>
 <section>

--- a/docs/rule_set/fpskope.html
+++ b/docs/rule_set/fpskope.html
@@ -24,6 +24,8 @@
 <pre><code class="python">from typing import List
 
 import numpy as np
+
+from imodels.util.arguments import check_binary_target
 import pandas as pd
 
 from imodels.rule_set.skope_rules import SkopeRulesClassifier
@@ -72,6 +74,7 @@ class FPSkopeClassifier(SkopeRulesClassifier):
 
     def fit(self, X, y=None, feature_names=None, undiscretized_features=[], sample_weight=None):
         self.undiscretized_features = undiscretized_features
+        check_binary_target(self, y)
         super().fit(X, y, feature_names=feature_names, sample_weight=sample_weight)
         return self
 
@@ -88,7 +91,8 @@ class FPSkopeClassifier(SkopeRulesClassifier):
                                       self.estimators_samples_,
                                       self.estimators_features_,
                                       self.feature_placeholders,
-                                      oob=False)</code></pre>
+                                      oob=False,
+                                      sample_weight=self.sample_weight)</code></pre>
 </details>
 </section>
 <section>
@@ -249,6 +253,7 @@ estimator.</dd>
 
     def fit(self, X, y=None, feature_names=None, undiscretized_features=[], sample_weight=None):
         self.undiscretized_features = undiscretized_features
+        check_binary_target(self, y)
         super().fit(X, y, feature_names=feature_names, sample_weight=sample_weight)
         return self
 
@@ -265,7 +270,8 @@ estimator.</dd>
                                       self.estimators_samples_,
                                       self.estimators_features_,
                                       self.feature_placeholders,
-                                      oob=False)</code></pre>
+                                      oob=False,
+                                      sample_weight=self.sample_weight)</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">

--- a/docs/rule_set/rule_fit.html
+++ b/docs/rule_set/rule_fit.html
@@ -45,11 +45,10 @@ import scipy
 from scipy.special import softmax
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.base import TransformerMixin
-from sklearn.utils.multiclass import unique_labels
-from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
+from sklearn.utils.validation import check_array, check_is_fitted
 
 from imodels.rule_set.rule_set import RuleSet
-from imodels.util.arguments import check_fit_arguments
+from imodels.util.arguments import check_fit_arguments, check_predict_X
 from imodels.util.extract import extract_rulefit
 from imodels.util.rule import get_feature_dict, replace_feature_name, Rule
 from imodels.util.score import score_linear
@@ -187,6 +186,7 @@ class RuleFit(BaseEstimator, TransformerMixin, RuleSet):
         For classification, returns discrete output.
         &#39;&#39;&#39;
         check_is_fitted(self)
+        check_predict_X(self, X)
         if scipy.sparse.issparse(X):
             X = X.toarray()
         X = check_array(X)
@@ -198,6 +198,7 @@ class RuleFit(BaseEstimator, TransformerMixin, RuleSet):
 
     def predict_proba(self, X):
         check_is_fitted(self)
+        check_predict_X(self, X)
         if scipy.sparse.issparse(X):
             X = X.toarray()
         X = check_array(X)
@@ -570,6 +571,7 @@ the trees are grown, so tuning them on the generator has no effect.</dd>
         For classification, returns discrete output.
         &#39;&#39;&#39;
         check_is_fitted(self)
+        check_predict_X(self, X)
         if scipy.sparse.issparse(X):
             X = X.toarray()
         X = check_array(X)
@@ -581,6 +583,7 @@ the trees are grown, so tuning them on the generator has no effect.</dd>
 
     def predict_proba(self, X):
         check_is_fitted(self)
+        check_predict_X(self, X)
         if scipy.sparse.issparse(X):
             X = X.toarray()
         X = check_array(X)
@@ -819,6 +822,7 @@ For classification, returns discrete output.</p></div>
     For classification, returns discrete output.
     &#39;&#39;&#39;
     check_is_fitted(self)
+    check_predict_X(self, X)
     if scipy.sparse.issparse(X):
         X = X.toarray()
     X = check_array(X)
@@ -840,6 +844,7 @@ For classification, returns discrete output.</p></div>
 </summary>
 <pre><code class="python">def predict_proba(self, X):
     check_is_fitted(self)
+    check_predict_X(self, X)
     if scipy.sparse.issparse(X):
         X = X.toarray()
     X = check_array(X)

--- a/docs/rule_set/skope_rules.html
+++ b/docs/rule_set/skope_rules.html
@@ -158,10 +158,11 @@ import pandas
 import six
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.utils.multiclass import check_classification_targets, unique_labels
-from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
+from sklearn.utils.validation import check_array, check_is_fitted
 
 from imodels.rule_set.rule_set import RuleSet
-from imodels.util.arguments import check_binary_target, check_fit_arguments, decode_labels
+from imodels.util.arguments import (check_binary_target, check_fit_arguments,
+                                    check_predict_X, decode_labels)
 from imodels.util.rule import replace_feature_name, get_feature_dict, Rule
 from imodels.util.extract import extract_skope
 from imodels.util.score import score_precision_recall
@@ -426,6 +427,7 @@ class SkopeRulesClassifier(BaseEstimator, RuleSet, ClassifierMixin):
             For each observations, tells whether or not (1 or 0) it should
             be considered as an outlier according to the selected rules.
         &#34;&#34;&#34;
+        check_predict_X(self, X)
         X = check_array(X)
         return decode_labels(self, np.argmax(self.predict_proba(X), axis=1))
 
@@ -433,6 +435,8 @@ class SkopeRulesClassifier(BaseEstimator, RuleSet, ClassifierMixin):
         &#39;&#39;&#39;Predict probability of a particular sample being an outlier or not
 
         &#39;&#39;&#39;
+        check_is_fitted(self, &#39;rules_without_feature_names_&#39;)
+        check_predict_X(self, X)
         X = check_array(X)
         weight_sum = np.sum([w[0] for (r, w) in self.rules_without_feature_names_])
         if weight_sum == 0:
@@ -565,7 +569,8 @@ class SkopeRulesClassifier(BaseEstimator, RuleSet, ClassifierMixin):
                              verbose=self.verbose)
 
     def _score_rules(self, X, y, rules) -&gt; List[Rule]:
-        return score_precision_recall(X, y, rules, self.estimators_samples_, self.estimators_features_, self.feature_placeholders)
+        return score_precision_recall(X, y, rules, self.estimators_samples_, self.estimators_features_,
+                                      self.feature_placeholders, sample_weight=self.sample_weight)
 
     def _prune_rules(self, rules) -&gt; List[Rule]:
         return deduplicate(
@@ -948,6 +953,7 @@ estimator.</dd>
             For each observations, tells whether or not (1 or 0) it should
             be considered as an outlier according to the selected rules.
         &#34;&#34;&#34;
+        check_predict_X(self, X)
         X = check_array(X)
         return decode_labels(self, np.argmax(self.predict_proba(X), axis=1))
 
@@ -955,6 +961,8 @@ estimator.</dd>
         &#39;&#39;&#39;Predict probability of a particular sample being an outlier or not
 
         &#39;&#39;&#39;
+        check_is_fitted(self, &#39;rules_without_feature_names_&#39;)
+        check_predict_X(self, X)
         X = check_array(X)
         weight_sum = np.sum([w[0] for (r, w) in self.rules_without_feature_names_])
         if weight_sum == 0:
@@ -1087,7 +1095,8 @@ estimator.</dd>
                              verbose=self.verbose)
 
     def _score_rules(self, X, y, rules) -&gt; List[Rule]:
-        return score_precision_recall(X, y, rules, self.estimators_samples_, self.estimators_features_, self.feature_placeholders)
+        return score_precision_recall(X, y, rules, self.estimators_samples_, self.estimators_features_,
+                                      self.feature_placeholders, sample_weight=self.sample_weight)
 
     def _prune_rules(self, rules) -&gt; List[Rule]:
         return deduplicate(
@@ -1267,6 +1276,7 @@ be considered as an outlier according to the selected rules.</dd>
         For each observations, tells whether or not (1 or 0) it should
         be considered as an outlier according to the selected rules.
     &#34;&#34;&#34;
+    check_predict_X(self, X)
     X = check_array(X)
     return decode_labels(self, np.argmax(self.predict_proba(X), axis=1))</code></pre>
 </details>
@@ -1284,6 +1294,8 @@ be considered as an outlier according to the selected rules.</dd>
     &#39;&#39;&#39;Predict probability of a particular sample being an outlier or not
 
     &#39;&#39;&#39;
+    check_is_fitted(self, &#39;rules_without_feature_names_&#39;)
+    check_predict_X(self, X)
     X = check_array(X)
     weight_sum = np.sum([w[0] for (r, w) in self.rules_without_feature_names_])
     if weight_sum == 0:

--- a/docs/rule_set/slipper.html
+++ b/docs/rule_set/slipper.html
@@ -36,7 +36,6 @@ class SlipperClassifier(BoostedRulesClassifier):
         n_estimators
         &#39;&#39;&#39;
         super().__init__(estimator=SlipperBaseEstimator(), n_estimators=n_estimators, **kwargs)
-        # super().__init__(n_estimators, SlipperBaseEstimator)
 
     def fit(self, X, y, feature_names=None, **kwargs):
         # its base estimator learns a single binary rule, so a multiclass target
@@ -86,7 +85,6 @@ Parameters</p>
         n_estimators
         &#39;&#39;&#39;
         super().__init__(estimator=SlipperBaseEstimator(), n_estimators=n_estimators, **kwargs)
-        # super().__init__(n_estimators, SlipperBaseEstimator)
 
     def fit(self, X, y, feature_names=None, **kwargs):
         # its base estimator learns a single binary rule, so a multiclass target

--- a/docs/tree/c45_tree/c45_tree.html
+++ b/docs/tree/c45_tree/c45_tree.html
@@ -42,63 +42,11 @@ import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.model_selection import cross_val_score
-from sklearn.utils.validation import check_array, check_is_fitted, check_X_y
-from imodels.util.arguments import check_fit_arguments, decode_labels
+from sklearn.utils.validation import check_array, check_is_fitted
+from imodels.util.arguments import check_fit_arguments, check_predict_X, decode_labels
 
 from ..c45_tree.c45_utils import decision, is_numeric_feature, gain, gain_ratio, get_best_split, \
     set_as_leaf_node
-from ...util.data_util import get_clean_dataset
-
-
-def _add_label(node, label):
-    if hasattr(node, &#34;labels&#34;):
-        node.labels.append(label)
-        return
-    node.labels = [label]
-    return
-
-
-def _get_next_node(children, att):
-    for child in children:
-        is_equal = child.getAttribute(&#34;flag&#34;) == &#34;m&#34; and child.getAttribute(&#34;feature&#34;) == att
-        is_less_than = child.getAttribute(&#34;flag&#34;) == &#34;l&#34; and float(att) &lt; float(child.getAttribute(&#34;feature&#34;))
-        is_greater_than = child.getAttribute(&#34;flag&#34;) == &#34;r&#34; and float(att) &gt;= float(child.getAttribute(&#34;feature&#34;))
-        if is_equal or is_less_than or is_greater_than:
-            return child
-
-
-def shrink_node(node, reg_param, parent_val, parent_num, cum_sum, scheme, constant):
-    &#34;&#34;&#34;Shrink the tree
-    &#34;&#34;&#34;
-
-    is_leaf = not node.hasChildNodes()
-    # if self.prediction_task == &#39;regression&#39;:
-    val = node.nodeValue
-    is_root = parent_val is None and parent_num is None
-    n_samples = len(node.labels) if (scheme != &#34;leaf_based&#34; or is_root) else parent_num
-
-    if is_root:
-        val_new = val
-
-    else:
-        reg_term = reg_param if scheme == &#34;constant&#34; else reg_param / parent_num
-
-        val_new = (val - parent_val) / (1 + reg_term)
-
-    cum_sum += val_new
-
-    if is_leaf:
-        if scheme == &#34;leaf_based&#34;:
-            v = constant + (val - constant) / (1 + reg_param / node.n_obs)
-            node.nodeValue = v
-        else:
-            node.nodeValue = cum_sum
-
-    else:
-        for c in node.childNodes:
-            shrink_node(c, reg_param, val, parent_num=n_samples, cum_sum=cum_sum, scheme=scheme, constant=constant)
-
-    return node
 
 
 def _add_label(node, label):
@@ -256,7 +204,7 @@ class C45TreeClassifier(BaseEstimator, ClassifierMixin):
 
     def raw_preds(self, X):
         check_is_fitted(self, [&#39;tree_&#39;, &#39;resultType&#39;, &#39;feature_names&#39;])
-        X = check_array(X)
+        X = check_array(check_predict_X(self, X))
         if isinstance(X, pd.DataFrame):
             X = deepcopy(X)
             X.columns = self.feature_names
@@ -296,6 +244,7 @@ class C45TreeClassifier(BaseEstimator, ClassifierMixin):
         return decode_labels(self, np.argmax(self.predict_proba(X), axis=1))
 
     def predict_proba(self, X):
+        check_is_fitted(self, &#39;dom_&#39;)
         if len(self.classes_) == 2:
             # unchanged binary path: leaves hold the probability of class 1,
             # which is also what hierarchical shrinkage rewrites them to
@@ -492,16 +441,7 @@ class HSC45TreeClassifierCV(HSC45TreeClassifier):
             cv_scores = cross_val_score(est, X, y, cv=self.cv, scoring=self.scoring)
             self.scores_.append(np.mean(cv_scores))
         self.reg_param = self.reg_param_list[np.argmax(self.scores_)]
-        super().fit(X=X, y=y)
-
-
-if __name__ == &#39;__main__&#39;:
-    X, y, feature_names = get_clean_dataset(&#39;ionosphere&#39;, data_source=&#39;pmlb&#39;)
-    m = C45TreeClassifier(max_rules=3)
-    m.fit(X, y)
-    s_m = HSC45TreeClassifier(estimator_=m)
-    s_m.fit(X, y)
-    preds = s_m.predict_proba(X)</code></pre>
+        super().fit(X=X, y=y)</code></pre>
 </details>
 </section>
 <section>
@@ -662,7 +602,7 @@ if __name__ == &#39;__main__&#39;:
 
     def raw_preds(self, X):
         check_is_fitted(self, [&#39;tree_&#39;, &#39;resultType&#39;, &#39;feature_names&#39;])
-        X = check_array(X)
+        X = check_array(check_predict_X(self, X))
         if isinstance(X, pd.DataFrame):
             X = deepcopy(X)
             X.columns = self.feature_names
@@ -702,6 +642,7 @@ if __name__ == &#39;__main__&#39;:
         return decode_labels(self, np.argmax(self.predict_proba(X), axis=1))
 
     def predict_proba(self, X):
+        check_is_fitted(self, &#39;dom_&#39;)
         if len(self.classes_) == 2:
             # unchanged binary path: leaves hold the probability of class 1,
             # which is also what hierarchical shrinkage rewrites them to
@@ -1093,6 +1034,7 @@ def root(self):
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def predict_proba(self, X):
+    check_is_fitted(self, &#39;dom_&#39;)
     if len(self.classes_) == 2:
         # unchanged binary path: leaves hold the probability of class 1,
         # which is also what hierarchical shrinkage rewrites them to
@@ -1118,7 +1060,7 @@ def root(self):
 </summary>
 <pre><code class="python">def raw_preds(self, X):
     check_is_fitted(self, [&#39;tree_&#39;, &#39;resultType&#39;, &#39;feature_names&#39;])
-    X = check_array(X)
+    X = check_array(check_predict_X(self, X))
     if isinstance(X, pd.DataFrame):
         X = deepcopy(X)
         X.columns = self.feature_names

--- a/docs/tree/cart_ccp.html
+++ b/docs/tree/cart_ccp.html
@@ -25,10 +25,8 @@
 from typing import List
 
 import numpy as np
-from sklearn import datasets
 from sklearn.base import BaseEstimator, ClassifierMixin
-from sklearn.model_selection import cross_val_score, train_test_split
-from sklearn.tree import DecisionTreeClassifier
+from sklearn.model_selection import cross_val_score
 
 from imodels.tree.hierarchical_shrinkage import HSTreeRegressor, HSTreeClassifier
 from imodels.util.tree import compute_tree_complexity
@@ -64,8 +62,7 @@ class DecisionTreeCCPClassifier(ClassifierMixin, BaseEstimator):
     def _get_alpha(self, X, y, sample_weight=None, *args, **kwargs):
         path = self.estimator_.cost_complexity_pruning_path(
             X, y, sample_weight=sample_weight)
-        ccp_alphas, impurities = path.ccp_alphas, path.impurities
-        complexities = {}
+        ccp_alphas = path.ccp_alphas
         low = 0
         high = len(ccp_alphas) - 1
         cur = 0
@@ -93,6 +90,9 @@ class DecisionTreeCCPClassifier(ClassifierMixin, BaseEstimator):
         # self.alpha = closest_alpha
 
     def fit(self, X, y, sample_weight=None, *args, **kwargs):
+        # fit a copy, so the estimator passed to __init__ is left untouched and
+        # two models sharing one estimator cannot interfere with each other
+        self.estimator_ = deepcopy(self.estimator_)
         params_for_fitting = self.estimator_.get_params()
         self._get_alpha(X, y, sample_weight, *args, **kwargs)
         params_for_fitting[&#39;ccp_alpha&#39;] = self.alpha
@@ -166,8 +166,7 @@ class DecisionTreeCCPRegressor(BaseEstimator):
     def _get_alpha(self, X, y, sample_weight=None):
         path = self.estimator_.cost_complexity_pruning_path(
             X, y, sample_weight=sample_weight)
-        ccp_alphas, impurities = path.ccp_alphas, path.impurities
-        complexities = {}
+        ccp_alphas = path.ccp_alphas
         low = 0
         high = len(ccp_alphas) - 1
         cur = 0
@@ -198,6 +197,8 @@ class DecisionTreeCCPRegressor(BaseEstimator):
     #  self.alpha = closest_alpha
 
     def fit(self, X, y, sample_weight=None):
+        # fit a copy (see DecisionTreeCCPClassifier.fit)
+        self.estimator_ = deepcopy(self.estimator_)
         params_for_fitting = self.estimator_.get_params()
         self._get_alpha(X, y, sample_weight)
         params_for_fitting[&#39;ccp_alpha&#39;] = self.alpha
@@ -272,24 +273,7 @@ class HSDecisionTreeCCPClassifierCV(HSTreeClassifier):
             cv_scores = cross_val_score(est, X, y, cv=self.cv, scoring=self.scoring)
             self.scores_.append(np.mean(cv_scores))
         self.reg_param = self.reg_param_list[np.argmax(self.scores_)]
-        return super().fit(X=X, y=y)
-
-
-if __name__ == &#39;__main__&#39;:
-    m = DecisionTreeCCPClassifier(estimator_=DecisionTreeClassifier(random_state=1), desired_complexity=10,
-                                  complexity_measure=&#39;max_leaf_nodes&#39;)
-    # X,y = make_friedman1() #For regression
-    X, y = datasets.load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.33, random_state=42)
-    m.fit(X_train, y_train)
-    m.predict(X_test)
-    print(m.score(X_test, y_test))
-
-    m = HSDecisionTreeCCPClassifierCV(estimator_=DecisionTreeClassifier(random_state=1), desired_complexity=10,
-                                       reg_param_list=[0.0, 0.1, 1.0, 5.0, 10.0, 25.0, 50.0, 100.0])
-    m.fit(X_train, y_train)
-    print(m.score(X_test, y_test))</code></pre>
+        return super().fit(X=X, y=y)</code></pre>
 </details>
 </section>
 <section>
@@ -369,8 +353,7 @@ array([1, 1, 1])
     def _get_alpha(self, X, y, sample_weight=None, *args, **kwargs):
         path = self.estimator_.cost_complexity_pruning_path(
             X, y, sample_weight=sample_weight)
-        ccp_alphas, impurities = path.ccp_alphas, path.impurities
-        complexities = {}
+        ccp_alphas = path.ccp_alphas
         low = 0
         high = len(ccp_alphas) - 1
         cur = 0
@@ -398,6 +381,9 @@ array([1, 1, 1])
         # self.alpha = closest_alpha
 
     def fit(self, X, y, sample_weight=None, *args, **kwargs):
+        # fit a copy, so the estimator passed to __init__ is left untouched and
+        # two models sharing one estimator cannot interfere with each other
+        self.estimator_ = deepcopy(self.estimator_)
         params_for_fitting = self.estimator_.get_params()
         self._get_alpha(X, y, sample_weight, *args, **kwargs)
         params_for_fitting[&#39;ccp_alpha&#39;] = self.alpha
@@ -489,6 +475,9 @@ def feature_importances_(self):
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def fit(self, X, y, sample_weight=None, *args, **kwargs):
+    # fit a copy, so the estimator passed to __init__ is left untouched and
+    # two models sharing one estimator cannot interfere with each other
+    self.estimator_ = deepcopy(self.estimator_)
     params_for_fitting = self.estimator_.get_params()
     self._get_alpha(X, y, sample_weight, *args, **kwargs)
     params_for_fitting[&#39;ccp_alpha&#39;] = self.alpha
@@ -807,8 +796,7 @@ array([3, 3, 3])
     def _get_alpha(self, X, y, sample_weight=None):
         path = self.estimator_.cost_complexity_pruning_path(
             X, y, sample_weight=sample_weight)
-        ccp_alphas, impurities = path.ccp_alphas, path.impurities
-        complexities = {}
+        ccp_alphas = path.ccp_alphas
         low = 0
         high = len(ccp_alphas) - 1
         cur = 0
@@ -839,6 +827,8 @@ array([3, 3, 3])
     #  self.alpha = closest_alpha
 
     def fit(self, X, y, sample_weight=None):
+        # fit a copy (see DecisionTreeCCPClassifier.fit)
+        self.estimator_ = deepcopy(self.estimator_)
         params_for_fitting = self.estimator_.get_params()
         self._get_alpha(X, y, sample_weight)
         params_for_fitting[&#39;ccp_alpha&#39;] = self.alpha
@@ -923,6 +913,8 @@ def feature_importances_(self):
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def fit(self, X, y, sample_weight=None):
+    # fit a copy (see DecisionTreeCCPClassifier.fit)
+    self.estimator_ = deepcopy(self.estimator_)
     params_for_fitting = self.estimator_.get_params()
     self._get_alpha(X, y, sample_weight)
     params_for_fitting[&#39;ccp_alpha&#39;] = self.alpha

--- a/docs/tree/custom_greedy_tree.html
+++ b/docs/tree/custom_greedy_tree.html
@@ -21,20 +21,9 @@
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">from sklearn.tree._tree import Tree
-from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
-from sklearn.base import ClassifierMixin, RegressorMixin
-from sklearn import __version__
-from collections import namedtuple
-import pandas as pd
-import numpy as np
+<pre><code class="python">import numpy as np
 
-from collections import namedtuple
-
-from sklearn import __version__
-from sklearn.base import ClassifierMixin, RegressorMixin
-from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
-from sklearn.tree._tree import Tree
+from sklearn.base import ClassifierMixin
 import imodels.util.tree
 
 
@@ -189,33 +178,7 @@ class CustomDecisionTreeClassifier(ClassifierMixin):
                 node = node.left
             elif node.right:
                 node = node.right
-        return node.predicted_probs
-
-
-if __name__ == &#39;__main__&#39;:
-    from sklearn.datasets import load_breast_cancer, load_iris
-    from sklearn.model_selection import train_test_split
-    from sklearn.metrics import accuracy_score
-
-    # data = load_breast_cancer()
-    data = load_iris()
-    X = data.data
-    y = data.target
-    # print(np.unique(y))
-
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, random_state=42, test_size=0.5)
-    m = CustomDecisionTreeClassifier(
-        # max_leaf_nodes=20,
-        impurity_func=&#39;cost_information_gain_ratio&#39;)
-    m.fit(X_train, y_train)
-    y_pred = m.predict(X_test)
-    print(&#34;Accuracy:&#34;, accuracy_score(y_test, y_pred))
-    print(&#39;n_nodes&#39;, m.n_splits + 1)
-    print(&#39;shapes&#39;, m.predict_proba(X_test).shape, m.predict(X_test).shape)
-
-    cost = imodels.util.tree.calculate_mean_depth_of_points_in_custom_tree(m)
-    print(&#39;Cost&#39;, cost)</code></pre>
+        return node.predicted_probs</code></pre>
 </details>
 </section>
 <section>

--- a/docs/tree/figs.html
+++ b/docs/tree/figs.html
@@ -28,13 +28,11 @@ import itertools
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from scipy.special import expit
-from sklearn import datasets
 from sklearn import tree
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
-from sklearn.model_selection import train_test_split, cross_val_score
-from sklearn.tree import plot_tree, DecisionTreeClassifier
-from sklearn.utils import check_X_y, check_array
+from sklearn.model_selection import cross_val_score
+from sklearn.tree import plot_tree
+from sklearn.utils import check_array
 from joblib import Parallel, delayed
 from sklearn.utils.class_weight import compute_sample_weight
 from sklearn.utils.validation import _check_sample_weight, check_is_fitted
@@ -42,13 +40,8 @@ from sklearn.utils.validation import _check_sample_weight, check_is_fitted
 from scipy.special import softmax
 
 from imodels.tree.viz_utils import extract_sklearn_tree_from_figs
-from imodels.util.arguments import check_fit_arguments
+from imodels.util.arguments import check_fit_arguments, check_predict_X
 from imodels.util.data_util import encode_categories
-
-import scipy.sparse
-from sklearn.utils.validation import check_X_y, check_array
-from sklearn.utils.multiclass import check_classification_targets, type_of_target
-from sklearn.preprocessing import OneHotEncoder
 
 
 class Node:
@@ -121,7 +114,7 @@ class Node:
         if self.is_root:
             return f&#34;X_{self.feature} &lt;= {self.threshold:0.3f}&#34; + one_proportion
         elif self.left is None and self.right is None:
-            return f&#34;ΔRisk = [&#34; + &#34;, &#34;.join(f&#34;{v:.2f}&#34; for v in self.value) + &#34;]&#34; + one_proportion
+            return &#34;ΔRisk = [&#34; + &#34;, &#34;.join(f&#34;{v:.2f}&#34; for v in self.value) + &#34;]&#34; + one_proportion
         else:
             return f&#34;X_{self.feature} &lt;= {self.threshold:0.3f}&#34; + one_proportion
 
@@ -188,7 +181,6 @@ class FIGS(BaseEstimator):
         self.class_weight = class_weight
         self.verbose = verbose
         self.n_jobs = n_jobs
-        self._init_decision_function()
         self.n_outputs = None
         self.need_to_reshape = False
 
@@ -236,17 +228,6 @@ class FIGS(BaseEstimator):
         if sample_weight is None:
             return class_based
         return np.asarray(sample_weight, dtype=float) * class_based
-
-    def _init_decision_function(self):
-        &#34;&#34;&#34;Sets decision function based on _estimator_type&#34;&#34;&#34;
-        # used by sklearn GridSearchCV, BaggingClassifier
-        if isinstance(self, ClassifierMixin):
-
-            def decision_function(x):
-                return self.predict_proba(x)[:, 1]
-
-        elif isinstance(self, RegressorMixin):
-            decision_function = self.predict
 
     def _construct_node_with_stump(
         self,
@@ -388,6 +369,8 @@ class FIGS(BaseEstimator):
 
         if hasattr(y, &#39;values&#39;):
             y = y.values
+        # y may still be a plain list here, which has no .shape
+        y = np.asarray(y)
         if len(y.shape) == 1:
             y = y.reshape(-1, 1)
         
@@ -446,8 +429,19 @@ class FIGS(BaseEstimator):
             # get node with max impurity_reduction (since it&#39;s sorted)
             split_node = potential_splits.pop()
 
-            # don&#39;t split on node
-            if split_node.impurity_reduction &lt; self.min_impurity_decrease:
+            # don&#39;t split on node.
+            # impurity_reduction is None when the stump found no valid split,
+            # which happens when y is constant over the node -- there is nothing
+            # left to fit, so stop rather than compare None to a float
+            if (split_node.impurity_reduction is None
+                    or split_node.impurity_reduction &lt; self.min_impurity_decrease):
+                # nothing worth splitting on. If that happened before any tree
+                # was grown, keep this node as a single leaf: predictions are a
+                # sum over trees, so with none at all the model would return 0
+                # whatever y is, rather than y&#39;s mean.
+                if split_node.is_root and not self.trees_:
+                    split_node.setattrs(tree_num=0, left=None, right=None)
+                    self.trees_.append(split_node)
                 finished = True
                 break
             elif (
@@ -710,10 +704,10 @@ class FIGS(BaseEstimator):
         if hasattr(self, &#34;_encoder&#34;):
             X = self._encode_categories(
                 X, categorical_features=categorical_features, encoder_name=&#34;_encoder&#34;)
-        X = check_array(X)
+        X = check_array(check_predict_X(self, X))
         preds = np.zeros((X.shape[0], self.n_outputs, len(self.trees_)))
-        for i, tree in enumerate(self.trees_):
-            preds[:, :, i] += self._predict_tree(tree, X)
+        for i, figs_tree in enumerate(self.trees_):
+            preds[:, :, i] += self._predict_tree(figs_tree, X)
         
         if isinstance(self, RegressorMixin):
             if by_tree:
@@ -750,12 +744,12 @@ class FIGS(BaseEstimator):
         if hasattr(self, &#34;_encoder&#34;):
             X = self._encode_categories(
                 X, categorical_features=categorical_features, encoder_name=&#34;_encoder&#34;)
-        X = check_array(X)
+        X = check_array(check_predict_X(self, X))
         if isinstance(self, RegressorMixin):
             return NotImplemented
         preds = np.zeros((X.shape[0], self.n_outputs))
-        for tree in self.trees_:
-            preds += self._predict_tree(tree, X)
+        for figs_tree in self.trees_:
+            preds += self._predict_tree(figs_tree, X)
         if use_clipped_prediction:
             # old behavior, pre v1.3.9
             # constrain to range of probabilities by clipping
@@ -813,27 +807,27 @@ class FIGS(BaseEstimator):
         fig_size=None,
     ):
         is_single_tree = len(self.trees_) &lt; 2 or tree_number is not None
-        n_cols = int(cols)
-        n_rows = int(np.ceil(len(self.trees_) / n_cols))
 
         if feature_names is None:
             if hasattr(self, &#34;feature_names_&#34;) and self.feature_names_ is not None:
                 feature_names = self.feature_names_
 
         n_plots = int(len(self.trees_)) if tree_number is None else 1
-        fig, axs = plt.subplots(n_plots, dpi=dpi)
+        # lay the trees out over `cols` columns, rather than stacking them all
+        # in a single one
+        n_cols = 1 if is_single_tree else max(1, min(int(cols), n_plots))
+        n_rows = int(np.ceil(n_plots / n_cols))
+        fig, axs = plt.subplots(n_rows, n_cols, dpi=dpi, squeeze=False)
         if fig_size is not None:
             fig.set_size_inches(fig_size, fig_size)
 
+        # any trailing cells of the grid hold no tree
+        for ax in axs.flat[n_plots:]:
+            ax.axis(&#34;off&#34;)
+
         n_classes = 1 if isinstance(self, RegressorMixin) else self.n_outputs
-        ax_size = int(len(self.trees_))
         for i in range(n_plots):
-            r = i // n_cols
-            c = i % n_cols
-            if not is_single_tree:
-                ax = axs[i]
-            else:
-                ax = axs
+            ax = axs.flat[i]
             try:
                 dt = extract_sklearn_tree_from_figs(
                     self, i if tree_number is None else tree_number, n_classes
@@ -861,10 +855,26 @@ class FIGSRegressor(RegressorMixin, FIGS):
 
 
 class FIGSClassifier(ClassifierMixin, FIGS):
-    
+
     @property
     def class_map(self):
         return self._class_map
+
+    def decision_function(self, X):
+        &#34;&#34;&#34;Confidence score for the positive class, one value per sample.
+
+        Defined for binary problems only, matching sklearn&#39;s convention; it is
+        what scorers like roc_auc and wrappers like BaggingClassifier reach for
+        before falling back to predict_proba.
+        &#34;&#34;&#34;
+        proba = self.predict_proba(X)
+        if proba.shape[1] != 2:
+            raise AttributeError(
+                &#34;decision_function is only defined for binary classification; &#34;
+                f&#34;this model was fitted with {proba.shape[1]} classes. &#34;
+                &#34;Use predict_proba instead.&#34;
+            )
+        return proba[:, 1]
 
 
 class FIGSCV(BaseEstimator):
@@ -943,9 +953,11 @@ class FIGSCV(BaseEstimator):
         return self
 
     def predict_proba(self, X):
+        check_is_fitted(self, &#39;figs&#39;)
         return self.figs.predict_proba(X)
 
     def predict(self, X, by_tree = False):
+        check_is_fitted(self, &#39;figs&#39;)
         return self.figs.predict(X, by_tree = by_tree)
 
     @property
@@ -1049,51 +1061,7 @@ class FIGSClassifierCV(ClassifierMixin, FIGSCV):
 #             self.estimators.append(est)
     
 #     def predict(self, X):
-#         return np.array([est.predict(X) for est in self.estimators]).T.squeeze(0)
-
-        
-
-
-
-if __name__ == &#34;__main__&#34;:
-    from sklearn import datasets
-
-    X_cls, Y_cls = datasets.load_breast_cancer(return_X_y=True)
-    X_reg, Y_reg = datasets.make_friedman1(100)
-
-    categories = [&#34;cat&#34;, &#34;dog&#34;, &#34;bird&#34;, &#34;fish&#34;]
-    categories_2 = [&#34;bear&#34;, &#34;chicken&#34;, &#34;cow&#34;]
-
-    X_cat = pd.DataFrame(X_reg)
-    X_cat[&#34;pet1&#34;] = np.random.choice(categories, size=(100, 1))
-    X_cat[&#34;pet2&#34;] = np.random.choice(categories_2, size=(100, 1))
-
-    # X_cat.columns[-1] = &#34;pet&#34;
-    Y_cat = Y_reg
-
-    est = FIGSRegressor(max_rules=10)
-    est.fit(X_cat, Y_cat, categorical_features=[&#34;pet1&#34;, &#34;pet2&#34;])
-    est.predict(X_cat, categorical_features=[&#34;pet1&#34;, &#34;pet2&#34;])
-    est.plot(tree_number=1)
-
-    est = FIGSClassifier(max_rules=10)
-    # est.fit(X_cls, Y_cls, sample_weight=np.arange(0, X_cls.shape[0]))
-    est.fit(X_cls, Y_cls, sample_weight=[1] * X_cls.shape[0])
-    est.predict(X_cls)
-
-    est = FIGSRegressorCV()
-    est.fit(X_reg, Y_reg)
-    est.predict(X_reg)
-    print(est.max_rules)
-    est.figs.plot(tree_number=0)
-
-    est = FIGSClassifierCV()
-    est.fit(X_cls, Y_cls)
-    est.predict(X_cls)
-    print(est.max_rules)
-    est.figs.plot(tree_number=0)
-
-# %%</code></pre>
+#         return np.array([est.predict(X) for est in self.estimators]).T.squeeze(0)</code></pre>
 </details>
 </section>
 <section>
@@ -1202,7 +1170,6 @@ when both are given.</p></div>
         self.class_weight = class_weight
         self.verbose = verbose
         self.n_jobs = n_jobs
-        self._init_decision_function()
         self.n_outputs = None
         self.need_to_reshape = False
 
@@ -1250,17 +1217,6 @@ when both are given.</p></div>
         if sample_weight is None:
             return class_based
         return np.asarray(sample_weight, dtype=float) * class_based
-
-    def _init_decision_function(self):
-        &#34;&#34;&#34;Sets decision function based on _estimator_type&#34;&#34;&#34;
-        # used by sklearn GridSearchCV, BaggingClassifier
-        if isinstance(self, ClassifierMixin):
-
-            def decision_function(x):
-                return self.predict_proba(x)[:, 1]
-
-        elif isinstance(self, RegressorMixin):
-            decision_function = self.predict
 
     def _construct_node_with_stump(
         self,
@@ -1402,6 +1358,8 @@ when both are given.</p></div>
 
         if hasattr(y, &#39;values&#39;):
             y = y.values
+        # y may still be a plain list here, which has no .shape
+        y = np.asarray(y)
         if len(y.shape) == 1:
             y = y.reshape(-1, 1)
         
@@ -1460,8 +1418,19 @@ when both are given.</p></div>
             # get node with max impurity_reduction (since it&#39;s sorted)
             split_node = potential_splits.pop()
 
-            # don&#39;t split on node
-            if split_node.impurity_reduction &lt; self.min_impurity_decrease:
+            # don&#39;t split on node.
+            # impurity_reduction is None when the stump found no valid split,
+            # which happens when y is constant over the node -- there is nothing
+            # left to fit, so stop rather than compare None to a float
+            if (split_node.impurity_reduction is None
+                    or split_node.impurity_reduction &lt; self.min_impurity_decrease):
+                # nothing worth splitting on. If that happened before any tree
+                # was grown, keep this node as a single leaf: predictions are a
+                # sum over trees, so with none at all the model would return 0
+                # whatever y is, rather than y&#39;s mean.
+                if split_node.is_root and not self.trees_:
+                    split_node.setattrs(tree_num=0, left=None, right=None)
+                    self.trees_.append(split_node)
                 finished = True
                 break
             elif (
@@ -1724,10 +1693,10 @@ when both are given.</p></div>
         if hasattr(self, &#34;_encoder&#34;):
             X = self._encode_categories(
                 X, categorical_features=categorical_features, encoder_name=&#34;_encoder&#34;)
-        X = check_array(X)
+        X = check_array(check_predict_X(self, X))
         preds = np.zeros((X.shape[0], self.n_outputs, len(self.trees_)))
-        for i, tree in enumerate(self.trees_):
-            preds[:, :, i] += self._predict_tree(tree, X)
+        for i, figs_tree in enumerate(self.trees_):
+            preds[:, :, i] += self._predict_tree(figs_tree, X)
         
         if isinstance(self, RegressorMixin):
             if by_tree:
@@ -1764,12 +1733,12 @@ when both are given.</p></div>
         if hasattr(self, &#34;_encoder&#34;):
             X = self._encode_categories(
                 X, categorical_features=categorical_features, encoder_name=&#34;_encoder&#34;)
-        X = check_array(X)
+        X = check_array(check_predict_X(self, X))
         if isinstance(self, RegressorMixin):
             return NotImplemented
         preds = np.zeros((X.shape[0], self.n_outputs))
-        for tree in self.trees_:
-            preds += self._predict_tree(tree, X)
+        for figs_tree in self.trees_:
+            preds += self._predict_tree(figs_tree, X)
         if use_clipped_prediction:
             # old behavior, pre v1.3.9
             # constrain to range of probabilities by clipping
@@ -1827,27 +1796,27 @@ when both are given.</p></div>
         fig_size=None,
     ):
         is_single_tree = len(self.trees_) &lt; 2 or tree_number is not None
-        n_cols = int(cols)
-        n_rows = int(np.ceil(len(self.trees_) / n_cols))
 
         if feature_names is None:
             if hasattr(self, &#34;feature_names_&#34;) and self.feature_names_ is not None:
                 feature_names = self.feature_names_
 
         n_plots = int(len(self.trees_)) if tree_number is None else 1
-        fig, axs = plt.subplots(n_plots, dpi=dpi)
+        # lay the trees out over `cols` columns, rather than stacking them all
+        # in a single one
+        n_cols = 1 if is_single_tree else max(1, min(int(cols), n_plots))
+        n_rows = int(np.ceil(n_plots / n_cols))
+        fig, axs = plt.subplots(n_rows, n_cols, dpi=dpi, squeeze=False)
         if fig_size is not None:
             fig.set_size_inches(fig_size, fig_size)
 
+        # any trailing cells of the grid hold no tree
+        for ax in axs.flat[n_plots:]:
+            ax.axis(&#34;off&#34;)
+
         n_classes = 1 if isinstance(self, RegressorMixin) else self.n_outputs
-        ax_size = int(len(self.trees_))
         for i in range(n_plots):
-            r = i // n_cols
-            c = i % n_cols
-            if not is_single_tree:
-                ax = axs[i]
-            else:
-                ax = axs
+            ax = axs.flat[i]
             try:
                 dt = extract_sklearn_tree_from_figs(
                     self, i if tree_number is None else tree_number, n_classes
@@ -1962,6 +1931,8 @@ are ignored while searching for a split in each node.</p></div>
 
     if hasattr(y, &#39;values&#39;):
         y = y.values
+    # y may still be a plain list here, which has no .shape
+    y = np.asarray(y)
     if len(y.shape) == 1:
         y = y.reshape(-1, 1)
     
@@ -2020,8 +1991,19 @@ are ignored while searching for a split in each node.</p></div>
         # get node with max impurity_reduction (since it&#39;s sorted)
         split_node = potential_splits.pop()
 
-        # don&#39;t split on node
-        if split_node.impurity_reduction &lt; self.min_impurity_decrease:
+        # don&#39;t split on node.
+        # impurity_reduction is None when the stump found no valid split,
+        # which happens when y is constant over the node -- there is nothing
+        # left to fit, so stop rather than compare None to a float
+        if (split_node.impurity_reduction is None
+                or split_node.impurity_reduction &lt; self.min_impurity_decrease):
+            # nothing worth splitting on. If that happened before any tree
+            # was grown, keep this node as a single leaf: predictions are a
+            # sum over trees, so with none at all the model would return 0
+            # whatever y is, rather than y&#39;s mean.
+            if split_node.is_root and not self.trees_:
+                split_node.setattrs(tree_num=0, left=None, right=None)
+                self.trees_.append(split_node)
             finished = True
             break
         elif (
@@ -2248,27 +2230,27 @@ are ignored while searching for a split in each node.</p></div>
     fig_size=None,
 ):
     is_single_tree = len(self.trees_) &lt; 2 or tree_number is not None
-    n_cols = int(cols)
-    n_rows = int(np.ceil(len(self.trees_) / n_cols))
 
     if feature_names is None:
         if hasattr(self, &#34;feature_names_&#34;) and self.feature_names_ is not None:
             feature_names = self.feature_names_
 
     n_plots = int(len(self.trees_)) if tree_number is None else 1
-    fig, axs = plt.subplots(n_plots, dpi=dpi)
+    # lay the trees out over `cols` columns, rather than stacking them all
+    # in a single one
+    n_cols = 1 if is_single_tree else max(1, min(int(cols), n_plots))
+    n_rows = int(np.ceil(n_plots / n_cols))
+    fig, axs = plt.subplots(n_rows, n_cols, dpi=dpi, squeeze=False)
     if fig_size is not None:
         fig.set_size_inches(fig_size, fig_size)
 
+    # any trailing cells of the grid hold no tree
+    for ax in axs.flat[n_plots:]:
+        ax.axis(&#34;off&#34;)
+
     n_classes = 1 if isinstance(self, RegressorMixin) else self.n_outputs
-    ax_size = int(len(self.trees_))
     for i in range(n_plots):
-        r = i // n_cols
-        c = i % n_cols
-        if not is_single_tree:
-            ax = axs[i]
-        else:
-            ax = axs
+        ax = axs.flat[i]
         try:
             dt = extract_sklearn_tree_from_figs(
                 self, i if tree_number is None else tree_number, n_classes
@@ -2305,10 +2287,10 @@ are ignored while searching for a split in each node.</p></div>
     if hasattr(self, &#34;_encoder&#34;):
         X = self._encode_categories(
             X, categorical_features=categorical_features, encoder_name=&#34;_encoder&#34;)
-    X = check_array(X)
+    X = check_array(check_predict_X(self, X))
     preds = np.zeros((X.shape[0], self.n_outputs, len(self.trees_)))
-    for i, tree in enumerate(self.trees_):
-        preds[:, :, i] += self._predict_tree(tree, X)
+    for i, figs_tree in enumerate(self.trees_):
+        preds[:, :, i] += self._predict_tree(figs_tree, X)
     
     if isinstance(self, RegressorMixin):
         if by_tree:
@@ -2349,12 +2331,12 @@ Set use_clipped_prediction=True to use prior behavior of clipping between 0 and 
     if hasattr(self, &#34;_encoder&#34;):
         X = self._encode_categories(
             X, categorical_features=categorical_features, encoder_name=&#34;_encoder&#34;)
-    X = check_array(X)
+    X = check_array(check_predict_X(self, X))
     if isinstance(self, RegressorMixin):
         return NotImplemented
     preds = np.zeros((X.shape[0], self.n_outputs))
-    for tree in self.trees_:
-        preds += self._predict_tree(tree, X)
+    for figs_tree in self.trees_:
+        preds += self._predict_tree(figs_tree, X)
     if use_clipped_prediction:
         # old behavior, pre v1.3.9
         # constrain to range of probabilities by clipping
@@ -2806,9 +2788,11 @@ array([3, 3, 3])
         return self
 
     def predict_proba(self, X):
+        check_is_fitted(self, &#39;figs&#39;)
         return self.figs.predict_proba(X)
 
     def predict(self, X, by_tree = False):
+        check_is_fitted(self, &#39;figs&#39;)
         return self.figs.predict(X, by_tree = by_tree)
 
     @property
@@ -3024,6 +3008,7 @@ contained subobjects that are estimators.</dd>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def predict(self, X, by_tree = False):
+    check_is_fitted(self, &#39;figs&#39;)
     return self.figs.predict(X, by_tree = by_tree)</code></pre>
 </details>
 </dd>
@@ -3037,6 +3022,7 @@ contained subobjects that are estimators.</dd>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def predict_proba(self, X):
+    check_is_fitted(self, &#39;figs&#39;)
     return self.figs.predict_proba(X)</code></pre>
 </details>
 </dd>
@@ -3228,10 +3214,26 @@ when both are given.</p></div>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">class FIGSClassifier(ClassifierMixin, FIGS):
-    
+
     @property
     def class_map(self):
-        return self._class_map</code></pre>
+        return self._class_map
+
+    def decision_function(self, X):
+        &#34;&#34;&#34;Confidence score for the positive class, one value per sample.
+
+        Defined for binary problems only, matching sklearn&#39;s convention; it is
+        what scorers like roc_auc and wrappers like BaggingClassifier reach for
+        before falling back to predict_proba.
+        &#34;&#34;&#34;
+        proba = self.predict_proba(X)
+        if proba.shape[1] != 2:
+            raise AttributeError(
+                &#34;decision_function is only defined for binary classification; &#34;
+                f&#34;this model was fitted with {proba.shape[1]} classes. &#34;
+                &#34;Use predict_proba instead.&#34;
+            )
+        return proba[:, 1]</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">
@@ -3259,6 +3261,35 @@ def class_map(self):
 </dl>
 <h3>Methods</h3>
 <dl>
+<dt id="imodels.tree.figs.FIGSClassifier.decision_function"><code class="name flex">
+<span>def <span class="ident">decision_function</span></span>(<span>self, X)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Confidence score for the positive class, one value per sample.</p>
+<p>Defined for binary problems only, matching sklearn's convention; it is
+what scorers like roc_auc and wrappers like BaggingClassifier reach for
+before falling back to predict_proba.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def decision_function(self, X):
+    &#34;&#34;&#34;Confidence score for the positive class, one value per sample.
+
+    Defined for binary problems only, matching sklearn&#39;s convention; it is
+    what scorers like roc_auc and wrappers like BaggingClassifier reach for
+    before falling back to predict_proba.
+    &#34;&#34;&#34;
+    proba = self.predict_proba(X)
+    if proba.shape[1] != 2:
+        raise AttributeError(
+            &#34;decision_function is only defined for binary classification; &#34;
+            f&#34;this model was fitted with {proba.shape[1]} classes. &#34;
+            &#34;Use predict_proba instead.&#34;
+        )
+    return proba[:, 1]</code></pre>
+</details>
+</dd>
 <dt id="imodels.tree.figs.FIGSClassifier.set_score_request"><code class="name flex">
 <span>def <span class="ident">set_score_request</span></span>(<span>self: <a title="imodels.tree.figs.FIGSClassifier" href="#imodels.tree.figs.FIGSClassifier">FIGSClassifier</a>, *, sample_weight: bool | str | None = '$UNCHANGED$') ‑> <a title="imodels.tree.figs.FIGSClassifier" href="#imodels.tree.figs.FIGSClassifier">FIGSClassifier</a></span>
 </code></dt>
@@ -4001,7 +4032,7 @@ default=<code>sklearn.utils.metadata_routing.UNCHANGED</code></dt>
         if self.is_root:
             return f&#34;X_{self.feature} &lt;= {self.threshold:0.3f}&#34; + one_proportion
         elif self.left is None and self.right is None:
-            return f&#34;ΔRisk = [&#34; + &#34;, &#34;.join(f&#34;{v:.2f}&#34; for v in self.value) + &#34;]&#34; + one_proportion
+            return &#34;ΔRisk = [&#34; + &#34;, &#34;.join(f&#34;{v:.2f}&#34; for v in self.value) + &#34;]&#34; + one_proportion
         else:
             return f&#34;X_{self.feature} &lt;= {self.threshold:0.3f}&#34; + one_proportion
 
@@ -4035,7 +4066,7 @@ default=<code>sklearn.utils.metadata_routing.UNCHANGED</code></dt>
     if self.is_root:
         return f&#34;X_{self.feature} &lt;= {self.threshold:0.3f}&#34; + one_proportion
     elif self.left is None and self.right is None:
-        return f&#34;ΔRisk = [&#34; + &#34;, &#34;.join(f&#34;{v:.2f}&#34; for v in self.value) + &#34;]&#34; + one_proportion
+        return &#34;ΔRisk = [&#34; + &#34;, &#34;.join(f&#34;{v:.2f}&#34; for v in self.value) + &#34;]&#34; + one_proportion
     else:
         return f&#34;X_{self.feature} &lt;= {self.threshold:0.3f}&#34; + one_proportion</code></pre>
 </details>
@@ -4111,6 +4142,7 @@ default=<code>sklearn.utils.metadata_routing.UNCHANGED</code></dt>
 <h4><code><a title="imodels.tree.figs.FIGSClassifier" href="#imodels.tree.figs.FIGSClassifier">FIGSClassifier</a></code></h4>
 <ul class="">
 <li><code><a title="imodels.tree.figs.FIGSClassifier.class_map" href="#imodels.tree.figs.FIGSClassifier.class_map">class_map</a></code></li>
+<li><code><a title="imodels.tree.figs.FIGSClassifier.decision_function" href="#imodels.tree.figs.FIGSClassifier.decision_function">decision_function</a></code></li>
 <li><code><a title="imodels.tree.figs.FIGSClassifier.set_score_request" href="#imodels.tree.figs.FIGSClassifier.set_score_request">set_score_request</a></code></li>
 </ul>
 </li>

--- a/docs/tree/hierarchical_shrinkage.html
+++ b/docs/tree/hierarchical_shrinkage.html
@@ -25,21 +25,16 @@
 from typing import List
 
 import numpy as np
-from sklearn import datasets
 from sklearn.base import BaseEstimator, RegressorMixin, ClassifierMixin
-from sklearn.metrics import r2_score, mean_squared_error, log_loss
+from sklearn.metrics import mean_squared_error, log_loss
 from sklearn.model_selection import KFold
-from sklearn.model_selection import train_test_split
 from sklearn.tree import DecisionTreeRegressor, DecisionTreeClassifier, export_text
-from sklearn.ensemble import (
-    GradientBoostingClassifier,
-    GradientBoostingRegressor,
-)
+from sklearn.ensemble import GradientBoostingClassifier
 
 from sklearn.utils.validation import check_is_fitted
 
 from imodels.util import checks
-from imodels.util.arguments import check_fit_arguments
+from imodels.util.arguments import check_fit_arguments, check_predict_X
 from imodels.util.tree import compute_tree_complexity
 
 
@@ -147,7 +142,10 @@ class HSTree(BaseEstimator):
             self, X, y, feature_names, allow_nan=True)
         if feature_names is not None:
             self.feature_names = feature_names
-        self.estimator_ = self.estimator_.fit(
+        # fit a copy: shrinkage rewrites the tree in place, so fitting the
+        # object handed to __init__ would shrink it out from under any other
+        # model built on the same estimator
+        self.estimator_ = deepcopy(self.estimator_).fit(
             X, y, *args, sample_weight=sample_weight, **kwargs
         )
         self._shrink()
@@ -291,6 +289,7 @@ class HSTree(BaseEstimator):
                 self._shrink_tree(self._unwrap_tree(t), self.reg_param)
 
     def predict(self, X, *args, **kwargs):
+        check_predict_X(self, X)
         preds = self.estimator_.predict(X, *args, **kwargs)
         # fit encodes y as 0..n_classes-1, so map back onto the original labels.
         # When the estimator was fitted elsewhere and passed in already fitted,
@@ -301,6 +300,7 @@ class HSTree(BaseEstimator):
             return preds
 
     def predict_proba(self, X, *args, **kwargs):
+        check_predict_X(self, X)
         if hasattr(self.estimator_, &#34;predict_proba&#34;):
             probs = self.estimator_.predict_proba(X, *args, **kwargs)
             # the shrinkage arithmetic can leave values a hair outside [0, 1]
@@ -612,59 +612,7 @@ class HSTreeRegressorCV(HSTreeRegressor):
         for attr in attr_list:
             s += attr + &#34;=&#34; + repr(getattr(self, attr)) + &#34;, &#34;
         s = s[:-2] + &#34;)&#34;
-        return s
-
-
-if __name__ == &#34;__main__&#34;:
-    np.random.seed(15)
-    # X, y = datasets.fetch_california_housing(return_X_y=True)  # regression
-    # X, y = datasets.load_breast_cancer(return_X_y=True)  # binary classification
-    X, y = datasets.load_diabetes(return_X_y=True)  # regression
-    # X = np.random.randn(500, 10)
-    # y = (X[:, 0] &gt; 0).astype(float) + (X[:, 1] &gt; 1).astype(float)
-
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.33, random_state=10
-    )
-    print(&#34;X.shape&#34;, X.shape)
-    print(&#34;ys&#34;, np.unique(y_train))
-
-    # m = HSTree(estimator_=DecisionTreeClassifier(), reg_param=0.1)
-    # m = DecisionTreeClassifier(max_leaf_nodes = 20,random_state=1, max_features=None)
-    # m = DecisionTreeClassifier(random_state=42)
-    m = GradientBoostingRegressor(random_state=10, n_estimators=5)
-    # print(&#39;best alpha&#39;, m.reg_param)
-    m.fit(X_train, y_train)
-    # m.predict_proba(X_train)  # just run this
-    print(&#34;score&#34;, r2_score(y_test, m.predict(X_test)))
-    print(&#34;running again....&#34;)
-
-    # x = DecisionTreeRegressor(random_state = 42, ccp_alpha = 0.3)
-    # x.fit(X_train,y_train)
-
-    # m = HSTree(estimator_=DecisionTreeRegressor(random_state=42, max_features=None), reg_param=10)
-    # m = HSTree(estimator_=DecisionTreeClassifier(random_state=42, max_features=None), reg_param=0)
-    # m = HSTreeRegressorCV(
-    #     estimator_=DecisionTreeClassifier(random_state=42),
-    #     shrinkage_scheme_=&#34;node_based&#34;,
-    #     reg_param_list=[0.1, 1, 2, 5, 10, 25, 50, 100, 500],
-    # )
-    # m = ShrunkTreeCV(estimator_=DecisionTreeClassifier())
-    m = HSTreeRegressor(m)
-    print(&#34;score&#34;, r2_score(y_test, m.predict(X_test)))
-
-    m = HSTreeRegressor(
-        estimator_=GradientBoostingRegressor(
-            random_state=10,
-            n_estimators=5,
-        ),
-        reg_param=1,
-    )
-    m.fit(X_train, y_train)
-    print(&#34;best alpha&#34;, m.reg_param)
-    # m.predict_proba(X_train)  # just run this
-    # print(&#39;score&#39;, m.score(X_test, y_test))
-    print(&#34;score&#34;, r2_score(y_test, m.predict(X_test)))</code></pre>
+        return s</code></pre>
 </details>
 </section>
 <section>
@@ -829,7 +777,10 @@ If estimator is None, then max_leaf_nodes is passed to the default decision tree
             self, X, y, feature_names, allow_nan=True)
         if feature_names is not None:
             self.feature_names = feature_names
-        self.estimator_ = self.estimator_.fit(
+        # fit a copy: shrinkage rewrites the tree in place, so fitting the
+        # object handed to __init__ would shrink it out from under any other
+        # model built on the same estimator
+        self.estimator_ = deepcopy(self.estimator_).fit(
             X, y, *args, sample_weight=sample_weight, **kwargs
         )
         self._shrink()
@@ -973,6 +924,7 @@ If estimator is None, then max_leaf_nodes is passed to the default decision tree
                 self._shrink_tree(self._unwrap_tree(t), self.reg_param)
 
     def predict(self, X, *args, **kwargs):
+        check_predict_X(self, X)
         preds = self.estimator_.predict(X, *args, **kwargs)
         # fit encodes y as 0..n_classes-1, so map back onto the original labels.
         # When the estimator was fitted elsewhere and passed in already fitted,
@@ -983,6 +935,7 @@ If estimator is None, then max_leaf_nodes is passed to the default decision tree
             return preds
 
     def predict_proba(self, X, *args, **kwargs):
+        check_predict_X(self, X)
         if hasattr(self.estimator_, &#34;predict_proba&#34;):
             probs = self.estimator_.predict_proba(X, *args, **kwargs)
             # the shrinkage arithmetic can leave values a hair outside [0, 1]
@@ -1124,7 +1077,10 @@ def feature_importances_(self):
         self, X, y, feature_names, allow_nan=True)
     if feature_names is not None:
         self.feature_names = feature_names
-    self.estimator_ = self.estimator_.fit(
+    # fit a copy: shrinkage rewrites the tree in place, so fitting the
+    # object handed to __init__ would shrink it out from under any other
+    # model built on the same estimator
+    self.estimator_ = deepcopy(self.estimator_).fit(
         X, y, *args, sample_weight=sample_weight, **kwargs
     )
     self._shrink()
@@ -1200,6 +1156,7 @@ contained subobjects that are estimators.</dd>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def predict(self, X, *args, **kwargs):
+    check_predict_X(self, X)
     preds = self.estimator_.predict(X, *args, **kwargs)
     # fit encodes y as 0..n_classes-1, so map back onto the original labels.
     # When the estimator was fitted elsewhere and passed in already fitted,
@@ -1220,6 +1177,7 @@ contained subobjects that are estimators.</dd>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def predict_proba(self, X, *args, **kwargs):
+    check_predict_X(self, X)
     if hasattr(self.estimator_, &#34;predict_proba&#34;):
         probs = self.estimator_.predict_proba(X, *args, **kwargs)
         # the shrinkage arithmetic can leave values a hair outside [0, 1]
@@ -1687,69 +1645,6 @@ Note: args, kwargs are not used but left so that imodels-experiments can still p
     return super().fit(X=X, y=y, *args, **kwargs)</code></pre>
 </details>
 </dd>
-<dt id="imodels.tree.hierarchical_shrinkage.HSTreeClassifierCV.set_fit_request"><code class="name flex">
-<span>def <span class="ident">set_fit_request</span></span>(<span>self: <a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifierCV" href="#imodels.tree.hierarchical_shrinkage.HSTreeClassifierCV">HSTreeClassifierCV</a>) ‑> <a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifierCV" href="#imodels.tree.hierarchical_shrinkage.HSTreeClassifierCV">HSTreeClassifierCV</a></span>
-</code></dt>
-<dd>
-<div class="desc"><p>No-op.</p>
-<p>Calling this method has no effect.</p>
-<h2 id="returns">Returns</h2>
-<dl>
-<dt><strong><code>self</code></strong> :&ensp;<code>object</code></dt>
-<dd>The updated object.</dd>
-</dl></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def func(*args, **kw):
-    &#34;&#34;&#34;Updates the `_metadata_request` attribute of the consumer (`instance`)
-    for the parameters provided as `**kw`.
-
-    This docstring is overwritten below.
-    See REQUESTER_DOC for expected functionality.
-    &#34;&#34;&#34;
-    if not _routing_enabled():
-        raise RuntimeError(
-            &#34;This method is only available when metadata routing is enabled.&#34;
-            &#34; You can enable it using&#34;
-            &#34; sklearn.set_config(enable_metadata_routing=True).&#34;
-        )
-
-    if self.validate_keys and (set(kw) - set(self.keys)):
-        raise TypeError(
-            f&#34;Unexpected args: {set(kw) - set(self.keys)} in {self.name}. &#34;
-            f&#34;Accepted arguments are: {set(self.keys)}&#34;
-        )
-
-    # This makes it possible to use the decorated method as an unbound method,
-    # for instance when monkeypatching.
-    # https://github.com/scikit-learn/scikit-learn/issues/28632
-    if instance is None:
-        _instance = args[0]
-        args = args[1:]
-    else:
-        _instance = instance
-
-    # Replicating python&#39;s behavior when positional args are given other than
-    # `self`, and `self` is only allowed if this method is unbound.
-    if args:
-        raise TypeError(
-            f&#34;set_{self.name}_request() takes 0 positional argument but&#34;
-            f&#34; {len(args)} were given&#34;
-        )
-
-    requests = _instance._get_metadata_request()
-    method_metadata_request = getattr(requests, self.name)
-
-    for prop, alias in kw.items():
-        if alias is not UNCHANGED:
-            method_metadata_request.add_request(param=prop, alias=alias)
-    _instance._metadata_request = requests
-
-    return _instance</code></pre>
-</details>
-</dd>
 </dl>
 <h3>Inherited members</h3>
 <ul class="hlist">
@@ -1759,6 +1654,7 @@ Note: args, kwargs are not used but left so that imodels-experiments can still p
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifier.feature_importances_" href="#imodels.tree.hierarchical_shrinkage.HSTree.feature_importances_">feature_importances_</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifier.get_params" href="#imodels.tree.hierarchical_shrinkage.HSTree.get_params">get_params</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifier.get_rules" href="#imodels.tree.hierarchical_shrinkage.HSTree.get_rules">get_rules</a></code></li>
+<li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifier.set_fit_request" href="#imodels.tree.hierarchical_shrinkage.HSTree.set_fit_request">set_fit_request</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifier.set_score_request" href="#imodels.tree.hierarchical_shrinkage.HSTreeClassifier.set_score_request">set_score_request</a></code></li>
 </ul>
 </li>
@@ -2124,69 +2020,6 @@ Note: args, kwargs are not used but left so that imodels-experiments can still p
     return super().fit(X=X, y=y, *args, **kwargs)</code></pre>
 </details>
 </dd>
-<dt id="imodels.tree.hierarchical_shrinkage.HSTreeRegressorCV.set_fit_request"><code class="name flex">
-<span>def <span class="ident">set_fit_request</span></span>(<span>self: <a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressorCV" href="#imodels.tree.hierarchical_shrinkage.HSTreeRegressorCV">HSTreeRegressorCV</a>) ‑> <a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressorCV" href="#imodels.tree.hierarchical_shrinkage.HSTreeRegressorCV">HSTreeRegressorCV</a></span>
-</code></dt>
-<dd>
-<div class="desc"><p>No-op.</p>
-<p>Calling this method has no effect.</p>
-<h2 id="returns">Returns</h2>
-<dl>
-<dt><strong><code>self</code></strong> :&ensp;<code>object</code></dt>
-<dd>The updated object.</dd>
-</dl></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def func(*args, **kw):
-    &#34;&#34;&#34;Updates the `_metadata_request` attribute of the consumer (`instance`)
-    for the parameters provided as `**kw`.
-
-    This docstring is overwritten below.
-    See REQUESTER_DOC for expected functionality.
-    &#34;&#34;&#34;
-    if not _routing_enabled():
-        raise RuntimeError(
-            &#34;This method is only available when metadata routing is enabled.&#34;
-            &#34; You can enable it using&#34;
-            &#34; sklearn.set_config(enable_metadata_routing=True).&#34;
-        )
-
-    if self.validate_keys and (set(kw) - set(self.keys)):
-        raise TypeError(
-            f&#34;Unexpected args: {set(kw) - set(self.keys)} in {self.name}. &#34;
-            f&#34;Accepted arguments are: {set(self.keys)}&#34;
-        )
-
-    # This makes it possible to use the decorated method as an unbound method,
-    # for instance when monkeypatching.
-    # https://github.com/scikit-learn/scikit-learn/issues/28632
-    if instance is None:
-        _instance = args[0]
-        args = args[1:]
-    else:
-        _instance = instance
-
-    # Replicating python&#39;s behavior when positional args are given other than
-    # `self`, and `self` is only allowed if this method is unbound.
-    if args:
-        raise TypeError(
-            f&#34;set_{self.name}_request() takes 0 positional argument but&#34;
-            f&#34; {len(args)} were given&#34;
-        )
-
-    requests = _instance._get_metadata_request()
-    method_metadata_request = getattr(requests, self.name)
-
-    for prop, alias in kw.items():
-        if alias is not UNCHANGED:
-            method_metadata_request.add_request(param=prop, alias=alias)
-    _instance._metadata_request = requests
-
-    return _instance</code></pre>
-</details>
-</dd>
 </dl>
 <h3>Inherited members</h3>
 <ul class="hlist">
@@ -2196,6 +2029,7 @@ Note: args, kwargs are not used but left so that imodels-experiments can still p
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressor.feature_importances_" href="#imodels.tree.hierarchical_shrinkage.HSTree.feature_importances_">feature_importances_</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressor.get_params" href="#imodels.tree.hierarchical_shrinkage.HSTree.get_params">get_params</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressor.get_rules" href="#imodels.tree.hierarchical_shrinkage.HSTree.get_rules">get_rules</a></code></li>
+<li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressor.set_fit_request" href="#imodels.tree.hierarchical_shrinkage.HSTree.set_fit_request">set_fit_request</a></code></li>
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressor.set_score_request" href="#imodels.tree.hierarchical_shrinkage.HSTreeRegressor.set_score_request">set_score_request</a></code></li>
 </ul>
 </li>
@@ -2240,7 +2074,6 @@ Note: args, kwargs are not used but left so that imodels-experiments can still p
 <h4><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifierCV" href="#imodels.tree.hierarchical_shrinkage.HSTreeClassifierCV">HSTreeClassifierCV</a></code></h4>
 <ul class="">
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifierCV.fit" href="#imodels.tree.hierarchical_shrinkage.HSTreeClassifierCV.fit">fit</a></code></li>
-<li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeClassifierCV.set_fit_request" href="#imodels.tree.hierarchical_shrinkage.HSTreeClassifierCV.set_fit_request">set_fit_request</a></code></li>
 </ul>
 </li>
 <li>
@@ -2253,7 +2086,6 @@ Note: args, kwargs are not used but left so that imodels-experiments can still p
 <h4><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressorCV" href="#imodels.tree.hierarchical_shrinkage.HSTreeRegressorCV">HSTreeRegressorCV</a></code></h4>
 <ul class="">
 <li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressorCV.fit" href="#imodels.tree.hierarchical_shrinkage.HSTreeRegressorCV.fit">fit</a></code></li>
-<li><code><a title="imodels.tree.hierarchical_shrinkage.HSTreeRegressorCV.set_fit_request" href="#imodels.tree.hierarchical_shrinkage.HSTreeRegressorCV.set_fit_request">set_fit_request</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/tree/rf_plus/feature_importance/ppms/ppms.html
+++ b/docs/tree/rf_plus/feature_importance/ppms/ppms.html
@@ -24,8 +24,6 @@
 <pre><code class="python"># generic imports
 import copy
 from abc import ABC
-import numpy as np
-from scipy.special import expit
 from joblib import Parallel, delayed
 
 class MDIPlusGenericRegressorPPM(ABC):

--- a/docs/tree/rf_plus/rf_plus/rf_plus_models.html
+++ b/docs/tree/rf_plus/rf_plus/rf_plus_models.html
@@ -31,7 +31,6 @@ from sklearn.base import BaseEstimator, RegressorMixin, ClassifierMixin
 from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted
 from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier
-from sklearn.model_selection import train_test_split
 from sklearn.ensemble import GradientBoostingRegressor, GradientBoostingClassifier
 from imodels.util.sklearn_compat import (
     generate_unsampled_indices as _generate_unsampled_indices,
@@ -137,7 +136,7 @@ class _RandomForestPlus(BaseEstimator):
             elif self.rf_model.get_params()[&#39;loss&#39;] == &#34;log_loss&#34;:
                 if self.rf_model.init == &#34;zero&#34;:
                     self._y_avg = 0
-                elif self.rf_model.init == None:
+                elif self.rf_model.init is None:
                     # get the most common class
                     self._y_avg = float(round(np.mean(y)))
                 else:

--- a/docs/tree/rf_plus/rf_plus/rf_plus_utils.html
+++ b/docs/tree/rf_plus/rf_plus/rf_plus_utils.html
@@ -78,7 +78,6 @@ def _neg_log_loss(y_true, y_pred):
 
 def _check_Xy(X,y):
     if isinstance(X, pd.DataFrame):
-        feature_names_ = list(X.columns)
         X_array = X.values
     elif isinstance(X, np.ndarray):
         X_array = X
@@ -92,7 +91,6 @@ def _check_Xy(X,y):
 
 def _check_X(X):
     if isinstance(X, pd.DataFrame):
-        feature_names_ = list(X.columns)
         X_array = X.values
     elif isinstance(X, np.ndarray):
         X_array = X

--- a/docs/tree/tao.html
+++ b/docs/tree/tao.html
@@ -21,21 +21,19 @@
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">import random
-from copy import deepcopy
+<pre><code class="python">from copy import deepcopy
 from queue import deque
 
 import numpy as np
 from mlxtend.classifier import LogisticRegression
-from sklearn import datasets
 from sklearn.base import BaseEstimator, RegressorMixin, ClassifierMixin
 from sklearn.linear_model import LinearRegression
 from sklearn.metrics import get_scorer
-from sklearn.model_selection import train_test_split
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor, export_text
 from sklearn.utils import check_X_y
 
-from imodels.util.arguments import check_fit_arguments
+from imodels.util.arguments import check_fit_arguments, check_predict_X
+from sklearn.utils.validation import check_is_fitted
 
 
 class TaoTree(BaseEstimator):
@@ -412,6 +410,8 @@ class TaoTree(BaseEstimator):
         return self.model.feature_importances_
 
     def predict(self, X):
+        check_is_fitted(self, &#39;model&#39;)
+        check_predict_X(self, X)
         preds = self.model.predict(X)
         if hasattr(self, &#34;classes_&#34;):
             return np.array([self.classes_[int(i)] for i in preds])
@@ -419,6 +419,8 @@ class TaoTree(BaseEstimator):
             return preds
 
     def predict_proba(self, X):
+        check_is_fitted(self, &#39;model&#39;)
+        check_predict_X(self, X)
         return self.model.predict_proba(X)
 
     # def score(self, X, y):
@@ -430,37 +432,7 @@ class TaoTreeRegressor(TaoTree, RegressorMixin):
 
 
 class TaoTreeClassifier(TaoTree, ClassifierMixin):
-    pass
-
-
-if __name__ == &#39;__main__&#39;:
-    np.random.seed(13)
-    random.seed(13)
-    X, y = datasets.load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.33, random_state=42
-    )
-    print(&#39;X.shape&#39;, X.shape)
-    print(&#39;ys&#39;, np.unique(y_train), &#39;\n\n&#39;)
-    m = TaoTreeClassifier(randomize_tree=False, weight_errors=False,
-                          node_model=&#39;stump&#39;, model_args={&#39;max_depth&#39;: 3},
-                          verbose=1)
-    m.fit(X_train, y_train)
-    print(&#39;Train acc&#39;, np.mean(m.predict(X_train) == y_train))
-    print(&#39;Test acc&#39;, np.mean(m.predict(X_test) == y_test))
-    # print(m.predict(X_train), m.predict_proba(X_train).shape)
-    # print(m.predict_proba(X_train))
-
-    # X, y = datasets.load_diabetes(return_X_y=True)  # regression
-    # X = np.random.randn(500, 10)
-    # y = (X[:, 0] &gt; 0).astype(float) + (X[:, 1] &gt; 1).astype(float)
-    # X_train, X_test, y_train, y_test = train_test_split(
-    #     X, y, test_size=0.33, random_state=42
-    # )
-    # m = TaoRegressor()
-    # m.fit(X_train, y_train)
-    # print(&#39;mse&#39;, np.mean(np.square(m.predict(X_test) - y_test)),
-    #       &#39;baseline&#39;, np.mean(np.square(y_test)))</code></pre>
+    pass</code></pre>
 </details>
 </section>
 <section>
@@ -928,6 +900,8 @@ Note: this implementation learns single-feature splits rather than oblique trees
         return self.model.feature_importances_
 
     def predict(self, X):
+        check_is_fitted(self, &#39;model&#39;)
+        check_predict_X(self, X)
         preds = self.model.predict(X)
         if hasattr(self, &#34;classes_&#34;):
             return np.array([self.classes_[int(i)] for i in preds])
@@ -935,6 +909,8 @@ Note: this implementation learns single-feature splits rather than oblique trees
             return preds
 
     def predict_proba(self, X):
+        check_is_fitted(self, &#39;model&#39;)
+        check_predict_X(self, X)
         return self.model.predict_proba(X)
 
     # def score(self, X, y):
@@ -1069,6 +1045,8 @@ are ignored while searching for a split in each node.</p></div>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def predict(self, X):
+    check_is_fitted(self, &#39;model&#39;)
+    check_predict_X(self, X)
     preds = self.model.predict(X)
     if hasattr(self, &#34;classes_&#34;):
         return np.array([self.classes_[int(i)] for i in preds])
@@ -1086,6 +1064,8 @@ are ignored while searching for a split in each node.</p></div>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def predict_proba(self, X):
+    check_is_fitted(self, &#39;model&#39;)
+    check_predict_X(self, X)
     return self.model.predict_proba(X)
 
 # def score(self, X, y):

--- a/docs/util/arguments.html
+++ b/docs/util/arguments.html
@@ -26,7 +26,7 @@
 import numpy as np
 import pandas as pd
 from sklearn.base import ClassifierMixin
-from sklearn.utils.validation import check_X_y, check_array
+from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
 from sklearn.utils.multiclass import check_classification_targets
 import scipy.sparse
 
@@ -98,6 +98,49 @@ def _finite_check_kwarg(allow_nan):
             if &#34;ensure_all_finite&#34; in signature(check_X_y).parameters
             else &#34;force_all_finite&#34;)
     return {name: &#34;allow-nan&#34;}
+
+
+def check_predict_X(model, X):
+    &#34;&#34;&#34;Check X at predict time against the data the model was fitted on.
+
+    Models that index X by a stored feature number silently accept extra
+    columns, returning predictions that look reasonable but ignore part of the
+    input. They equally silently accept the right columns in the wrong order,
+    which quietly returns predictions for the wrong features. sklearn raises in
+    both cases, and so should we.
+
+    Also raises NotFittedError when called before fit. Otherwise predicting on
+    an unfitted model fails later with whatever AttributeError the model
+    happens to hit first, which callers cannot catch as NotFittedError.
+
+    Pass X before converting it to an array, or the column names are gone by the
+    time this sees them.
+    &#34;&#34;&#34;
+    check_is_fitted(model)
+
+    # read the shape off X directly: np.shape() would coerce X, and sklearn&#39;s
+    # estimator checks pass array-likes that must reach check_array untouched
+    shape = getattr(X, &#39;shape&#39;, None)
+    n_given = shape[1] if shape is not None and len(shape) == 2 else None
+
+    n_features = getattr(model, &#39;n_features_in_&#39;, None)
+    if n_features is not None and n_given is not None and n_given != n_features:
+        raise ValueError(
+            f&#34;X has {n_given} features, but &#34;
+            f&#34;{type(model).__name__} is expecting {n_features} features as input.&#34;
+        )
+
+    fitted_names = getattr(model, &#39;feature_names_in_&#39;, None)
+    if fitted_names is not None and hasattr(X, &#39;columns&#39;):
+        given = np.asarray(X.columns, dtype=object)
+        if not np.array_equal(given, np.asarray(fitted_names, dtype=object)):
+            raise ValueError(
+                &#34;The feature names should match those that were passed during &#34;
+                f&#34;fit.\nFeature names seen at fit time, in order:\n&#34;
+                f&#34;{list(fitted_names)}\nFeature names given, in order:\n&#34;
+                f&#34;{list(given)}&#34;
+            )
+    return X
 
 
 def set_feature_names_in(model, X):
@@ -245,6 +288,68 @@ tree). That estimator still raises if it cannot.</p></div>
     return X, y, model.feature_names_</code></pre>
 </details>
 </dd>
+<dt id="imodels.util.arguments.check_predict_X"><code class="name flex">
+<span>def <span class="ident">check_predict_X</span></span>(<span>model, X)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Check X at predict time against the data the model was fitted on.</p>
+<p>Models that index X by a stored feature number silently accept extra
+columns, returning predictions that look reasonable but ignore part of the
+input. They equally silently accept the right columns in the wrong order,
+which quietly returns predictions for the wrong features. sklearn raises in
+both cases, and so should we.</p>
+<p>Also raises NotFittedError when called before fit. Otherwise predicting on
+an unfitted model fails later with whatever AttributeError the model
+happens to hit first, which callers cannot catch as NotFittedError.</p>
+<p>Pass X before converting it to an array, or the column names are gone by the
+time this sees them.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def check_predict_X(model, X):
+    &#34;&#34;&#34;Check X at predict time against the data the model was fitted on.
+
+    Models that index X by a stored feature number silently accept extra
+    columns, returning predictions that look reasonable but ignore part of the
+    input. They equally silently accept the right columns in the wrong order,
+    which quietly returns predictions for the wrong features. sklearn raises in
+    both cases, and so should we.
+
+    Also raises NotFittedError when called before fit. Otherwise predicting on
+    an unfitted model fails later with whatever AttributeError the model
+    happens to hit first, which callers cannot catch as NotFittedError.
+
+    Pass X before converting it to an array, or the column names are gone by the
+    time this sees them.
+    &#34;&#34;&#34;
+    check_is_fitted(model)
+
+    # read the shape off X directly: np.shape() would coerce X, and sklearn&#39;s
+    # estimator checks pass array-likes that must reach check_array untouched
+    shape = getattr(X, &#39;shape&#39;, None)
+    n_given = shape[1] if shape is not None and len(shape) == 2 else None
+
+    n_features = getattr(model, &#39;n_features_in_&#39;, None)
+    if n_features is not None and n_given is not None and n_given != n_features:
+        raise ValueError(
+            f&#34;X has {n_given} features, but &#34;
+            f&#34;{type(model).__name__} is expecting {n_features} features as input.&#34;
+        )
+
+    fitted_names = getattr(model, &#39;feature_names_in_&#39;, None)
+    if fitted_names is not None and hasattr(X, &#39;columns&#39;):
+        given = np.asarray(X.columns, dtype=object)
+        if not np.array_equal(given, np.asarray(fitted_names, dtype=object)):
+            raise ValueError(
+                &#34;The feature names should match those that were passed during &#34;
+                f&#34;fit.\nFeature names seen at fit time, in order:\n&#34;
+                f&#34;{list(fitted_names)}\nFeature names given, in order:\n&#34;
+                f&#34;{list(given)}&#34;
+            )
+    return X</code></pre>
+</details>
+</dd>
 <dt id="imodels.util.arguments.decode_labels"><code class="name flex">
 <span>def <span class="ident">decode_labels</span></span>(<span>model, preds)</span>
 </code></dt>
@@ -317,6 +422,7 @@ again afterwards.</p></div>
 <li><code><a title="imodels.util.arguments.check_binary_target" href="#imodels.util.arguments.check_binary_target">check_binary_target</a></code></li>
 <li><code><a title="imodels.util.arguments.check_fit_X" href="#imodels.util.arguments.check_fit_X">check_fit_X</a></code></li>
 <li><code><a title="imodels.util.arguments.check_fit_arguments" href="#imodels.util.arguments.check_fit_arguments">check_fit_arguments</a></code></li>
+<li><code><a title="imodels.util.arguments.check_predict_X" href="#imodels.util.arguments.check_predict_X">check_predict_X</a></code></li>
 <li><code><a title="imodels.util.arguments.decode_labels" href="#imodels.util.arguments.decode_labels">decode_labels</a></code></li>
 <li><code><a title="imodels.util.arguments.set_feature_names_in" href="#imodels.util.arguments.set_feature_names_in">set_feature_names_in</a></code></li>
 </ul>

--- a/docs/util/automl.html
+++ b/docs/util/automl.html
@@ -35,11 +35,11 @@ from imodels import (
 )
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.linear_model import LogisticRegression, ElasticNet, Ridge
-import imodels
-from sklearn.model_selection import GridSearchCV, train_test_split
+from sklearn.model_selection import GridSearchCV
 import numpy as np
 from sklearn.pipeline import Pipeline
 from imodels.util.arguments import set_feature_names_in
+from sklearn.utils.validation import check_is_fitted
 
 
 class AutoInterpretableModel(BaseEstimator):
@@ -74,13 +74,29 @@ class AutoInterpretableModel(BaseEstimator):
         return self
 
     def predict(self, X):
+        check_is_fitted(self, &#39;est_&#39;)
         return self.est_.predict(X)
 
     def predict_proba(self, X):
+        check_is_fitted(self, &#39;est_&#39;)
         return self.est_.predict_proba(X)
 
     def score(self, X, y):
+        check_is_fitted(self, &#39;est_&#39;)
         return self.est_.score(X, y)
+
+    def get_rules(self, feature_names=None):
+        &#34;&#34;&#34;Return this model&#39;s rules as a DataFrame (see imodels.get_rules).
+
+        The rules are those of the model the search selected.
+        &#34;&#34;&#34;
+        from imodels.util.get_rules import get_rules
+        return get_rules(self, feature_names=feature_names)
+
+    def apply(self, X):
+        &#34;&#34;&#34;Return the leaf each sample reaches (see imodels.util.apply.apply_leaves).&#34;&#34;&#34;
+        from imodels.util.apply import apply_leaves
+        return apply_leaves(self, X)
 
     PARAM_GRID_LINEAR_CLASSIFICATION = [
         {
@@ -164,25 +180,7 @@ class AutoInterpretableClassifier(AutoInterpretableModel, ClassifierMixin):
 
 
 class AutoInterpretableRegressor(AutoInterpretableModel, RegressorMixin):
-    ...
-
-
-if __name__ == &#34;__main__&#34;:
-    X, y, feature_names = imodels.get_clean_dataset(&#34;heart&#34;)
-
-    print(&#34;shapes&#34;, X.shape, y.shape, &#34;nunique&#34;, np.unique(y).size)
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, random_state=42, test_size=0.2
-    )
-
-    m = AutoInterpretableClassifier()
-    # m = AutoInterpretableRegressor()
-    m.fit(X_train, y_train)
-
-    print(&#34;best params&#34;, m.est_.best_params_)
-    print(&#34;best score&#34;, m.est_.best_score_)
-    print(&#34;best estimator&#34;, m.est_.best_estimator_)
-    print(&#34;best estimator params&#34;, m.est_.best_estimator_.get_params())</code></pre>
+    ...</code></pre>
 </details>
 </section>
 <section>
@@ -222,6 +220,8 @@ This is basically a wrapper around GridSearchCV, with some preselected models.</
 <ul class="hlist">
 <li><code><b><a title="imodels.util.automl.AutoInterpretableModel" href="#imodels.util.automl.AutoInterpretableModel">AutoInterpretableModel</a></b></code>:
 <ul class="hlist">
+<li><code><a title="imodels.util.automl.AutoInterpretableModel.apply" href="#imodels.util.automl.AutoInterpretableModel.apply">apply</a></code></li>
+<li><code><a title="imodels.util.automl.AutoInterpretableModel.get_rules" href="#imodels.util.automl.AutoInterpretableModel.get_rules">get_rules</a></code></li>
 <li><code><a title="imodels.util.automl.AutoInterpretableModel.set_fit_request" href="#imodels.util.automl.AutoInterpretableModel.set_fit_request">set_fit_request</a></code></li>
 </ul>
 </li>
@@ -271,13 +271,29 @@ This is basically a wrapper around GridSearchCV, with some preselected models.</
         return self
 
     def predict(self, X):
+        check_is_fitted(self, &#39;est_&#39;)
         return self.est_.predict(X)
 
     def predict_proba(self, X):
+        check_is_fitted(self, &#39;est_&#39;)
         return self.est_.predict_proba(X)
 
     def score(self, X, y):
+        check_is_fitted(self, &#39;est_&#39;)
         return self.est_.score(X, y)
+
+    def get_rules(self, feature_names=None):
+        &#34;&#34;&#34;Return this model&#39;s rules as a DataFrame (see imodels.get_rules).
+
+        The rules are those of the model the search selected.
+        &#34;&#34;&#34;
+        from imodels.util.get_rules import get_rules
+        return get_rules(self, feature_names=feature_names)
+
+    def apply(self, X):
+        &#34;&#34;&#34;Return the leaf each sample reaches (see imodels.util.apply.apply_leaves).&#34;&#34;&#34;
+        from imodels.util.apply import apply_leaves
+        return apply_leaves(self, X)
 
     PARAM_GRID_LINEAR_CLASSIFICATION = [
         {
@@ -388,6 +404,21 @@ This is basically a wrapper around GridSearchCV, with some preselected models.</
 </dl>
 <h3>Methods</h3>
 <dl>
+<dt id="imodels.util.automl.AutoInterpretableModel.apply"><code class="name flex">
+<span>def <span class="ident">apply</span></span>(<span>self, X)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Return the leaf each sample reaches (see imodels.util.apply.apply_leaves).</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def apply(self, X):
+    &#34;&#34;&#34;Return the leaf each sample reaches (see imodels.util.apply.apply_leaves).&#34;&#34;&#34;
+    from imodels.util.apply import apply_leaves
+    return apply_leaves(self, X)</code></pre>
+</details>
+</dd>
 <dt id="imodels.util.automl.AutoInterpretableModel.fit"><code class="name flex">
 <span>def <span class="ident">fit</span></span>(<span>self, X, y, cv=5)</span>
 </code></dt>
@@ -413,6 +444,25 @@ This is basically a wrapper around GridSearchCV, with some preselected models.</
     return self</code></pre>
 </details>
 </dd>
+<dt id="imodels.util.automl.AutoInterpretableModel.get_rules"><code class="name flex">
+<span>def <span class="ident">get_rules</span></span>(<span>self, feature_names=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Return this model's rules as a DataFrame (see imodels.get_rules).</p>
+<p>The rules are those of the model the search selected.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_rules(self, feature_names=None):
+    &#34;&#34;&#34;Return this model&#39;s rules as a DataFrame (see imodels.get_rules).
+
+    The rules are those of the model the search selected.
+    &#34;&#34;&#34;
+    from imodels.util.get_rules import get_rules
+    return get_rules(self, feature_names=feature_names)</code></pre>
+</details>
+</dd>
 <dt id="imodels.util.automl.AutoInterpretableModel.predict"><code class="name flex">
 <span>def <span class="ident">predict</span></span>(<span>self, X)</span>
 </code></dt>
@@ -423,6 +473,7 @@ This is basically a wrapper around GridSearchCV, with some preselected models.</
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def predict(self, X):
+    check_is_fitted(self, &#39;est_&#39;)
     return self.est_.predict(X)</code></pre>
 </details>
 </dd>
@@ -436,6 +487,7 @@ This is basically a wrapper around GridSearchCV, with some preselected models.</
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def predict_proba(self, X):
+    check_is_fitted(self, &#39;est_&#39;)
     return self.est_.predict_proba(X)</code></pre>
 </details>
 </dd>
@@ -449,6 +501,7 @@ This is basically a wrapper around GridSearchCV, with some preselected models.</
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def score(self, X, y):
+    check_is_fitted(self, &#39;est_&#39;)
     return self.est_.score(X, y)</code></pre>
 </details>
 </dd>
@@ -576,6 +629,8 @@ This is basically a wrapper around GridSearchCV, with some preselected models.</
 <ul class="hlist">
 <li><code><b><a title="imodels.util.automl.AutoInterpretableModel" href="#imodels.util.automl.AutoInterpretableModel">AutoInterpretableModel</a></b></code>:
 <ul class="hlist">
+<li><code><a title="imodels.util.automl.AutoInterpretableModel.apply" href="#imodels.util.automl.AutoInterpretableModel.apply">apply</a></code></li>
+<li><code><a title="imodels.util.automl.AutoInterpretableModel.get_rules" href="#imodels.util.automl.AutoInterpretableModel.get_rules">get_rules</a></code></li>
 <li><code><a title="imodels.util.automl.AutoInterpretableModel.set_fit_request" href="#imodels.util.automl.AutoInterpretableModel.set_fit_request">set_fit_request</a></code></li>
 </ul>
 </li>
@@ -607,7 +662,9 @@ This is basically a wrapper around GridSearchCV, with some preselected models.</
 <li><code><a title="imodels.util.automl.AutoInterpretableModel.PARAM_GRID_DEFAULT_REGRESSION" href="#imodels.util.automl.AutoInterpretableModel.PARAM_GRID_DEFAULT_REGRESSION">PARAM_GRID_DEFAULT_REGRESSION</a></code></li>
 <li><code><a title="imodels.util.automl.AutoInterpretableModel.PARAM_GRID_LINEAR_CLASSIFICATION" href="#imodels.util.automl.AutoInterpretableModel.PARAM_GRID_LINEAR_CLASSIFICATION">PARAM_GRID_LINEAR_CLASSIFICATION</a></code></li>
 <li><code><a title="imodels.util.automl.AutoInterpretableModel.PARAM_GRID_LINEAR_REGRESSION" href="#imodels.util.automl.AutoInterpretableModel.PARAM_GRID_LINEAR_REGRESSION">PARAM_GRID_LINEAR_REGRESSION</a></code></li>
+<li><code><a title="imodels.util.automl.AutoInterpretableModel.apply" href="#imodels.util.automl.AutoInterpretableModel.apply">apply</a></code></li>
 <li><code><a title="imodels.util.automl.AutoInterpretableModel.fit" href="#imodels.util.automl.AutoInterpretableModel.fit">fit</a></code></li>
+<li><code><a title="imodels.util.automl.AutoInterpretableModel.get_rules" href="#imodels.util.automl.AutoInterpretableModel.get_rules">get_rules</a></code></li>
 <li><code><a title="imodels.util.automl.AutoInterpretableModel.predict" href="#imodels.util.automl.AutoInterpretableModel.predict">predict</a></code></li>
 <li><code><a title="imodels.util.automl.AutoInterpretableModel.predict_proba" href="#imodels.util.automl.AutoInterpretableModel.predict_proba">predict_proba</a></code></li>
 <li><code><a title="imodels.util.automl.AutoInterpretableModel.score" href="#imodels.util.automl.AutoInterpretableModel.score">score</a></code></li>

--- a/docs/util/data_util.html
+++ b/docs/util/data_util.html
@@ -30,7 +30,6 @@ import pandas as pd
 import requests
 import sklearn.datasets
 from scipy.sparse import issparse
-from sklearn.datasets import fetch_openml
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import OneHotEncoder
 
@@ -353,17 +352,7 @@ def encode_categories(X, features, encoder=None):
     X_encoded = pd.concat([X_encoded, X_one_hot], axis=1)
     if encoder is not None:
         return X_encoded
-    return X_encoded, one_hot_encoder
-
-
-if __name__ == &#34;__main__&#34;:
-    import imodels
-
-    # X, y, feature_names = imodels.get_clean_dataset(&#39;compas_two_year_clean&#39;, data_source=&#39;imodels&#39;, test_size=0.5)
-    X_train, X_test, y_train, y_test, feature_names = imodels.get_clean_dataset(
-        &#34;compas_two_year_clean&#34;, data_source=&#34;imodels&#34;, test_size=0.5
-    )
-    print(X_train.shape, y_train.shape)</code></pre>
+    return X_encoded, one_hot_encoder</code></pre>
 </details>
 </section>
 <section>

--- a/docs/util/ensemble.html
+++ b/docs/util/ensemble.html
@@ -24,11 +24,6 @@
 <pre><code class="python">from sklearn.base import BaseEstimator, RegressorMixin, clone
 from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
 import numpy as np
-from sklearn.model_selection import train_test_split
-from sklearn.metrics import mean_squared_error
-from sklearn.tree import DecisionTreeRegressor
-from sklearn.linear_model import LinearRegression
-import imodels
 
 
 class ResidualBoostingRegressor(BaseEstimator, RegressorMixin):
@@ -126,33 +121,7 @@ class SimpleBaggingRegressor:
                                for estimator in self.estimators_])
 
         # Aggregate predictions
-        return np.mean(predictions, axis=0)
-
-
-if __name__ == &#39;__main__&#39;:
-    import imodels.algebraic.gam_multitask
-    X, y, feature_names = imodels.get_clean_dataset(&#39;california_housing&#39;)
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.2, random_state=42)
-    X_train = X_train[:50, :2]
-    y_train = y_train[:50]
-    X_test = X_test[:50, :2]
-    y_test = y_test[:50]
-    # estimator = DecisionTreeRegressor(max_depth=3)
-    estimator = imodels.algebraic.gam_multitask.MultiTaskGAMRegressor()
-    for n_estimators in [1, 3, 5]:
-        # residual_boosting_regressor = ResidualBoostingRegressor(
-        # estimator=estimator, n_estimators=n_estimators)
-        residual_boosting_regressor = SimpleBaggingRegressor(
-            estimator=estimator, n_estimators=n_estimators)
-        residual_boosting_regressor.fit(X_train, y_train)
-
-        y_pred = residual_boosting_regressor.predict(X_test)
-        mse_train = mean_squared_error(
-            y_train, residual_boosting_regressor.predict(X_train))
-        mse = mean_squared_error(y_test, y_pred)
-        print(
-            f&#39;MSE with {n_estimators} estimators: {mse:.2f} (train: {mse_train:.2f})&#39;)</code></pre>
+        return np.mean(predictions, axis=0)</code></pre>
 </details>
 </section>
 <section>

--- a/docs/util/extract.html
+++ b/docs/util/extract.html
@@ -24,7 +24,6 @@
 <pre><code class="python">from typing import Iterable, Tuple, List
 
 import numpy as np
-import pandas as pd
 from mlxtend import frequent_patterns as mlx
 from sklearn.ensemble import BaggingRegressor, GradientBoostingRegressor, RandomForestRegressor, \
     GradientBoostingClassifier, RandomForestClassifier
@@ -255,12 +254,7 @@ def extract_marginal_curves(clf, X, max_evals=100):
         shape_function_vals = clf.predict_proba(dummy_input)[:, 1] - base
         feature_vals_list.append(feature_vals)
         shape_function_vals_list.append(shape_function_vals.tolist())
-    return feature_vals_list, shape_function_vals_list
-
-
-if __name__ == &#39;__main__&#39;:
-    init_signature = inspect.signature(BaggingRegressor.__init__)
-    print(&#39;estimator&#39; in init_signature.parameters.keys())</code></pre>
+    return feature_vals_list, shape_function_vals_list</code></pre>
 </details>
 </section>
 <section>

--- a/docs/util/get_rules.html
+++ b/docs/util/get_rules.html
@@ -146,12 +146,23 @@ def _rules_from_wrapped_model(model, feature_names):
     return None
 
 
-def _has_rules(model):
+def _has_rules(model, _depth=0):
     if getattr(model, &#39;rules_&#39;, None) is not None:
         return True
     if is_sklearn_tree(model):
         return True
-    return any(hasattr(model, attr) for attr in (&#39;trees_&#39;, &#39;estimators_&#39;))
+    if any(hasattr(model, attr) for attr in (&#39;trees_&#39;, &#39;estimators_&#39;)):
+        return True
+    # a wrapper may hold the model with the rules several levels down, e.g. a
+    # search whose best estimator is a pipeline; the depth cap keeps a model
+    # that refers back to itself from looping
+    if _depth &gt;= 4:
+        return False
+    for attr in WRAPPED_MODEL_ATTRS:
+        inner = getattr(model, attr, None)
+        if inner is not None and inner is not model and _has_rules(inner, _depth + 1):
+            return True
+    return False
 
 
 def _rules_from_rulefit(model, feature_names):

--- a/docs/util/model_trees.html
+++ b/docs/util/model_trees.html
@@ -36,8 +36,12 @@ models are tree-based.
 
 import numpy as np
 
-#: attributes under which a model may keep the fitted model it delegates to
-WRAPPED_MODEL_ATTRS = (&#39;figs&#39;, &#39;estimator_&#39;, &#39;model&#39;)
+#: attributes under which a model may keep the fitted model it delegates to.
+#: `est_`/`best_estimator_`/`_final_estimator` cover the search-and-pipeline
+#: chain that AutoInterpretableModel builds: est_ is a GridSearchCV whose
+#: best_estimator_ is a Pipeline ending in the model actually chosen.
+WRAPPED_MODEL_ATTRS = (&#39;figs&#39;, &#39;estimator_&#39;, &#39;model&#39;,
+                       &#39;est_&#39;, &#39;best_estimator_&#39;, &#39;_final_estimator&#39;)
 
 
 def is_sklearn_tree(estimator) -&gt; bool:
@@ -110,7 +114,10 @@ def sklearn_trees(model, convert_figs=True):
 <dl>
 <dt id="imodels.util.model_trees.WRAPPED_MODEL_ATTRS"><code class="name">var <span class="ident">WRAPPED_MODEL_ATTRS</span></code></dt>
 <dd>
-<div class="desc"><p>attributes under which a model may keep the fitted model it delegates to</p></div>
+<div class="desc"><p>attributes under which a model may keep the fitted model it delegates to.
+<code>est_</code>/<code>best_estimator_</code>/<code>_final_estimator</code> cover the search-and-pipeline
+chain that AutoInterpretableModel builds: est_ is a GridSearchCV whose
+best_estimator_ is a Pipeline ending in the model actually chosen.</p></div>
 </dd>
 </dl>
 </section>

--- a/docs/util/score.html
+++ b/docs/util/score.html
@@ -43,7 +43,8 @@ def score_precision_recall(X,
                            samples: List[List[int]],
                            features: List[List[int]],
                            feature_names: List[str],
-                           oob: bool = True) -&gt; List[Rule]:
+                           oob: bool = True,
+                           sample_weight=None) -&gt; List[Rule]:
 
     scored_rules = []
 
@@ -75,26 +76,37 @@ def score_precision_recall(X,
 
         y_oob = y[mask]
         y_oob = np.array((y_oob != 0))
+        # the weights have to follow the same samples the rules are scored on
+        w_oob = None if sample_weight is None else np.asarray(
+            sample_weight, dtype=float)[mask]
 
         # Add OOB performances to rules:
         scored_rules += [
-            Rule(r, args=_eval_rule_perf(r, X_oob, y_oob))
+            Rule(r, args=_eval_rule_perf(r, X_oob, y_oob, w_oob))
             for r in set(curr_rules)
         ]
 
     return scored_rules
 
 
-def _eval_rule_perf(rule: str, X, y) -&gt; Tuple[float, float]:
+def _eval_rule_perf(rule: str, X, y, sample_weight=None) -&gt; Tuple[float, float]:
     detected_index = list(X.query(rule).index)
     if len(detected_index) &lt;= 1:
         return (0, 0)
     y_detected = y[detected_index]
-    true_pos = y_detected[y_detected &gt; 0].sum()
+    # with uniform weights these are exactly the unweighted precision and
+    # recall, so passing no weights leaves rule selection unchanged
+    weights = np.ones(len(y)) if sample_weight is None else np.asarray(
+        sample_weight, dtype=float)
+    w_detected = weights[detected_index]
+    true_pos = float((w_detected * (y_detected &gt; 0)).sum())
     if true_pos == 0:
         return (0, 0)
-    pos = y[y &gt; 0].sum()
-    return y_detected.mean(), float(true_pos) / pos
+    pos = float((weights * (y &gt; 0)).sum())
+    detected = float(w_detected.sum())
+    if detected == 0 or pos == 0:
+        return (0, 0)
+    return true_pos / detected, true_pos / pos
 
 
 def score_linear(X, y, rules: List[str],
@@ -309,7 +321,7 @@ def get_best_alpha_under_max_rules(X, y, rules: List[str],
 </details>
 </dd>
 <dt id="imodels.util.score.score_precision_recall"><code class="name flex">
-<span>def <span class="ident">score_precision_recall</span></span>(<span>X, y, rules: List[List[str]], samples: List[List[int]], features: List[List[int]], feature_names: List[str], oob: bool = True) ‑> List[<a title="imodels.util.rule.Rule" href="rule.html#imodels.util.rule.Rule">Rule</a>]</span>
+<span>def <span class="ident">score_precision_recall</span></span>(<span>X, y, rules: List[List[str]], samples: List[List[int]], features: List[List[int]], feature_names: List[str], oob: bool = True, sample_weight=None) ‑> List[<a title="imodels.util.rule.Rule" href="rule.html#imodels.util.rule.Rule">Rule</a>]</span>
 </code></dt>
 <dd>
 <div class="desc"></div>
@@ -323,7 +335,8 @@ def get_best_alpha_under_max_rules(X, y, rules: List[str],
                            samples: List[List[int]],
                            features: List[List[int]],
                            feature_names: List[str],
-                           oob: bool = True) -&gt; List[Rule]:
+                           oob: bool = True,
+                           sample_weight=None) -&gt; List[Rule]:
 
     scored_rules = []
 
@@ -355,10 +368,13 @@ def get_best_alpha_under_max_rules(X, y, rules: List[str],
 
         y_oob = y[mask]
         y_oob = np.array((y_oob != 0))
+        # the weights have to follow the same samples the rules are scored on
+        w_oob = None if sample_weight is None else np.asarray(
+            sample_weight, dtype=float)[mask]
 
         # Add OOB performances to rules:
         scored_rules += [
-            Rule(r, args=_eval_rule_perf(r, X_oob, y_oob))
+            Rule(r, args=_eval_rule_perf(r, X_oob, y_oob, w_oob))
             for r in set(curr_rules)
         ]
 

--- a/docs/util/transforms.html
+++ b/docs/util/transforms.html
@@ -52,7 +52,6 @@ class Winsorizer():
                 self.winsor_lims[:, i_col] = [lower, upper]
 
     def trim(self, X):
-        X_ = X.copy()
         X_ = np.where(X &gt; self.winsor_lims[1, :], np.tile(self.winsor_lims[1, :], [X.shape[0], 1]),
                       np.where(X &lt; self.winsor_lims[0, :], np.tile(self.winsor_lims[0, :], [X.shape[0], 1]), X))
         return X_
@@ -71,7 +70,7 @@ class FriedScale():
 
     def train(self, X):
         # get multipliers
-        if self.winsorizer != None:
+        if self.winsorizer is not None:
             X_trimmed = self.winsorizer.trim(X)
         else:
             X_trimmed = X
@@ -85,7 +84,7 @@ class FriedScale():
         self.scale_multipliers = scale_multipliers
 
     def scale(self, X):
-        if self.winsorizer != None:
+        if self.winsorizer is not None:
             return self.winsorizer.trim(X) * self.scale_multipliers
         else:
             return X * self.scale_multipliers
@@ -149,18 +148,7 @@ class CorrelationScreenTransformer(BaseEstimator, TransformerMixin):
         if input_type == np.ndarray:
             X_transformed = X_transformed.values
 
-        return X_transformed
-
-
-if __name__ == &#39;__main__&#39;:
-    X = np.random.randn(5, 5)
-    X[:, 0] = [1, 1, 0, 1, 1]
-    X[:, 1] = X[:, 0]
-
-    transformer = CorrelationScreenTransformer()
-    print(X)
-    X_transformed = transformer.fit_transform(X)
-    print(X_transformed)</code></pre>
+        return X_transformed</code></pre>
 </details>
 </section>
 <section>
@@ -352,7 +340,7 @@ Warning: this class should not be used directly.</p></div>
 
     def train(self, X):
         # get multipliers
-        if self.winsorizer != None:
+        if self.winsorizer is not None:
             X_trimmed = self.winsorizer.trim(X)
         else:
             X_trimmed = X
@@ -366,7 +354,7 @@ Warning: this class should not be used directly.</p></div>
         self.scale_multipliers = scale_multipliers
 
     def scale(self, X):
-        if self.winsorizer != None:
+        if self.winsorizer is not None:
             return self.winsorizer.trim(X) * self.scale_multipliers
         else:
             return X * self.scale_multipliers</code></pre>
@@ -383,7 +371,7 @@ Warning: this class should not be used directly.</p></div>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def scale(self, X):
-    if self.winsorizer != None:
+    if self.winsorizer is not None:
         return self.winsorizer.trim(X) * self.scale_multipliers
     else:
         return X * self.scale_multipliers</code></pre>
@@ -400,7 +388,7 @@ Warning: this class should not be used directly.</p></div>
 </summary>
 <pre><code class="python">def train(self, X):
     # get multipliers
-    if self.winsorizer != None:
+    if self.winsorizer is not None:
         X_trimmed = self.winsorizer.trim(X)
     else:
         X_trimmed = X
@@ -449,7 +437,6 @@ Warning: this class should not be used directly.</p></div>
                 self.winsor_lims[:, i_col] = [lower, upper]
 
     def trim(self, X):
-        X_ = X.copy()
         X_ = np.where(X &gt; self.winsor_lims[1, :], np.tile(self.winsor_lims[1, :], [X.shape[0], 1]),
                       np.where(X &lt; self.winsor_lims[0, :], np.tile(self.winsor_lims[0, :], [X.shape[0], 1]), X))
         return X_</code></pre>
@@ -487,7 +474,6 @@ Warning: this class should not be used directly.</p></div>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def trim(self, X):
-    X_ = X.copy()
     X_ = np.where(X &gt; self.winsor_lims[1, :], np.tile(self.winsor_lims[1, :], [X.shape[0], 1]),
                   np.where(X &lt; self.winsor_lims[0, :], np.tile(self.winsor_lims[0, :], [X.shape[0], 1]), X))
     return X_</code></pre>

--- a/docs/util/tree.html
+++ b/docs/util/tree.html
@@ -21,10 +21,7 @@
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">from sklearn import datasets
-from sklearn.tree import DecisionTreeRegressor
-import numpy as np
-from sklearn.tree._tree import Tree
+<pre><code class="python">import numpy as np
 from imodels.tree.custom_greedy_tree import CustomDecisionTreeClassifier
 
 
@@ -204,14 +201,7 @@ def compute_mean_llm_calls(model_name, num_prompts, model=None, X=None):
     elif model_name in [&#34;manual_ensemble&#34;, &#34;manual_boosting&#34;]:
         return num_prompts
     else:
-        return num_prompts
-
-
-if __name__ == &#39;__main__&#39;:
-    X, y = datasets.fetch_california_housing(return_X_y=True)  # regression
-    m = DecisionTreeRegressor(random_state=42, max_leaf_nodes=4)
-    m.fit(X, y)
-    print(compute_tree_complexity(m.tree_, complexity_measure=&#39;num_leaves&#39;))</code></pre>
+        return num_prompts</code></pre>
 </details>
 </section>
 <section>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imodels"
-version = "2.0.3"
+version = "3.0.0"
 description = "Implementations of various interpretable models"
 readme = "readme.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Version

`pyproject.toml` 2.0.3 → **3.0.0**. That is the only place the version is declared — there is no `imodels.__version__` and no other file in the repo references it.

One deliberate exception: `docs/conda/meta.yaml` still reads 1.0.2. A conda recipe's version is tied to the sha256 of a *published* sdist, so it can only move once 3.0.0 is actually on PyPI. PR #285 is the one that updates that recipe.

## Docs

Rebuilt with the same steps as `docs/build_docs.sh` (pdoc3 → flatten `docs/imodels/` → drop `tests` → `style_docs.py`). `uv` isn't available in this environment, so I ran pdoc directly.

Worth noting: pdoc aborts on the first module it cannot import, and three modules need *optional* dependencies that aren't in the dev group — `statsmodels` (bartpy diagnostics), `torch` (`util.neural_nets`), and `interpret` (`algebraic.gam_multitask`, `gam_shap`). The committed docs include pages for all of them, so I installed the three rather than passing `--skip-errors`, which would have silently deleted those pages. `glmnet` turned out not to be needed — `tree.rf_plus` imports fine without it.

All 149 pages regenerate; none added, none removed. The new API surface shows up as expected — `fit`/`transform`/`fit_transform` on the MDLP discretizers, `sample_weight` in `util/score.html`, and the `get_rules`, `apply` and fast-and-frugal-tree pages.

### Why index.html shrinks

`imodels/__init__.py` is just `.. include:: ../readme.md`, so `index.html` tracks the readme. Master's most recent commit d40f96f ("Clean up readme") dropped the fast-and-frugal-tree row and wrapped the task-support section in a collapsible `<summary><h3>`, which removes its table-of-contents anchor. The rebuilt page reflects the current readme faithfully — I checked that the model table, the sklearn-API paragraph and the model names are all still present, rather than assuming the smaller file meant lost content.

Two pre-existing quirks I left alone, having confirmed they are identical in the committed docs and not caused by this rebuild: `index.html` has no `<title>` (the custom `html.mako` never emitted one), and the `favs` block `style_docs.py` tries to strip no longer matches the readme, so that replacement is a no-op.

Full suite at the new version: 1026 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGCPxZcezhRgroNWzLRAcf